### PR TITLE
test: add percentage formatter coverage

### DIFF
--- a/RadixCoreTests/FileSizeFormatterTests.swift
+++ b/RadixCoreTests/FileSizeFormatterTests.swift
@@ -8,4 +8,22 @@ final class FileSizeFormatterTests: XCTestCase {
         XCTAssertEqual(RadixFormatters.size(512), "512 bytes")
         XCTAssertEqual(RadixFormatters.size(1_024), "1 KB")
     }
+
+    func testPercentageReturnsNilForNonPositiveTotal() {
+        XCTAssertNil(RadixFormatters.percentage(part: 1, total: 0))
+        XCTAssertNil(RadixFormatters.percentage(part: 1, total: -10))
+    }
+
+    func testPercentageFormatsRatioWithOneFractionDigit() {
+        XCTAssertEqual(RadixFormatters.percentage(part: 0, total: 10), "0.0%")
+        XCTAssertEqual(RadixFormatters.percentage(part: 1, total: 4), "25.0%")
+        XCTAssertEqual(RadixFormatters.percentage(part: 1, total: 3), "33.3%")
+        XCTAssertEqual(RadixFormatters.percentage(part: 1, total: 1), "100.0%")
+    }
+
+    func testPercentageDoesNotClampAboveOneHundredPercent() {
+        // A child can exceed its container (e.g. hard-link dedup or
+        // allocated-vs-logical accounting); the formatter reports the raw ratio.
+        XCTAssertEqual(RadixFormatters.percentage(part: 3, total: 2), "150.0%")
+    }
 }


### PR DESCRIPTION
- Adds unit coverage for RadixFormatters.percentage(part:total:), which was previously untested despite use in the sunburst chart and selection inspector.
- Covers: non-positive total → nil, normal ratio formatting (incl. rounding), and the part > total edge (documents current >100% behavior).
- Verified: full suite passes (swift test → 300 passed, 0 failures).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added new unit tests to strengthen coverage for percentage formatting, including handling of zero/negative totals, correct formatting across common ratios (e.g., 0% and 100%), and expected output when the part exceeds the total.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->