### PR TITLE
feat: add scan comparison

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -59,6 +59,7 @@ let package = Package(
                 "Services/ScanArchiveProgressReporting.swift",
                 "Services/ScanArchiveService.swift",
                 "Services/ScanArchiveTopologyValidator.swift",
+                "Services/ScanComparisonService.swift",
                 "Services/ScanDiagnostics.swift",
                 "Services/ScanCoordinator.swift",
                 "Services/ScanEngine.swift",

--- a/Radix/App/RadixCommands.swift
+++ b/Radix/App/RadixCommands.swift
@@ -23,13 +23,21 @@ struct RadixCommands: Commands {
                 workspaceFocusAction?(.chart)
             }
             .keyboardShortcut("2")
-            .disabled(workspaceFocusAction == nil || scanState.snapshot == nil)
+            .disabled(
+                !appModel.canUseWorkspaceCommands ||
+                    workspaceFocusAction == nil ||
+                    scanState.snapshot == nil
+            )
 
             Button("Focus Contents", systemImage: "list.bullet") {
                 workspaceFocusAction?(.contents)
             }
             .keyboardShortcut("3")
-            .disabled(workspaceFocusAction == nil || scanState.snapshot == nil)
+            .disabled(
+                !appModel.canUseWorkspaceCommands ||
+                    workspaceFocusAction == nil ||
+                    scanState.snapshot == nil
+            )
 
             Divider()
 
@@ -37,7 +45,7 @@ struct RadixCommands: Commands {
                 inspectorVisibility?.wrappedValue.toggle()
             }
             .keyboardShortcut("i", modifiers: [.control, .command])
-            .disabled(inspectorVisibility == nil)
+            .disabled(!appModel.canUseWorkspaceCommands || inspectorVisibility == nil)
 
             Divider()
 
@@ -45,19 +53,31 @@ struct RadixCommands: Commands {
                 sunburstViewportAction?(.zoomIn)
             }
             .keyboardShortcut("+", modifiers: [.command])
-            .disabled(sunburstViewportAction == nil || scanState.snapshot == nil)
+            .disabled(
+                !appModel.canUseWorkspaceCommands ||
+                    sunburstViewportAction == nil ||
+                    scanState.snapshot == nil
+            )
 
             Button("Zoom Out", systemImage: "minus.magnifyingglass") {
                 sunburstViewportAction?(.zoomOut)
             }
             .keyboardShortcut("-", modifiers: [.command])
-            .disabled(sunburstViewportAction == nil || scanState.snapshot == nil)
+            .disabled(
+                !appModel.canUseWorkspaceCommands ||
+                    sunburstViewportAction == nil ||
+                    scanState.snapshot == nil
+            )
 
             Button("Actual Size", systemImage: "arrow.counterclockwise") {
                 sunburstViewportAction?(.reset)
             }
             .keyboardShortcut("0", modifiers: [.command])
-            .disabled(sunburstViewportAction == nil || scanState.snapshot == nil)
+            .disabled(
+                !appModel.canUseWorkspaceCommands ||
+                    sunburstViewportAction == nil ||
+                    scanState.snapshot == nil
+            )
         }
 
         CommandGroup(replacing: .newItem) {
@@ -127,13 +147,13 @@ struct RadixCommands: Commands {
                 appModel.navigateBack()
             }
             .keyboardShortcut("[", modifiers: [.command])
-            .disabled(!navigation.canNavigateBack)
+            .disabled(!appModel.canUseWorkspaceCommands || !navigation.canNavigateBack)
 
             Button("Forward", systemImage: "chevron.forward") {
                 appModel.navigateForward()
             }
             .keyboardShortcut("]", modifiers: [.command])
-            .disabled(!navigation.canNavigateForward)
+            .disabled(!appModel.canUseWorkspaceCommands || !navigation.canNavigateForward)
 
             Divider()
 
@@ -141,7 +161,7 @@ struct RadixCommands: Commands {
                 appModel.navigateToParent()
             }
             .keyboardShortcut(.upArrow, modifiers: [.command])
-            .disabled(!navigation.canNavigateToParent)
+            .disabled(!appModel.canUseWorkspaceCommands || !navigation.canNavigateToParent)
 
             Divider()
 
@@ -149,13 +169,13 @@ struct RadixCommands: Commands {
                 appModel.zoomIntoSelection()
             }
             .keyboardShortcut(.downArrow, modifiers: [.command])
-            .disabled(!navigation.canZoomIntoSelection)
+            .disabled(!appModel.canUseWorkspaceCommands || !navigation.canZoomIntoSelection)
 
             Button("Back to Scan Root", systemImage: "arrowshape.turn.up.backward") {
                 appModel.resetFocusToRoot()
             }
             .keyboardShortcut("\\", modifiers: [.command, .option])
-            .disabled(navigation.isFocusedAtRoot)
+            .disabled(!appModel.canUseWorkspaceCommands || navigation.isFocusedAtRoot)
 
             Divider()
 
@@ -163,7 +183,7 @@ struct RadixCommands: Commands {
                 appModel.clearSelection()
             }
             .keyboardShortcut(.escape, modifiers: [])
-            .disabled(!navigation.canClearSelection)
+            .disabled(!appModel.canUseWorkspaceCommands || !navigation.canClearSelection)
         }
 
         CommandMenu("Inspect") {
@@ -181,7 +201,10 @@ struct RadixCommands: Commands {
                 appModel.addSelectedNodesToDiscardPile()
             }
             .keyboardShortcut("l", modifiers: [.command, .shift])
-            .disabled(!selectedActionAvailability.canMoveToTrash)
+            .disabled(
+                !appModel.canUseWorkspaceCommands ||
+                    !selectedActionAvailability.canMoveToTrash
+            )
 
             selectedFileActionCommand(.moveToTrash, shortcut: .delete, modifiers: [])
         }
@@ -228,6 +251,9 @@ struct RadixCommands: Commands {
             commandSelectedFileActions.perform(action)
         }
         .keyboardShortcut(shortcut, modifiers: modifiers)
-        .disabled(!action.isEnabled(in: selectedActionAvailability))
+        .disabled(
+            !appModel.canUseWorkspaceCommands ||
+                !action.isEnabled(in: selectedActionAvailability)
+        )
     }
 }

--- a/Radix/App/RadixCommands.swift
+++ b/Radix/App/RadixCommands.swift
@@ -101,17 +101,22 @@ struct RadixCommands: Commands {
 
             Divider()
 
-            Button("Compare Snapshots…", systemImage: "rectangle.split.2x1") {
+            Button("Compare Scans…", systemImage: "rectangle.split.2x1") {
                 appModel.compareScanSnapshots()
             }
             .keyboardShortcut("d", modifiers: [.command, .shift])
             .disabled(!appModel.canCompareScanSnapshots)
 
-            Button("Compare Current Scan With Snapshot…", systemImage: "arrow.left.arrow.right") {
+            Button("Compare Current Scan With Saved Scan…", systemImage: "arrow.left.arrow.right") {
                 appModel.compareCurrentScanWithSnapshot()
             }
             .keyboardShortcut("d", modifiers: [.command, .option])
             .disabled(!appModel.canCompareCurrentScanWithSnapshot)
+
+            Button("Compare With Previous Scan", systemImage: "chart.bar.xaxis") {
+                appModel.compareCurrentScanWithPreviousScan()
+            }
+            .disabled(!appModel.canCompareCurrentScanWithPreviousScan)
 
             Divider()
 

--- a/Radix/App/RadixCommands.swift
+++ b/Radix/App/RadixCommands.swift
@@ -81,6 +81,20 @@ struct RadixCommands: Commands {
 
             Divider()
 
+            Button("Compare Snapshots…", systemImage: "rectangle.split.2x1") {
+                appModel.compareScanSnapshots()
+            }
+            .keyboardShortcut("d", modifiers: [.command, .shift])
+            .disabled(!appModel.canCompareScanSnapshots)
+
+            Button("Compare Current Scan With Snapshot…", systemImage: "arrow.left.arrow.right") {
+                appModel.compareCurrentScanWithSnapshot()
+            }
+            .keyboardShortcut("d", modifiers: [.command, .option])
+            .disabled(!appModel.canCompareCurrentScanWithSnapshot)
+
+            Divider()
+
             Button("Rescan", systemImage: "arrow.clockwise") {
                 appModel.rescan()
             }

--- a/Radix/ContentView.swift
+++ b/Radix/ContentView.swift
@@ -782,7 +782,12 @@ private extension ContentView {
             canReveal: { appModel.canRevealComparisonRowInFinder($0) },
             showInBrowser: { appModel.showComparisonRowInBrowser($0) },
             canShowInBrowser: { appModel.canShowComparisonRowInBrowser($0) },
-            copyPath: { appModel.copyComparisonRowPath($0) }
+            copyPath: { appModel.copyComparisonRowPath($0) },
+            revealNode: { appModel.revealComparisonChangeNodeInFinder($0) },
+            canRevealNode: { appModel.canRevealComparisonChangeNodeInFinder($0) },
+            showNodeInBrowser: { appModel.showComparisonChangeNodeInBrowser($0) },
+            canShowNodeInBrowser: { appModel.canShowComparisonChangeNodeInBrowser($0) },
+            copyNodePath: { appModel.copyComparisonChangeNodePath($0) }
         )
     }
 

--- a/Radix/ContentView.swift
+++ b/Radix/ContentView.swift
@@ -15,6 +15,7 @@ struct ContentView: View {
     @Environment(\.scenePhase) private var scenePhase
 
     @State private var splitViewVisibility: NavigationSplitViewVisibility = .all
+    @State private var sidebarWasAutoHiddenForComparison = false
     @State private var showsInspector = true
     @State private var inspectorPresentationBeforeComparison: Bool?
     @State private var showsDiscardPileReview = false
@@ -76,6 +77,12 @@ struct ContentView: View {
                 .inspectorColumnWidth(min: 260, ideal: 320, max: 380)
         }
         .focusedSceneValue(\.inspectorVisibility, $showsInspector)
+        .onChange(of: appModel.scanComparison?.id) { previousID, currentID in
+            updateSidebarPresentationForComparison(
+                wasComparing: previousID != nil,
+                isComparing: currentID != nil
+            )
+        }
         .onChange(of: appModel.archiveOperation) { previousOperation, currentOperation in
             guard previousOperation?.kind == .compare,
                   currentOperation == nil else {
@@ -675,6 +682,21 @@ private struct WorkspaceDetailView: View {
 }
 
 private extension ContentView {
+    func updateSidebarPresentationForComparison(wasComparing: Bool, isComparing: Bool) {
+        if !wasComparing, isComparing, splitViewVisibility == .all {
+            sidebarWasAutoHiddenForComparison = true
+            splitViewVisibility = .detailOnly
+            return
+        }
+
+        guard wasComparing, !isComparing, sidebarWasAutoHiddenForComparison else { return }
+        sidebarWasAutoHiddenForComparison = false
+
+        if splitViewVisibility == .detailOnly {
+            splitViewVisibility = .all
+        }
+    }
+
     func comparisonSetupDidAppear() {
         guard inspectorPresentationBeforeComparison == nil else { return }
 

--- a/Radix/ContentView.swift
+++ b/Radix/ContentView.swift
@@ -78,10 +78,14 @@ struct ContentView: View {
         }
         .focusedSceneValue(\.inspectorVisibility, $showsInspector)
         .onChange(of: appModel.scanComparison?.id) { previousID, currentID in
-            updateSidebarPresentationForComparison(
-                wasComparing: previousID != nil,
-                isComparing: currentID != nil
-            )
+            Task { @MainActor in
+                await Task.yield()
+                guard appModel.scanComparison?.id == currentID else { return }
+                updateSidebarPresentationForComparison(
+                    wasComparing: previousID != nil,
+                    isComparing: currentID != nil
+                )
+            }
         }
         .onChange(of: appModel.archiveOperation) { previousOperation, currentOperation in
             guard previousOperation?.kind == .compare,
@@ -711,7 +715,6 @@ private extension ContentView {
 
     func confirmComparisonSetup() {
         appModel.confirmComparisonSetup()
-        restoreInspectorIfComparisonInactive()
     }
 
     func closeScanComparison() {

--- a/Radix/ContentView.swift
+++ b/Radix/ContentView.swift
@@ -16,6 +16,7 @@ struct ContentView: View {
 
     @State private var splitViewVisibility: NavigationSplitViewVisibility = .all
     @State private var showsInspector = true
+    @State private var inspectorPresentationBeforeComparison: Bool?
     @State private var showsDiscardPileReview = false
     @State private var discardPileDragIsActive = false
     @State private var discardPileDragMonitorTask: Task<Void, Never>?
@@ -48,8 +49,9 @@ struct ContentView: View {
                     appModel.sunburstFreeSpaceAvailableCapacity(for: snapshot, focusNode: focusNode)
                 },
                 closeScanComparison: {
-                    appModel.closeScanComparison()
+                    closeScanComparison()
                 },
+                workspaceDidAppear: workspaceDidAppear,
                 comparisonRowActions: comparisonRowActions,
                 comparisonLocationActions: comparisonLocationActions,
                 actions: workspaceActions
@@ -66,21 +68,22 @@ struct ContentView: View {
             appModel.setWorkspaceWindowNumber(window?.windowNumber)
         })
         .inspector(isPresented: $showsInspector) {
-            Group {
-                if appModel.scanComparison == nil {
-                    SelectionInspectorView(
-                        scanState: appModel.scanState,
-                        navigation: appModel.navigation,
-                        fullDiskAccessStatus: appModel.fullDiskAccessStatus,
-                        actions: selectionInspectorActions
-                    )
-                } else {
-                    ComparisonInspectorPlaceholder()
-                }
-            }
-            .inspectorColumnWidth(min: 260, ideal: 320, max: 380)
+            SelectionInspectorView(
+                scanState: appModel.scanState,
+                navigation: appModel.navigation,
+                fullDiskAccessStatus: appModel.fullDiskAccessStatus,
+                actions: selectionInspectorActions
+            )
+                .inspectorColumnWidth(min: 260, ideal: 320, max: 380)
         }
         .focusedSceneValue(\.inspectorVisibility, $showsInspector)
+        .onChange(of: appModel.archiveOperation) { previousOperation, currentOperation in
+            guard previousOperation?.kind == .compare,
+                  currentOperation == nil else {
+                return
+            }
+            restoreInspectorIfComparisonInactive()
+        }
         .overlay(alignment: .top) {
             if let archiveOperation = appModel.archiveOperation {
                 ArchiveOperationBanner(
@@ -144,7 +147,7 @@ struct ContentView: View {
             get: { appModel.pendingComparisonSetup != nil },
             set: { isPresented in
                 if !isPresented {
-                    appModel.cancelComparisonSetup()
+                    cancelComparisonSetup()
                 }
             }
         )) {
@@ -168,12 +171,13 @@ struct ContentView: View {
                         appModel.swapPendingComparisonSetup()
                     },
                     onCancel: {
-                        appModel.cancelComparisonSetup()
+                        cancelComparisonSetup()
                     },
                     onCompare: {
-                        appModel.confirmComparisonSetup()
+                        confirmComparisonSetup()
                     }
                 )
+                .onAppear(perform: comparisonSetupDidAppear)
                 .interactiveDismissDisabled()
             }
         }
@@ -564,17 +568,6 @@ private extension ContentView {
     }
 }
 
-private struct ComparisonInspectorPlaceholder: View {
-    var body: some View {
-        ContentUnavailableView(
-            "Storage Changes",
-            systemImage: "chart.bar.xaxis",
-            description: Text("Close the comparison to inspect files in the current scan.")
-        )
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-    }
-}
-
 private struct WorkspaceWindowObserver: NSViewRepresentable {
     let onWindowChange: (NSWindow?) -> Void
 
@@ -633,6 +626,7 @@ private struct WorkspaceDetailView: View {
     let fullDiskAccessStatus: FullDiskAccessStatus
     let freeSpaceAvailableCapacity: (ScanSnapshot, FileNodeRecord) -> Int64?
     let closeScanComparison: () -> Void
+    let workspaceDidAppear: () -> Void
     let comparisonRowActions: ScanComparisonRowActions
     let comparisonLocationActions: ScanComparisonLocationActions
     let actions: WorkspaceActions
@@ -659,6 +653,7 @@ private struct WorkspaceDetailView: View {
                 freeSpaceAvailableCapacity: freeSpaceAvailableCapacity,
                 actions: actions
             )
+                .onAppear(perform: workspaceDidAppear)
                 .toolbar {
                     ToolbarItemGroup(placement: .navigation) {
                         Button {
@@ -683,6 +678,56 @@ private struct WorkspaceDetailView: View {
 }
 
 private extension ContentView {
+    func comparisonSetupDidAppear() {
+        guard inspectorPresentationBeforeComparison == nil else { return }
+
+        inspectorPresentationBeforeComparison = showsInspector
+        setInspectorPresented(false)
+    }
+
+    func cancelComparisonSetup() {
+        appModel.cancelComparisonSetup()
+        restoreInspectorIfComparisonInactive()
+    }
+
+    func confirmComparisonSetup() {
+        appModel.confirmComparisonSetup()
+        restoreInspectorIfComparisonInactive()
+    }
+
+    func closeScanComparison() {
+        appModel.closeScanComparison()
+    }
+
+    func workspaceDidAppear() {
+        guard inspectorPresentationBeforeComparison != nil else { return }
+
+        Task { @MainActor in
+            await Task.yield()
+            restoreInspectorIfComparisonInactive()
+        }
+    }
+
+    func restoreInspectorIfComparisonInactive() {
+        guard appModel.pendingComparisonSetup == nil,
+              appModel.archiveOperation?.kind != .compare,
+              appModel.scanComparison == nil,
+              let previousPresentation = inspectorPresentationBeforeComparison else {
+            return
+        }
+
+        inspectorPresentationBeforeComparison = nil
+        setInspectorPresented(previousPresentation)
+    }
+
+    func setInspectorPresented(_ isPresented: Bool) {
+        guard showsInspector != isPresented else { return }
+
+        withTransaction(Transaction(animation: nil)) {
+            showsInspector = isPresented
+        }
+    }
+
     var workspaceActions: WorkspaceActions {
         WorkspaceActions(
             chooseFolder: { appModel.presentOpenPanelAndScan() },

--- a/Radix/ContentView.swift
+++ b/Radix/ContentView.swift
@@ -36,6 +36,7 @@ struct ContentView: View {
             WorkspaceDetailView(
                 scanState: appModel.scanState,
                 navigation: appModel.navigation,
+                scanComparison: appModel.scanComparison,
                 isInspectorPresented: $showsInspector,
                 focusedWorkspaceTarget: $focusedWorkspaceTarget,
                 maxRenderedDepth: appModel.maxRenderedDepth,
@@ -46,6 +47,10 @@ struct ContentView: View {
                 freeSpaceAvailableCapacity: { snapshot, focusNode in
                     appModel.sunburstFreeSpaceAvailableCapacity(for: snapshot, focusNode: focusNode)
                 },
+                closeScanComparison: {
+                    appModel.closeScanComparison()
+                },
+                comparisonRowActions: comparisonRowActions,
                 actions: workspaceActions
             )
         }
@@ -59,7 +64,10 @@ struct ContentView: View {
         .background(WorkspaceWindowObserver { window in
             appModel.setWorkspaceWindowNumber(window?.windowNumber)
         })
-        .inspector(isPresented: $showsInspector) {
+        .inspector(isPresented: Binding(
+            get: { showsInspector && appModel.scanComparison == nil },
+            set: { showsInspector = $0 }
+        )) {
             SelectionInspectorView(
                 scanState: appModel.scanState,
                 navigation: appModel.navigation,
@@ -127,6 +135,40 @@ struct ContentView: View {
                 }
             )
             .interactiveDismissDisabled()
+        }
+        .sheet(isPresented: Binding(
+            get: { appModel.pendingComparisonSetup != nil },
+            set: { isPresented in
+                if !isPresented {
+                    appModel.cancelComparisonSetup()
+                }
+            }
+        )) {
+            if let setup = appModel.pendingComparisonSetup {
+                ScanComparisonSetupSheet(
+                    setup: setup,
+                    canUseCurrentScan: appModel.canUseCurrentScanInComparisonSetup,
+                    onChooseSnapshot: { slot in
+                        appModel.chooseComparisonSnapshot(for: slot)
+                    },
+                    onUseCurrentScan: { slot in
+                        appModel.useCurrentScanForComparisonSlot(slot)
+                    },
+                    onClear: { slot in
+                        appModel.clearComparisonSlot(slot)
+                    },
+                    onSwap: {
+                        appModel.swapPendingComparisonSetup()
+                    },
+                    onCancel: {
+                        appModel.cancelComparisonSetup()
+                    },
+                    onCompare: {
+                        appModel.confirmComparisonSetup()
+                    }
+                )
+                .interactiveDismissDisabled()
+            }
         }
         .alert(
             appModel.errorAlertTitle,
@@ -562,6 +604,7 @@ private struct WorkspaceWindowObserver: NSViewRepresentable {
 private struct WorkspaceDetailView: View {
     @ObservedObject var scanState: ScanCoordinator
     @ObservedObject var navigation: WorkspaceNavigationModel
+    let scanComparison: ScanComparison?
     @Binding var isInspectorPresented: Bool
     @FocusState.Binding var focusedWorkspaceTarget: WorkspaceFocusTarget?
 
@@ -571,41 +614,51 @@ private struct WorkspaceDetailView: View {
     let startupDiskTarget: ScanTarget?
     let fullDiskAccessStatus: FullDiskAccessStatus
     let freeSpaceAvailableCapacity: (ScanSnapshot, FileNodeRecord) -> Int64?
+    let closeScanComparison: () -> Void
+    let comparisonRowActions: ScanComparisonRowActions
     let actions: WorkspaceActions
 
     var body: some View {
-        WorkspaceView(
-            scanState: scanState,
-            navigation: navigation,
-            isInspectorPresented: $isInspectorPresented,
-            focusedWorkspaceTarget: $focusedWorkspaceTarget,
-            maxRenderedDepth: maxRenderedDepth,
-            showFreeSpaceInSunburst: showFreeSpaceInSunburst,
-            discardPileHiddenNodeIDs: discardPileHiddenNodeIDs,
-            startupDiskTarget: startupDiskTarget,
-            fullDiskAccessStatus: fullDiskAccessStatus,
-            freeSpaceAvailableCapacity: freeSpaceAvailableCapacity,
-            actions: actions
-        )
-            .toolbar {
-                ToolbarItemGroup(placement: .navigation) {
-                    Button {
-                        actions.navigateBack()
-                    } label: {
-                        Label("Back", systemImage: "chevron.backward")
-                    }
-                    .disabled(!navigation.canNavigateBack)
-                    .help("Back")
+        if let scanComparison {
+            ScanComparisonView(
+                comparison: scanComparison,
+                actions: comparisonRowActions,
+                onClose: closeScanComparison
+            )
+        } else {
+            WorkspaceView(
+                scanState: scanState,
+                navigation: navigation,
+                isInspectorPresented: $isInspectorPresented,
+                focusedWorkspaceTarget: $focusedWorkspaceTarget,
+                maxRenderedDepth: maxRenderedDepth,
+                showFreeSpaceInSunburst: showFreeSpaceInSunburst,
+                discardPileHiddenNodeIDs: discardPileHiddenNodeIDs,
+                startupDiskTarget: startupDiskTarget,
+                fullDiskAccessStatus: fullDiskAccessStatus,
+                freeSpaceAvailableCapacity: freeSpaceAvailableCapacity,
+                actions: actions
+            )
+                .toolbar {
+                    ToolbarItemGroup(placement: .navigation) {
+                        Button {
+                            actions.navigateBack()
+                        } label: {
+                            Label("Back", systemImage: "chevron.backward")
+                        }
+                        .disabled(!navigation.canNavigateBack)
+                        .help("Back")
 
-                    Button {
-                        actions.navigateForward()
-                    } label: {
-                        Label("Forward", systemImage: "chevron.forward")
+                        Button {
+                            actions.navigateForward()
+                        } label: {
+                            Label("Forward", systemImage: "chevron.forward")
+                        }
+                        .disabled(!navigation.canNavigateForward)
+                        .help("Forward")
                     }
-                    .disabled(!navigation.canNavigateForward)
-                    .help("Forward")
                 }
-            }
+        }
     }
 }
 
@@ -634,6 +687,16 @@ private extension ContentView {
             openFullDiskAccessSettings: { appModel.prepareAndOpenFullDiskAccessSettings() },
             setDiscardPileDragActive: setDiscardPileDragIsActive,
             setDiscardPileDragActiveAfterThreshold: setDiscardPileDragIsActiveAfterThreshold
+        )
+    }
+
+    var comparisonRowActions: ScanComparisonRowActions {
+        ScanComparisonRowActions(
+            reveal: { appModel.revealComparisonRowInFinder($0) },
+            canReveal: { appModel.canRevealComparisonRowInFinder($0) },
+            showInBrowser: { appModel.showComparisonRowInBrowser($0) },
+            canShowInBrowser: { appModel.canShowComparisonRowInBrowser($0) },
+            copyPath: { appModel.copyComparisonRowPath($0) }
         )
     }
 

--- a/Radix/ContentView.swift
+++ b/Radix/ContentView.swift
@@ -51,6 +51,7 @@ struct ContentView: View {
                     appModel.closeScanComparison()
                 },
                 comparisonRowActions: comparisonRowActions,
+                comparisonLocationActions: comparisonLocationActions,
                 actions: workspaceActions
             )
         }
@@ -64,17 +65,20 @@ struct ContentView: View {
         .background(WorkspaceWindowObserver { window in
             appModel.setWorkspaceWindowNumber(window?.windowNumber)
         })
-        .inspector(isPresented: Binding(
-            get: { showsInspector && appModel.scanComparison == nil },
-            set: { showsInspector = $0 }
-        )) {
-            SelectionInspectorView(
-                scanState: appModel.scanState,
-                navigation: appModel.navigation,
-                fullDiskAccessStatus: appModel.fullDiskAccessStatus,
-                actions: selectionInspectorActions
-            )
-                .inspectorColumnWidth(min: 260, ideal: 320, max: 380)
+        .inspector(isPresented: $showsInspector) {
+            Group {
+                if appModel.scanComparison == nil {
+                    SelectionInspectorView(
+                        scanState: appModel.scanState,
+                        navigation: appModel.navigation,
+                        fullDiskAccessStatus: appModel.fullDiskAccessStatus,
+                        actions: selectionInspectorActions
+                    )
+                } else {
+                    ComparisonInspectorPlaceholder()
+                }
+            }
+            .inspectorColumnWidth(min: 260, ideal: 320, max: 380)
         }
         .focusedSceneValue(\.inspectorVisibility, $showsInspector)
         .overlay(alignment: .top) {
@@ -557,6 +561,17 @@ private extension ContentView {
     }
 }
 
+private struct ComparisonInspectorPlaceholder: View {
+    var body: some View {
+        ContentUnavailableView(
+            "Storage Changes",
+            systemImage: "chart.bar.xaxis",
+            description: Text("Close the comparison to inspect files in the current scan.")
+        )
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
 private struct WorkspaceWindowObserver: NSViewRepresentable {
     let onWindowChange: (NSWindow?) -> Void
 
@@ -616,6 +631,7 @@ private struct WorkspaceDetailView: View {
     let freeSpaceAvailableCapacity: (ScanSnapshot, FileNodeRecord) -> Int64?
     let closeScanComparison: () -> Void
     let comparisonRowActions: ScanComparisonRowActions
+    let comparisonLocationActions: ScanComparisonLocationActions
     let actions: WorkspaceActions
 
     var body: some View {
@@ -623,6 +639,7 @@ private struct WorkspaceDetailView: View {
             ScanComparisonView(
                 comparison: scanComparison,
                 actions: comparisonRowActions,
+                locationActions: comparisonLocationActions,
                 onClose: closeScanComparison
             )
         } else {
@@ -669,6 +686,8 @@ private extension ContentView {
             startScan: { appModel.startScan($0) },
             stopScan: { appModel.stopScan() },
             rescan: { appModel.rescan() },
+            compareWithPreviousScan: { appModel.compareCurrentScanWithPreviousScan() },
+            canCompareWithPreviousScan: { appModel.canCompareCurrentScanWithPreviousScan },
             handleDroppedURLs: { appModel.handleDroppedURLs($0) },
             selectNodeImmediately: { appModel.select(nodeID: $0) },
             selectNode: { appModel.selectAfterViewUpdate(nodeID: $0) },
@@ -697,6 +716,15 @@ private extension ContentView {
             showInBrowser: { appModel.showComparisonRowInBrowser($0) },
             canShowInBrowser: { appModel.canShowComparisonRowInBrowser($0) },
             copyPath: { appModel.copyComparisonRowPath($0) }
+        )
+    }
+
+    var comparisonLocationActions: ScanComparisonLocationActions {
+        ScanComparisonLocationActions(
+            reveal: { appModel.revealComparisonLocationInFinder($0) },
+            canReveal: { appModel.canRevealComparisonLocationInFinder($0) },
+            showInBrowser: { appModel.showComparisonLocationInBrowser($0) },
+            canShowInBrowser: { appModel.canShowComparisonLocationInBrowser($0) }
         )
     }
 

--- a/Radix/ContentView.swift
+++ b/Radix/ContentView.swift
@@ -155,6 +155,9 @@ struct ContentView: View {
                     onChooseSnapshot: { slot in
                         appModel.chooseComparisonSnapshot(for: slot)
                     },
+                    onDropSnapshot: { url, slot in
+                        appModel.dropComparisonSnapshot(url, for: slot)
+                    },
                     onUseCurrentScan: { slot in
                         appModel.useCurrentScanForComparisonSlot(slot)
                     },

--- a/Radix/ContentView.swift
+++ b/Radix/ContentView.swift
@@ -53,7 +53,6 @@ struct ContentView: View {
                 },
                 workspaceDidAppear: workspaceDidAppear,
                 comparisonRowActions: comparisonRowActions,
-                comparisonLocationActions: comparisonLocationActions,
                 actions: workspaceActions
             )
         }
@@ -628,7 +627,6 @@ private struct WorkspaceDetailView: View {
     let closeScanComparison: () -> Void
     let workspaceDidAppear: () -> Void
     let comparisonRowActions: ScanComparisonRowActions
-    let comparisonLocationActions: ScanComparisonLocationActions
     let actions: WorkspaceActions
 
     var body: some View {
@@ -636,7 +634,6 @@ private struct WorkspaceDetailView: View {
             ScanComparisonView(
                 comparison: scanComparison,
                 actions: comparisonRowActions,
-                locationActions: comparisonLocationActions,
                 onClose: closeScanComparison
             )
         } else {
@@ -764,15 +761,6 @@ private extension ContentView {
             showInBrowser: { appModel.showComparisonRowInBrowser($0) },
             canShowInBrowser: { appModel.canShowComparisonRowInBrowser($0) },
             copyPath: { appModel.copyComparisonRowPath($0) }
-        )
-    }
-
-    var comparisonLocationActions: ScanComparisonLocationActions {
-        ScanComparisonLocationActions(
-            reveal: { appModel.revealComparisonLocationInFinder($0) },
-            canReveal: { appModel.canRevealComparisonLocationInFinder($0) },
-            showInBrowser: { appModel.showComparisonLocationInBrowser($0) },
-            canShowInBrowser: { appModel.canShowComparisonLocationInBrowser($0) }
         )
     }
 

--- a/Radix/Features/Comparison/ScanComparisonSetupSheet.swift
+++ b/Radix/Features/Comparison/ScanComparisonSetupSheet.swift
@@ -135,6 +135,25 @@ private struct ScanComparisonCandidateGroup: View {
                 alignment: .topLeading
             )
             .padding(8)
+            .contentShape(RoundedRectangle(cornerRadius: 6))
+            .background {
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(Color.accentColor.opacity(isDropTargeted ? 0.1 : 0))
+            }
+            .overlay {
+                RoundedRectangle(cornerRadius: 6)
+                    .stroke(
+                        Color.accentColor.opacity(isDropTargeted ? 0.9 : 0),
+                        style: StrokeStyle(lineWidth: 2, dash: [6, 4])
+                    )
+            }
+            .dropDestination(for: URL.self) { urls, _ in
+                guard !actionsDisabled, let sourceURL = urls.first else { return false }
+                onDropSnapshot(sourceURL, slot)
+                return true
+            } isTargeted: { isTargeted in
+                isDropTargeted = isTargeted && !actionsDisabled
+            }
         } label: {
             HStack(spacing: 8) {
                 Text(slot.title)
@@ -148,24 +167,6 @@ private struct ScanComparisonCandidateGroup: View {
             }
         }
         .frame(maxWidth: .infinity)
-        .background {
-            RoundedRectangle(cornerRadius: 8)
-                .fill(Color.accentColor.opacity(isDropTargeted ? 0.1 : 0))
-        }
-        .overlay {
-            RoundedRectangle(cornerRadius: 8)
-                .stroke(
-                    Color.accentColor.opacity(isDropTargeted ? 0.9 : 0),
-                    style: StrokeStyle(lineWidth: 2, dash: [6, 4])
-                )
-        }
-        .dropDestination(for: URL.self) { urls, _ in
-            guard !actionsDisabled, let sourceURL = urls.first else { return false }
-            onDropSnapshot(sourceURL, slot)
-            return true
-        } isTargeted: { isTargeted in
-            isDropTargeted = isTargeted && !actionsDisabled
-        }
     }
 
     private var emptyContent: some View {

--- a/Radix/Features/Comparison/ScanComparisonSetupSheet.swift
+++ b/Radix/Features/Comparison/ScanComparisonSetupSheet.swift
@@ -19,15 +19,22 @@ struct ScanComparisonSetupSheet: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 18) {
-            Label("Compare Snapshots", systemImage: "rectangle.split.2x1")
-                .font(.title3.weight(.semibold))
-                .labelStyle(.titleAndIcon)
-                .symbolRenderingMode(.hierarchical)
-                .foregroundStyle(.primary, .tint)
+        VStack(spacing: 0) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Compare Snapshots")
+                    .font(.title3.weight(.semibold))
+
+                Text("Choose the earlier and later snapshots you want to compare.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(20)
+
+            Divider()
 
             HStack(alignment: .center, spacing: 12) {
-                ScanComparisonCandidateSlotCard(
+                ScanComparisonCandidateGroup(
                     slot: .before,
                     candidate: setup.before,
                     isLoading: setup.loadingSlot == .before,
@@ -41,15 +48,14 @@ struct ScanComparisonSetupSheet: View {
                 Button {
                     onSwap()
                 } label: {
-                    Label("Swap", systemImage: "arrow.left.arrow.right")
+                    Label("Swap Before and After", systemImage: "arrow.left.arrow.right")
                 }
                 .labelStyle(.iconOnly)
                 .buttonStyle(.bordered)
-                .controlSize(.large)
-                .disabled(isBusy)
+                .disabled(isBusy || (setup.before == nil && setup.after == nil))
                 .help("Swap Before and After")
 
-                ScanComparisonCandidateSlotCard(
+                ScanComparisonCandidateGroup(
                     slot: .after,
                     candidate: setup.after,
                     isLoading: setup.loadingSlot == .after,
@@ -60,14 +66,18 @@ struct ScanComparisonSetupSheet: View {
                     onClear: onClear
                 )
             }
+            .padding(20)
 
-            if let statusMessage {
-                Label(statusMessage, systemImage: "exclamationmark.triangle")
-                    .font(.caption)
-                    .foregroundStyle(.red)
-            }
+            Divider()
 
-            HStack {
+            HStack(spacing: 12) {
+                if let statusMessage {
+                    Label(statusMessage, systemImage: "exclamationmark.triangle.fill")
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                        .lineLimit(2)
+                }
+
                 Spacer()
 
                 Button("Cancel", role: .cancel) {
@@ -81,13 +91,14 @@ struct ScanComparisonSetupSheet: View {
                 .keyboardShortcut(.defaultAction)
                 .disabled(!setup.canCompare)
             }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 14)
         }
-        .padding(24)
-        .frame(width: 760, alignment: .topLeading)
+        .frame(width: 700)
     }
 }
 
-private struct ScanComparisonCandidateSlotCard: View {
+private struct ScanComparisonCandidateGroup: View {
     let slot: ScanComparisonSlot
     let candidate: ScanComparisonCandidate?
     let isLoading: Bool
@@ -98,96 +109,78 @@ private struct ScanComparisonCandidateSlotCard: View {
     let onClear: (ScanComparisonSlot) -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            HStack(alignment: .center, spacing: 8) {
+        GroupBox {
+            Group {
+                if isLoading {
+                    loadingContent
+                } else if let candidate {
+                    VStack(alignment: .leading, spacing: 12) {
+                        candidateContent(candidate)
+                            .frame(maxWidth: .infinity, minHeight: 138, alignment: .topLeading)
+
+                        Divider()
+
+                        selectedActions
+                    }
+                } else {
+                    emptyContent
+                }
+            }
+            .frame(maxWidth: .infinity, minHeight: 180)
+            .padding(.top, 4)
+        } label: {
+            HStack(spacing: 8) {
                 Text(slot.title)
                     .font(.headline)
 
                 if candidate?.isCurrentScan == true {
                     Label("Current Scan", systemImage: "dot.radiowaves.left.and.right")
-                        .font(.caption.weight(.medium))
-                        .labelStyle(.titleAndIcon)
+                        .font(.caption)
                         .foregroundStyle(.secondary)
                 }
-
-                Spacer()
-
-                if isLoading {
-                    ProgressView()
-                        .controlSize(.small)
-                }
             }
-
-            Group {
-                if isLoading {
-                    loadingContent
-                } else if let candidate {
-                    candidateContent(candidate)
-                } else {
-                    emptyContent
-                }
-            }
-            .frame(maxWidth: .infinity, minHeight: 142, alignment: .topLeading)
-
-            HStack(spacing: 8) {
-                Button {
-                    onChooseSnapshot(slot)
-                } label: {
-                    Label("Choose Snapshot", systemImage: "folder")
-                }
-                .disabled(actionsDisabled)
-
-                Button {
-                    onUseCurrentScan(slot)
-                } label: {
-                    Label("Use Current Scan", systemImage: "dot.radiowaves.left.and.right")
-                }
-                .disabled(actionsDisabled || !canUseCurrentScan)
-
-                if candidate != nil {
-                    Button {
-                        onClear(slot)
-                    } label: {
-                        Label("Clear", systemImage: "xmark")
-                    }
-                    .labelStyle(.iconOnly)
-                    .disabled(actionsDisabled)
-                    .help("Clear \(slot.title)")
-                }
-            }
-            .controlSize(.small)
         }
-        .padding(14)
-        .frame(maxWidth: .infinity, minHeight: 246, alignment: .topLeading)
-        .background(.quaternary.opacity(0.55), in: RoundedRectangle(cornerRadius: 8))
+        .frame(maxWidth: .infinity)
     }
 
     private var emptyContent: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(spacing: 8) {
             Image(systemName: "doc.badge.plus")
                 .font(.title2)
                 .foregroundStyle(.secondary)
 
-            Text("No snapshot selected")
-                .font(.subheadline.weight(.semibold))
+            Text("No Snapshot Selected")
+                .font(.subheadline.weight(.medium))
+
+            Text("Choose a saved snapshot or use the current scan.")
+                .font(.caption)
                 .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+
+            sourceActions
+                .padding(.top, 4)
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     private var loadingContent: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Reading snapshot")
-                .font(.subheadline.weight(.semibold))
-            Text("...")
+        VStack(spacing: 8) {
+            ProgressView()
+                .controlSize(.small)
+
+            Text("Reading Snapshot…")
+                .font(.subheadline.weight(.medium))
+
+            Text("Validating snapshot contents")
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
-    @ViewBuilder
     private func candidateContent(_ candidate: ScanComparisonCandidate) -> some View {
         VStack(alignment: .leading, spacing: 12) {
-            VStack(alignment: .leading, spacing: 5) {
+            VStack(alignment: .leading, spacing: 4) {
                 Text(candidate.displayName)
                     .font(.subheadline.weight(.semibold))
                     .lineLimit(1)
@@ -202,32 +195,72 @@ private struct ScanComparisonCandidateSlotCard: View {
                     .help(candidate.path)
             }
 
-            Grid(alignment: .leading, horizontalSpacing: 16, verticalSpacing: 8) {
+            Grid(alignment: .leading, horizontalSpacing: 18, verticalSpacing: 8) {
                 GridRow {
-                    setupMetric("Scanned", RadixFormatters.date(candidate.scanDate))
-                    setupMetric("Size", RadixFormatters.size(candidate.totalAllocatedSize))
+                    metric("Scanned", RadixFormatters.date(candidate.scanDate))
+                    metric("Size", RadixFormatters.size(candidate.totalAllocatedSize))
                 }
+
                 GridRow {
-                    setupMetric("Files", candidate.fileCount.formatted())
-                    setupMetric("Folders", candidate.directoryCount.formatted())
+                    metric("Files", candidate.fileCount.formatted())
+                    metric("Folders", candidate.directoryCount.formatted())
                 }
-                GridRow {
-                    setupMetric("Warnings", candidate.warningCount.formatted())
-                    Color.clear.frame(width: 1, height: 1)
+
+                if candidate.warningCount > 0 {
+                    GridRow {
+                        metric("Warnings", candidate.warningCount.formatted())
+                        Color.clear
+                            .frame(width: 1, height: 1)
+                    }
                 }
             }
         }
     }
 
-    private func setupMetric(_ title: String, _ value: String) -> some View {
-        VStack(alignment: .leading, spacing: 3) {
+    private var sourceActions: some View {
+        HStack(spacing: 8) {
+            Button("Choose Snapshot…") {
+                onChooseSnapshot(slot)
+            }
+
+            Button("Use Current Scan") {
+                onUseCurrentScan(slot)
+            }
+            .disabled(!canUseCurrentScan)
+        }
+        .controlSize(.small)
+        .disabled(actionsDisabled)
+    }
+
+    private var selectedActions: some View {
+        HStack(spacing: 8) {
+            sourceActions
+
+            Spacer(minLength: 0)
+
+            Button {
+                onClear(slot)
+            } label: {
+                Label("Clear \(slot.title)", systemImage: "xmark")
+            }
+            .labelStyle(.iconOnly)
+            .buttonStyle(.borderless)
+            .help("Clear \(slot.title)")
+        }
+        .controlSize(.small)
+        .disabled(actionsDisabled)
+    }
+
+    private func metric(_ title: String, _ value: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
             Text(title)
                 .font(.caption)
                 .foregroundStyle(.secondary)
+
             Text(value)
-                .font(.caption.weight(.semibold))
-                .lineLimit(1)
+                .font(.caption.weight(.medium))
                 .monospacedDigit()
+                .lineLimit(1)
         }
     }
 }

--- a/Radix/Features/Comparison/ScanComparisonSetupSheet.swift
+++ b/Radix/Features/Comparison/ScanComparisonSetupSheet.swift
@@ -1,0 +1,233 @@
+import SwiftUI
+
+struct ScanComparisonSetupSheet: View {
+    let setup: ScanComparisonSetup
+    let canUseCurrentScan: Bool
+    let onChooseSnapshot: (ScanComparisonSlot) -> Void
+    let onUseCurrentScan: (ScanComparisonSlot) -> Void
+    let onClear: (ScanComparisonSlot) -> Void
+    let onSwap: () -> Void
+    let onCancel: () -> Void
+    let onCompare: () -> Void
+
+    private var isBusy: Bool {
+        setup.loadingSlot != nil
+    }
+
+    private var statusMessage: String? {
+        setup.errorMessage ?? setup.validationMessage
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            Label("Compare Snapshots", systemImage: "rectangle.split.2x1")
+                .font(.title3.weight(.semibold))
+                .labelStyle(.titleAndIcon)
+                .symbolRenderingMode(.hierarchical)
+                .foregroundStyle(.primary, .tint)
+
+            HStack(alignment: .center, spacing: 12) {
+                ScanComparisonCandidateSlotCard(
+                    slot: .before,
+                    candidate: setup.before,
+                    isLoading: setup.loadingSlot == .before,
+                    canUseCurrentScan: canUseCurrentScan,
+                    actionsDisabled: isBusy,
+                    onChooseSnapshot: onChooseSnapshot,
+                    onUseCurrentScan: onUseCurrentScan,
+                    onClear: onClear
+                )
+
+                Button {
+                    onSwap()
+                } label: {
+                    Label("Swap", systemImage: "arrow.left.arrow.right")
+                }
+                .labelStyle(.iconOnly)
+                .buttonStyle(.bordered)
+                .controlSize(.large)
+                .disabled(isBusy)
+                .help("Swap Before and After")
+
+                ScanComparisonCandidateSlotCard(
+                    slot: .after,
+                    candidate: setup.after,
+                    isLoading: setup.loadingSlot == .after,
+                    canUseCurrentScan: canUseCurrentScan,
+                    actionsDisabled: isBusy,
+                    onChooseSnapshot: onChooseSnapshot,
+                    onUseCurrentScan: onUseCurrentScan,
+                    onClear: onClear
+                )
+            }
+
+            if let statusMessage {
+                Label(statusMessage, systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+
+            HStack {
+                Spacer()
+
+                Button("Cancel", role: .cancel) {
+                    onCancel()
+                }
+                .keyboardShortcut(.cancelAction)
+
+                Button("Compare") {
+                    onCompare()
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(!setup.canCompare)
+            }
+        }
+        .padding(24)
+        .frame(width: 760, alignment: .topLeading)
+    }
+}
+
+private struct ScanComparisonCandidateSlotCard: View {
+    let slot: ScanComparisonSlot
+    let candidate: ScanComparisonCandidate?
+    let isLoading: Bool
+    let canUseCurrentScan: Bool
+    let actionsDisabled: Bool
+    let onChooseSnapshot: (ScanComparisonSlot) -> Void
+    let onUseCurrentScan: (ScanComparisonSlot) -> Void
+    let onClear: (ScanComparisonSlot) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(alignment: .center, spacing: 8) {
+                Text(slot.title)
+                    .font(.headline)
+
+                if candidate?.isCurrentScan == true {
+                    Label("Current Scan", systemImage: "dot.radiowaves.left.and.right")
+                        .font(.caption.weight(.medium))
+                        .labelStyle(.titleAndIcon)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                if isLoading {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+            }
+
+            Group {
+                if isLoading {
+                    loadingContent
+                } else if let candidate {
+                    candidateContent(candidate)
+                } else {
+                    emptyContent
+                }
+            }
+            .frame(maxWidth: .infinity, minHeight: 142, alignment: .topLeading)
+
+            HStack(spacing: 8) {
+                Button {
+                    onChooseSnapshot(slot)
+                } label: {
+                    Label("Choose Snapshot", systemImage: "folder")
+                }
+                .disabled(actionsDisabled)
+
+                Button {
+                    onUseCurrentScan(slot)
+                } label: {
+                    Label("Use Current Scan", systemImage: "dot.radiowaves.left.and.right")
+                }
+                .disabled(actionsDisabled || !canUseCurrentScan)
+
+                if candidate != nil {
+                    Button {
+                        onClear(slot)
+                    } label: {
+                        Label("Clear", systemImage: "xmark")
+                    }
+                    .labelStyle(.iconOnly)
+                    .disabled(actionsDisabled)
+                    .help("Clear \(slot.title)")
+                }
+            }
+            .controlSize(.small)
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, minHeight: 246, alignment: .topLeading)
+        .background(.quaternary.opacity(0.55), in: RoundedRectangle(cornerRadius: 8))
+    }
+
+    private var emptyContent: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Image(systemName: "doc.badge.plus")
+                .font(.title2)
+                .foregroundStyle(.secondary)
+
+            Text("No snapshot selected")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var loadingContent: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Reading snapshot")
+                .font(.subheadline.weight(.semibold))
+            Text("...")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    @ViewBuilder
+    private func candidateContent(_ candidate: ScanComparisonCandidate) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: 5) {
+                Text(candidate.displayName)
+                    .font(.subheadline.weight(.semibold))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+
+                Text(candidate.path)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .textSelection(.enabled)
+                    .help(candidate.path)
+            }
+
+            Grid(alignment: .leading, horizontalSpacing: 16, verticalSpacing: 8) {
+                GridRow {
+                    setupMetric("Scanned", RadixFormatters.date(candidate.scanDate))
+                    setupMetric("Size", RadixFormatters.size(candidate.totalAllocatedSize))
+                }
+                GridRow {
+                    setupMetric("Files", candidate.fileCount.formatted())
+                    setupMetric("Folders", candidate.directoryCount.formatted())
+                }
+                GridRow {
+                    setupMetric("Warnings", candidate.warningCount.formatted())
+                    Color.clear.frame(width: 1, height: 1)
+                }
+            }
+        }
+    }
+
+    private func setupMetric(_ title: String, _ value: String) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.caption.weight(.semibold))
+                .lineLimit(1)
+                .monospacedDigit()
+        }
+    }
+}

--- a/Radix/Features/Comparison/ScanComparisonSetupSheet.swift
+++ b/Radix/Features/Comparison/ScanComparisonSetupSheet.swift
@@ -71,12 +71,22 @@ struct ScanComparisonSetupSheet: View {
             Divider()
 
             HStack(spacing: 12) {
-                if let statusMessage {
-                    Label(statusMessage, systemImage: "exclamationmark.triangle.fill")
-                        .font(.caption)
-                        .foregroundStyle(.red)
-                        .lineLimit(2)
+                VStack(alignment: .leading, spacing: 4) {
+                    if let statusMessage {
+                        Label(statusMessage, systemImage: "exclamationmark.triangle.fill")
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                            .lineLimit(2)
+                    }
+
+                    ForEach(setup.compatibilityWarnings, id: \.self) { warning in
+                        Label(warning.message, systemImage: warning.symbolName)
+                            .font(.caption)
+                            .foregroundStyle(.orange)
+                            .lineLimit(2)
+                    }
                 }
+                .frame(maxWidth: 430, alignment: .leading)
 
                 Spacer()
 

--- a/Radix/Features/Comparison/ScanComparisonSetupSheet.swift
+++ b/Radix/Features/Comparison/ScanComparisonSetupSheet.swift
@@ -4,6 +4,7 @@ struct ScanComparisonSetupSheet: View {
     let setup: ScanComparisonSetup
     let canUseCurrentScan: Bool
     let onChooseSnapshot: (ScanComparisonSlot) -> Void
+    let onDropSnapshot: (URL, ScanComparisonSlot) -> Void
     let onUseCurrentScan: (ScanComparisonSlot) -> Void
     let onClear: (ScanComparisonSlot) -> Void
     let onSwap: () -> Void
@@ -41,6 +42,7 @@ struct ScanComparisonSetupSheet: View {
                     canUseCurrentScan: canUseCurrentScan && setup.canAssignCurrentScan(to: .before),
                     actionsDisabled: isBusy,
                     onChooseSnapshot: onChooseSnapshot,
+                    onDropSnapshot: onDropSnapshot,
                     onUseCurrentScan: onUseCurrentScan,
                     onClear: onClear
                 )
@@ -62,6 +64,7 @@ struct ScanComparisonSetupSheet: View {
                     canUseCurrentScan: canUseCurrentScan && setup.canAssignCurrentScan(to: .after),
                     actionsDisabled: isBusy,
                     onChooseSnapshot: onChooseSnapshot,
+                    onDropSnapshot: onDropSnapshot,
                     onUseCurrentScan: onUseCurrentScan,
                     onClear: onClear
                 )
@@ -109,8 +112,10 @@ private struct ScanComparisonCandidateGroup: View {
     let canUseCurrentScan: Bool
     let actionsDisabled: Bool
     let onChooseSnapshot: (ScanComparisonSlot) -> Void
+    let onDropSnapshot: (URL, ScanComparisonSlot) -> Void
     let onUseCurrentScan: (ScanComparisonSlot) -> Void
     let onClear: (ScanComparisonSlot) -> Void
+    @State private var isDropTargeted = false
 
     var body: some View {
         GroupBox {
@@ -143,6 +148,24 @@ private struct ScanComparisonCandidateGroup: View {
             }
         }
         .frame(maxWidth: .infinity)
+        .background {
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color.accentColor.opacity(isDropTargeted ? 0.1 : 0))
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(
+                    Color.accentColor.opacity(isDropTargeted ? 0.9 : 0),
+                    style: StrokeStyle(lineWidth: 2, dash: [6, 4])
+                )
+        }
+        .dropDestination(for: URL.self) { urls, _ in
+            guard !actionsDisabled, let sourceURL = urls.first else { return false }
+            onDropSnapshot(sourceURL, slot)
+            return true
+        } isTargeted: { isTargeted in
+            isDropTargeted = isTargeted && !actionsDisabled
+        }
     }
 
     private var emptyContent: some View {
@@ -158,6 +181,10 @@ private struct ScanComparisonCandidateGroup: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
+
+            Text("or drop a saved scan here")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
 
             sourceActions
                 .padding(.top, 4)

--- a/Radix/Features/Comparison/ScanComparisonSetupSheet.swift
+++ b/Radix/Features/Comparison/ScanComparisonSetupSheet.swift
@@ -33,7 +33,7 @@ struct ScanComparisonSetupSheet: View {
 
             Divider()
 
-            HStack(alignment: .center, spacing: 12) {
+            HStack(alignment: .center, spacing: 16) {
                 ScanComparisonCandidateGroup(
                     slot: .before,
                     candidate: setup.before,
@@ -94,7 +94,7 @@ struct ScanComparisonSetupSheet: View {
             .padding(.horizontal, 20)
             .padding(.vertical, 14)
         }
-        .frame(width: 700)
+        .frame(width: 780)
     }
 }
 
@@ -114,20 +114,18 @@ private struct ScanComparisonCandidateGroup: View {
                 if isLoading {
                     loadingContent
                 } else if let candidate {
-                    VStack(alignment: .leading, spacing: 12) {
-                        candidateContent(candidate)
-                            .frame(maxWidth: .infinity, minHeight: 138, alignment: .topLeading)
-
-                        Divider()
-
-                        selectedActions
-                    }
+                    candidateContent(candidate)
                 } else {
                     emptyContent
                 }
             }
-            .frame(maxWidth: .infinity, minHeight: 180)
-            .padding(.top, 4)
+            .frame(
+                maxWidth: .infinity,
+                minHeight: 170,
+                maxHeight: 170,
+                alignment: .topLeading
+            )
+            .padding(8)
         } label: {
             HStack(spacing: 8) {
                 Text(slot.title)
@@ -152,7 +150,7 @@ private struct ScanComparisonCandidateGroup: View {
             Text("No Snapshot Selected")
                 .font(.subheadline.weight(.medium))
 
-            Text("Choose a saved snapshot or use the current scan.")
+            Text(emptyStateMessage)
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
@@ -179,15 +177,15 @@ private struct ScanComparisonCandidateGroup: View {
     }
 
     private func candidateContent(_ candidate: ScanComparisonCandidate) -> some View {
-        VStack(alignment: .leading, spacing: 12) {
-            VStack(alignment: .leading, spacing: 4) {
+        VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 5) {
                 Text(candidate.displayName)
-                    .font(.subheadline.weight(.semibold))
+                    .font(.headline)
                     .lineLimit(1)
                     .truncationMode(.middle)
 
                 Text(candidate.path)
-                    .font(.caption)
+                    .font(.subheadline)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
                     .truncationMode(.middle)
@@ -195,26 +193,37 @@ private struct ScanComparisonCandidateGroup: View {
                     .help(candidate.path)
             }
 
-            Grid(alignment: .leading, horizontalSpacing: 18, verticalSpacing: 8) {
-                GridRow {
-                    metric("Scanned", RadixFormatters.date(candidate.scanDate))
-                    metric("Size", RadixFormatters.size(candidate.totalAllocatedSize))
-                }
+            Label(
+                "Scanned \(RadixFormatters.date(candidate.scanDate))",
+                systemImage: "clock"
+            )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
 
-                GridRow {
-                    metric("Files", candidate.fileCount.formatted())
-                    metric("Folders", candidate.directoryCount.formatted())
-                }
+            HStack(spacing: 28) {
+                metric("Size", RadixFormatters.size(candidate.totalAllocatedSize))
+                metric("Files", candidate.fileCount.formatted())
+                metric("Folders", candidate.directoryCount.formatted())
 
                 if candidate.warningCount > 0 {
-                    GridRow {
-                        metric("Warnings", candidate.warningCount.formatted())
-                        Color.clear
-                            .frame(width: 1, height: 1)
-                    }
+                    metric("Warnings", candidate.warningCount.formatted())
                 }
             }
+
+            Spacer(minLength: 0)
+
+            HStack {
+                Spacer()
+                selectedControls(for: candidate)
+            }
         }
+    }
+
+    private var emptyStateMessage: String {
+        canUseCurrentScan
+            ? "Choose a saved snapshot or use the current scan."
+            : "Choose a saved snapshot."
     }
 
     private var sourceActions: some View {
@@ -223,20 +232,34 @@ private struct ScanComparisonCandidateGroup: View {
                 onChooseSnapshot(slot)
             }
 
-            Button("Use Current Scan") {
-                onUseCurrentScan(slot)
+            if canUseCurrentScan {
+                Button("Use Current Scan") {
+                    onUseCurrentScan(slot)
+                }
             }
-            .disabled(!canUseCurrentScan)
         }
         .controlSize(.small)
         .disabled(actionsDisabled)
     }
 
-    private var selectedActions: some View {
+    private func selectedControls(for candidate: ScanComparisonCandidate) -> some View {
         HStack(spacing: 8) {
-            sourceActions
+            Button("Replace…") {
+                onChooseSnapshot(slot)
+            }
 
-            Spacer(minLength: 0)
+            if canUseCurrentScan, !candidate.isCurrentScan {
+                Button {
+                    onUseCurrentScan(slot)
+                } label: {
+                    Label(
+                        "Use Current Scan for \(slot.title)",
+                        systemImage: "dot.radiowaves.left.and.right"
+                    )
+                }
+                .labelStyle(.iconOnly)
+                .help("Use Current Scan")
+            }
 
             Button {
                 onClear(slot)

--- a/Radix/Features/Comparison/ScanComparisonSetupSheet.swift
+++ b/Radix/Features/Comparison/ScanComparisonSetupSheet.swift
@@ -21,10 +21,10 @@ struct ScanComparisonSetupSheet: View {
     var body: some View {
         VStack(spacing: 0) {
             VStack(alignment: .leading, spacing: 4) {
-                Text("Compare Snapshots")
+                Text("Compare Scans")
                     .font(.title3.weight(.semibold))
 
-                Text("Choose the earlier and later snapshots you want to compare.")
+                Text("Choose two scans of the same location with matching scan settings.")
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
             }
@@ -38,7 +38,7 @@ struct ScanComparisonSetupSheet: View {
                     slot: .before,
                     candidate: setup.before,
                     isLoading: setup.loadingSlot == .before,
-                    canUseCurrentScan: canUseCurrentScan,
+                    canUseCurrentScan: canUseCurrentScan && setup.canAssignCurrentScan(to: .before),
                     actionsDisabled: isBusy,
                     onChooseSnapshot: onChooseSnapshot,
                     onUseCurrentScan: onUseCurrentScan,
@@ -48,18 +48,18 @@ struct ScanComparisonSetupSheet: View {
                 Button {
                     onSwap()
                 } label: {
-                    Label("Swap Before and After", systemImage: "arrow.left.arrow.right")
+                    Label("Swap Earlier and Later", systemImage: "arrow.left.arrow.right")
                 }
                 .labelStyle(.iconOnly)
                 .buttonStyle(.bordered)
                 .disabled(isBusy || (setup.before == nil && setup.after == nil))
-                .help("Swap Before and After")
+                .help("Swap Earlier and Later")
 
                 ScanComparisonCandidateGroup(
                     slot: .after,
                     candidate: setup.after,
                     isLoading: setup.loadingSlot == .after,
-                    canUseCurrentScan: canUseCurrentScan,
+                    canUseCurrentScan: canUseCurrentScan && setup.canAssignCurrentScan(to: .after),
                     actionsDisabled: isBusy,
                     onChooseSnapshot: onChooseSnapshot,
                     onUseCurrentScan: onUseCurrentScan,
@@ -79,12 +79,6 @@ struct ScanComparisonSetupSheet: View {
                             .lineLimit(2)
                     }
 
-                    ForEach(setup.compatibilityWarnings, id: \.self) { warning in
-                        Label(warning.message, systemImage: warning.symbolName)
-                            .font(.caption)
-                            .foregroundStyle(.orange)
-                            .lineLimit(2)
-                    }
                 }
                 .frame(maxWidth: 430, alignment: .leading)
 
@@ -232,13 +226,13 @@ private struct ScanComparisonCandidateGroup: View {
 
     private var emptyStateMessage: String {
         canUseCurrentScan
-            ? "Choose a saved snapshot or use the current scan."
-            : "Choose a saved snapshot."
+            ? "Choose a saved scan or use the current scan."
+            : "Choose a saved scan."
     }
 
     private var sourceActions: some View {
         HStack(spacing: 8) {
-            Button("Choose Snapshot…") {
+            Button("Choose Saved Scan…") {
                 onChooseSnapshot(slot)
             }
 

--- a/Radix/Features/Comparison/ScanComparisonView.swift
+++ b/Radix/Features/Comparison/ScanComparisonView.swift
@@ -526,8 +526,9 @@ struct ScanComparisonView: View {
     @ViewBuilder
     private func aggregateChangeLabel(for node: ScanComparisonChangeTreeNode) -> some View {
         if node.isRemainder {
-            Label("Grouped", systemImage: "ellipsis.circle")
+            Text("-")
                 .foregroundStyle(.secondary)
+                .accessibilityLabel("Grouped smaller changes")
         } else if node.affectedCount == 1,
                   let directRowID = node.directRowID,
                   let row = comparison.rows.first(where: { $0.id == directRowID }),

--- a/Radix/Features/Comparison/ScanComparisonView.swift
+++ b/Radix/Features/Comparison/ScanComparisonView.swift
@@ -9,14 +9,37 @@ struct ScanComparisonRowActions {
 }
 
 struct ScanComparisonView: View {
+    private static let initialSortOrder = [
+        ScanComparisonRowComparator.defaultOrder
+    ]
+
     let comparison: ScanComparison
     let actions: ScanComparisonRowActions
     let onClose: () -> Void
 
     @State private var filter: ScanComparisonRowFilter = .all
     @State private var searchText = ""
-    @State private var sortOrder = [ScanComparisonRowComparator.defaultOrder]
+    @State private var sortOrder: [ScanComparisonRowComparator]
     @State private var selection = Set<ScanComparisonRow.ID>()
+    @State private var displayedRows: [ScanComparisonRow]
+
+    init(
+        comparison: ScanComparison,
+        actions: ScanComparisonRowActions,
+        onClose: @escaping () -> Void
+    ) {
+        self.comparison = comparison
+        self.actions = actions
+        self.onClose = onClose
+
+        let sortOrder = Self.initialSortOrder
+        self._sortOrder = State(initialValue: sortOrder)
+        self._displayedRows = State(initialValue: ScanComparisonRowQuery(
+            changeKind: nil,
+            searchText: "",
+            sortOrder: sortOrder
+        ).applying(to: comparison.rows))
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -41,6 +64,12 @@ struct ScanComparisonView: View {
                 }
                 .help("Close Comparison")
             }
+        }
+        .onChange(of: rowQuery) { _, query in
+            refreshDisplayedRows(using: query)
+        }
+        .onChange(of: comparison.id) { _, _ in
+            refreshDisplayedRows(using: rowQuery)
         }
     }
 
@@ -202,7 +231,7 @@ struct ScanComparisonView: View {
             }
             .width(min: 105, ideal: 120)
 
-            TableColumn("Delta", sortUsing: ScanComparisonRowComparator(field: .absoluteAllocatedDelta)) { row in
+            TableColumn("Delta", sortUsing: ScanComparisonRowComparator(field: .allocatedDelta)) { row in
                 Text(signedSize(row.allocatedDelta))
                     .foregroundStyle(deltaColor(row.allocatedDelta))
                     .monospacedDigit()
@@ -281,37 +310,18 @@ struct ScanComparisonView: View {
             : "Adjust filter or search."
     }
 
-    private var displayedRows: [ScanComparisonRow] {
-        let filtered = comparison.rows.filter { row in
-            filter.matches(row) && searchMatches(row)
-        }
-        return sorted(filtered)
+    private var rowQuery: ScanComparisonRowQuery {
+        ScanComparisonRowQuery(
+            changeKind: filter.changeKind,
+            searchText: searchText,
+            sortOrder: sortOrder
+        )
     }
 
-    private func searchMatches(_ row: ScanComparisonRow) -> Bool {
-        let trimmedSearchText = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedSearchText.isEmpty else { return true }
-        let query = SearchNormalizer.normalize(trimmedSearchText)
-        return SearchNormalizer.normalize(row.name).contains(query) ||
-            SearchNormalizer.normalize(row.relativePath).contains(query)
-    }
-
-    private func sorted(_ rows: [ScanComparisonRow]) -> [ScanComparisonRow] {
-        rows.sorted { lhs, rhs in
-            for comparator in sortOrder {
-                switch comparator.compare(lhs, rhs) {
-                case .orderedAscending:
-                    return true
-                case .orderedDescending:
-                    return false
-                case .orderedSame:
-                    continue
-                @unknown default:
-                    continue
-                }
-            }
-            return false
-        }
+    private func refreshDisplayedRows(using query: ScanComparisonRowQuery) {
+        let rows = query.applying(to: comparison.rows)
+        displayedRows = rows
+        selection.formIntersection(rows.lazy.map(\.id))
     }
 
     private func sizeText(_ size: Int64?) -> String {
@@ -367,18 +377,18 @@ private enum ScanComparisonRowFilter: String, CaseIterable, Identifiable {
         }
     }
 
-    func matches(_ row: ScanComparisonRow) -> Bool {
+    var changeKind: ScanComparisonChangeKind? {
         switch self {
         case .all:
-            return true
+            return nil
         case .added:
-            return row.kind == .added
+            return .added
         case .removed:
-            return row.kind == .removed
+            return .removed
         case .grew:
-            return row.kind == .grew
+            return .grew
         case .shrank:
-            return row.kind == .shrank
+            return .shrank
         }
     }
 }

--- a/Radix/Features/Comparison/ScanComparisonView.swift
+++ b/Radix/Features/Comparison/ScanComparisonView.swift
@@ -17,13 +17,14 @@ struct ScanComparisonView: View {
     private static let initialSortOrder = [
         ScanComparisonRowComparator.defaultOrder
     ]
+    private static let allChangeKinds = Set(ScanComparisonChangeKind.allCases)
 
     let comparison: ScanComparison
     let actions: ScanComparisonRowActions
     let onClose: () -> Void
 
     @State private var displayMode: ScanComparisonDisplayMode = .significant
-    @State private var impactFilter: ScanComparisonImpactFilter
+    @State private var selectedChangeKinds: Set<ScanComparisonChangeKind>
     @State private var searchText = ""
     @State private var focusedLocationPath: String?
     @State private var sortOrder: [ScanComparisonRowComparator]
@@ -42,24 +43,17 @@ struct ScanComparisonView: View {
         self.onClose = onClose
 
         let sortOrder = Self.initialSortOrder
-        let impactFilter: ScanComparisonImpactFilter = if comparison.summary.allocatedDelta > 0 {
-            .takingSpace
-        } else if comparison.summary.allocatedDelta < 0 {
-            .freeingSpace
-        } else {
-            .allActivity
-        }
-        self._impactFilter = State(initialValue: impactFilter)
+        let selectedChangeKinds = Self.allChangeKinds
+        self._selectedChangeKinds = State(initialValue: selectedChangeKinds)
         self._sortOrder = State(initialValue: sortOrder)
         self._displayedRows = State(initialValue: ScanComparisonRowQuery(
-            changeKind: nil,
-            impactFilter: impactFilter,
+            changeKinds: selectedChangeKinds,
             searchText: "",
             sortOrder: sortOrder,
             pathPrefix: nil
         ).applying(to: comparison.rows))
         self._projection = State(initialValue: comparison.changeTree.significantProjection(
-            impactFilter: impactFilter
+            changeKinds: selectedChangeKinds
         ))
     }
 
@@ -88,11 +82,12 @@ struct ScanComparisonView: View {
                 .help("Back to Scan")
             }
         }
+        .searchable(text: $searchText, placement: .toolbar, prompt: "Search Changes")
         .onChange(of: rowQuery) { _, query in
             refreshDisplayedRows(using: query)
         }
-        .onChange(of: impactFilter) { _, filter in
-            projection = comparison.changeTree.significantProjection(impactFilter: filter)
+        .onChange(of: selectedChangeKinds) { _, changeKinds in
+            projection = comparison.changeTree.significantProjection(changeKinds: changeKinds)
             aggregateSelection.removeAll()
         }
         .onChange(of: displayMode) { _, mode in
@@ -105,7 +100,7 @@ struct ScanComparisonView: View {
         }
         .onChange(of: comparison.id) { _, _ in
             refreshDisplayedRows(using: rowQuery)
-            projection = comparison.changeTree.significantProjection(impactFilter: impactFilter)
+            projection = comparison.changeTree.significantProjection(changeKinds: selectedChangeKinds)
         }
     }
 
@@ -143,7 +138,7 @@ struct ScanComparisonView: View {
                 coverageBanner
             }
 
-            HStack(spacing: 16) {
+            HStack(spacing: 12) {
                 Picker("Detail", selection: $displayMode) {
                     ForEach(ScanComparisonDisplayMode.allCases) { mode in
                         Text(mode.title).tag(mode)
@@ -151,49 +146,43 @@ struct ScanComparisonView: View {
                 }
                 .pickerStyle(.segmented)
                 .labelsHidden()
-                .frame(width: 240)
+                .frame(width: 240, alignment: .leading)
                 .accessibilityLabel("Comparison detail")
 
                 Divider()
                     .frame(height: 22)
 
-                Picker("Show", selection: $impactFilter) {
-                    ForEach(ScanComparisonImpactFilter.allCases) { filter in
-                        Label(filter.title, systemImage: filter.systemImageName).tag(filter)
+                Text("Show")
+
+                Menu(changeKindSelectionTitle) {
+                    ForEach(ScanComparisonChangeKind.allCases) { kind in
+                        Toggle(kind.title, isOn: changeKindBinding(for: kind))
                     }
-                }
-                .pickerStyle(.menu)
-                .fixedSize()
-                .accessibilityLabel("Show changes")
 
-                Spacer(minLength: 16)
+                    Divider()
 
-                HStack(spacing: 6) {
-                    Image(systemName: "magnifyingglass")
-                        .foregroundStyle(.secondary)
-
-                    TextField("Search names and paths", text: $searchText)
-                        .textFieldStyle(.plain)
-
-                    if !searchText.isEmpty {
-                        Button {
-                            searchText = ""
-                        } label: {
-                            Image(systemName: "xmark.circle.fill")
-                                .foregroundStyle(.secondary)
-                        }
-                        .buttonStyle(.plain)
-                        .help("Clear Search")
+                    Button("Select All") {
+                        selectedChangeKinds = Self.allChangeKinds
                     }
-                }
-                .padding(.horizontal, 8)
-                .frame(width: 280, height: 28)
-                .background(.quaternary, in: RoundedRectangle(cornerRadius: 6))
-            }
+                    .disabled(selectedChangeKinds == Self.allChangeKinds)
 
-            if !comparison.rows.isEmpty {
-                comparisonStatus
+                    Button("Clear") {
+                        selectedChangeKinds.removeAll()
+                    }
+                    .disabled(selectedChangeKinds.isEmpty)
+                }
+                .frame(width: 120, alignment: .leading)
+                .help(selectedChangeKindDescription)
+                .accessibilityLabel("Shown change types")
+
+                if !comparison.rows.isEmpty {
+                    comparisonStatus
+                        .frame(maxWidth: .infinity, alignment: .trailing)
+                } else {
+                    Spacer(minLength: 16)
+                }
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
 
             if effectiveDisplayMode == .significant, let selectedAggregateNode {
                 aggregateSelectionActions(for: selectedAggregateNode)
@@ -203,6 +192,7 @@ struct ScanComparisonView: View {
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 14)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private var changeHeadline: String {
@@ -238,6 +228,7 @@ struct ScanComparisonView: View {
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 8)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 8))
     }
 
@@ -337,6 +328,41 @@ struct ScanComparisonView: View {
         .frame(minWidth: 66, alignment: .leading)
     }
 
+    private var selectedChangeKindDescription: String {
+        let selectedKinds = ScanComparisonChangeKind.allCases.filter(selectedChangeKinds.contains)
+        if selectedKinds.isEmpty {
+            return "No change types selected"
+        }
+        return selectedKinds.map(\.title).joined(separator: ", ")
+    }
+
+    private var changeKindSelectionTitle: String {
+        if selectedChangeKinds == Self.allChangeKinds {
+            return "All Types"
+        }
+        if selectedChangeKinds.isEmpty {
+            return "None"
+        }
+        let selectedKinds = ScanComparisonChangeKind.allCases.filter(selectedChangeKinds.contains)
+        if selectedKinds.count <= 2 {
+            return selectedKinds.map(\.title).joined(separator: ", ")
+        }
+        return "\(selectedKinds.count) Types"
+    }
+
+    private func changeKindBinding(for kind: ScanComparisonChangeKind) -> Binding<Bool> {
+        Binding(
+            get: { selectedChangeKinds.contains(kind) },
+            set: { isSelected in
+                if isSelected {
+                    selectedChangeKinds.insert(kind)
+                } else {
+                    selectedChangeKinds.remove(kind)
+                }
+            }
+        )
+    }
+
     private var effectiveDisplayMode: ScanComparisonDisplayMode {
         searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             ? displayMode
@@ -369,20 +395,22 @@ struct ScanComparisonView: View {
                         .foregroundStyle(.secondary)
                 }
             }
-            Spacer()
         }
         .font(.caption)
         .foregroundStyle(.secondary)
+        .lineLimit(1)
         .accessibilityElement(children: .combine)
     }
 
     private var significantStatusText: String {
         let percentage = projection.representedFraction.formatted(.percent.precision(.fractionLength(0)))
-        let effect = impactFilter.statusNoun
-        if projection.hiddenRootCount == 0 {
-            return "Showing all meaningful \(effect) contributors; expand folders to trace their source."
+        if selectedChangeKinds.isEmpty {
+            return "No change types selected."
         }
-        return "Named contributors represent \(percentage) of \(effect); \(projection.groupedAffectedCount.formatted()) smaller changes are grouped under Other."
+        if projection.hiddenRootCount == 0 {
+            return "Showing all meaningful contributors; expand folders to trace their source."
+        }
+        return "Named contributors represent \(percentage) of selected impact; \(projection.groupedAffectedCount.formatted()) smaller changes are grouped under Other."
     }
 
     private var significantTable: some View {
@@ -391,60 +419,45 @@ struct ScanComparisonView: View {
             children: \.children,
             selection: $aggregateSelection
         ) {
-            TableColumn("Contributor") { node in
-                HStack(spacing: 8) {
-                    Image(systemName: itemSymbol(for: node))
-                        .foregroundStyle(node.isRemainder ? Color.secondary : Color.accentColor)
-                        .frame(width: 16)
-
-                    VStack(alignment: .leading, spacing: 1) {
-                        Text(node.name)
-                            .fontWeight(node.isRemainder ? .regular : .medium)
-                            .lineLimit(1)
-
-                        if node.isRemainder {
-                            Text("Switch to All Changes to inspect every item")
-                        } else if node.relativePath != node.name {
-                            Text(node.relativePath)
-                        }
-                    }
-                    .font(.caption)
-                    .foregroundStyle(node.isRemainder ? .secondary : .primary)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-                }
+            TableColumn("Item") { node in
+                comparisonItemLabel(
+                    name: node.name,
+                    symbol: itemSymbol(for: node),
+                    detail: node.isRemainder
+                        ? "Switch to All Changes to inspect every item"
+                        : itemLocation(for: node),
+                    isRemainder: node.isRemainder
+                )
             }
-            .width(min: 280, ideal: 520)
+            .width(min: 280, ideal: 500)
 
-            TableColumn("Taking Space") { node in
+            TableColumn("Change") { node in
+                aggregateChangeLabel(for: node)
+            }
+            .width(min: 105, ideal: 120)
+
+            TableColumn("Increase") { node in
                 Text(node.increasedAllocatedSize == 0 ? "–" : "+" + RadixFormatters.size(node.increasedAllocatedSize))
                     .foregroundStyle(node.increasedAllocatedSize == 0 ? Color.secondary : Color.red)
                     .monospacedDigit()
-                    .accessibilityLabel("Taking \(RadixFormatters.size(node.increasedAllocatedSize))")
+                    .accessibilityLabel("Increased by \(RadixFormatters.size(node.increasedAllocatedSize))")
             }
-            .width(min: 110, ideal: 130)
+            .width(min: 120, ideal: 140)
 
-            TableColumn("Freeing Space") { node in
+            TableColumn("Decrease") { node in
                 Text(node.reclaimedAllocatedSize == 0 ? "–" : "−" + RadixFormatters.size(node.reclaimedAllocatedSize))
                     .foregroundStyle(node.reclaimedAllocatedSize == 0 ? Color.secondary : Color.green)
                     .monospacedDigit()
-                    .accessibilityLabel("Freeing \(RadixFormatters.size(node.reclaimedAllocatedSize))")
+                    .accessibilityLabel("Decreased by \(RadixFormatters.size(node.reclaimedAllocatedSize))")
             }
-            .width(min: 110, ideal: 130)
+            .width(min: 135, ideal: 155)
 
-            TableColumn("Net") { node in
+            TableColumn("Net Change") { node in
                 Text(signedSize(node.allocatedDelta))
                     .foregroundStyle(deltaColor(node.allocatedDelta))
                     .monospacedDigit()
             }
-            .width(min: 100, ideal: 120)
-
-            TableColumn("Changes") { node in
-                Text(node.affectedCount.formatted())
-                    .monospacedDigit()
-                    .accessibilityLabel("\(node.affectedCount.formatted()) affected items")
-            }
-            .width(min: 75, ideal: 90)
+            .width(min: 105, ideal: 120)
         }
         .contextMenu(forSelectionType: ScanComparisonChangeTreeNode.ID.self) { ids in
             aggregateContextMenu(for: ids)
@@ -460,46 +473,38 @@ struct ScanComparisonView: View {
 
     private var comparisonTable: some View {
         Table(of: ScanComparisonRow.self, selection: $selection, sortOrder: $sortOrder) {
+            TableColumn("Item", sortUsing: ScanComparisonRowComparator(field: .relativePath)) { row in
+                comparisonItemLabel(
+                    name: row.name,
+                    symbol: itemSymbol(for: row),
+                    detail: itemLocation(for: row)
+                )
+            }
+            .width(min: 280, ideal: 500)
+
             TableColumn("Change", sortUsing: ScanComparisonRowComparator(field: .changeKind)) { row in
                 Label(row.kind.title, systemImage: row.kind.systemImageName)
                     .foregroundStyle(row.kind.tintColor)
             }
             .width(min: 105, ideal: 120)
 
-            TableColumn("Item", sortUsing: ScanComparisonRowComparator(field: .relativePath)) { row in
-                HStack(spacing: 8) {
-                    Image(systemName: itemSymbol(for: row))
-                        .foregroundStyle(.secondary)
-                        .frame(width: 16)
-
-                    VStack(alignment: .leading, spacing: 1) {
-                        Text(row.name)
-                            .lineLimit(1)
-
-                        Text(itemLocation(for: row))
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .lineLimit(1)
-                            .truncationMode(.middle)
-                            .textSelection(.enabled)
-                    }
-                }
-            }
-            .width(min: 280, ideal: 500)
-
-            TableColumn("Earlier", sortUsing: ScanComparisonRowComparator(field: .beforeAllocatedSize)) { row in
-                Text(sizeText(row.beforeAllocatedSize))
+            TableColumn("Increase", sortUsing: ScanComparisonRowComparator(field: .allocatedDelta)) { row in
+                Text(row.allocatedDelta > 0 ? "+" + RadixFormatters.size(row.allocatedDelta) : "–")
+                    .foregroundStyle(row.allocatedDelta > 0 ? Color.red : Color.secondary)
                     .monospacedDigit()
+                    .accessibilityLabel(positiveChangeAccessibilityLabel(for: row))
             }
-            .width(min: 105, ideal: 120)
+            .width(min: 120, ideal: 140)
 
-            TableColumn("Later", sortUsing: ScanComparisonRowComparator(field: .afterAllocatedSize)) { row in
-                Text(sizeText(row.afterAllocatedSize))
+            TableColumn("Decrease", sortUsing: ScanComparisonRowComparator(field: .allocatedDelta)) { row in
+                Text(row.allocatedDelta < 0 ? "−" + RadixFormatters.size(abs(row.allocatedDelta)) : "–")
+                    .foregroundStyle(row.allocatedDelta < 0 ? Color.green : Color.secondary)
                     .monospacedDigit()
+                    .accessibilityLabel(negativeChangeAccessibilityLabel(for: row))
             }
-            .width(min: 105, ideal: 120)
+            .width(min: 135, ideal: 155)
 
-            TableColumn("Delta", sortUsing: ScanComparisonRowComparator(field: .allocatedDelta)) { row in
+            TableColumn("Net Change", sortUsing: ScanComparisonRowComparator(field: .allocatedDelta)) { row in
                 Text(signedSize(row.allocatedDelta))
                     .foregroundStyle(deltaColor(row.allocatedDelta))
                     .monospacedDigit()
@@ -516,7 +521,24 @@ struct ScanComparisonView: View {
             guard let row = singleRow(in: ids), actions.canReveal(row) else { return }
             actions.reveal(row)
         }
-        .alternatingRowBackgrounds(.disabled)
+    }
+
+    @ViewBuilder
+    private func aggregateChangeLabel(for node: ScanComparisonChangeTreeNode) -> some View {
+        if node.isRemainder {
+            Label("Grouped", systemImage: "ellipsis.circle")
+                .foregroundStyle(.secondary)
+        } else if node.affectedCount == 1,
+                  let directRowID = node.directRowID,
+                  let row = comparison.rows.first(where: { $0.id == directRowID }),
+                  selectedChangeKinds.contains(row.kind) {
+            Label(row.kind.title, systemImage: row.kind.systemImageName)
+                .foregroundStyle(row.kind.tintColor)
+        } else {
+            Label("Summary", systemImage: "list.bullet.indent")
+                .foregroundStyle(.secondary)
+                .help("\(node.affectedCount.formatted()) changes summarized")
+        }
     }
 
     private var selectedRow: ScanComparisonRow? {
@@ -709,15 +731,17 @@ struct ScanComparisonView: View {
     }
 
     private var emptyStateDescription: String {
-        comparison.rows.isEmpty
+        if selectedChangeKinds.isEmpty {
+            return "Choose one or more change types to display."
+        }
+        return comparison.rows.isEmpty
             ? "No tracked size changes were found."
             : "Choose a different view or adjust your search."
     }
 
     private var rowQuery: ScanComparisonRowQuery {
         ScanComparisonRowQuery(
-            changeKind: nil,
-            impactFilter: impactFilter,
+            changeKinds: selectedChangeKinds,
             searchText: searchText,
             sortOrder: sortOrder,
             pathPrefix: focusedLocationPath
@@ -730,9 +754,40 @@ struct ScanComparisonView: View {
         selection.formIntersection(rows.lazy.map(\.id))
     }
 
-    private func sizeText(_ size: Int64?) -> String {
-        guard let size else { return "-" }
-        return RadixFormatters.size(size)
+    private func positiveChangeAccessibilityLabel(for row: ScanComparisonRow) -> String {
+        guard row.allocatedDelta > 0 else { return "No increase" }
+        return "Increased by \(RadixFormatters.size(row.allocatedDelta))"
+    }
+
+    private func negativeChangeAccessibilityLabel(for row: ScanComparisonRow) -> String {
+        guard row.allocatedDelta < 0 else { return "No decrease" }
+        return "Decreased by \(RadixFormatters.size(abs(row.allocatedDelta)))"
+    }
+
+    private func comparisonItemLabel(
+        name: String,
+        symbol: String,
+        detail: String,
+        isRemainder: Bool = false
+    ) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: symbol)
+                .foregroundStyle(.secondary)
+                .frame(width: 16)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(name)
+                    .foregroundStyle(isRemainder ? Color.secondary : Color.primary)
+                    .lineLimit(1)
+
+                Text(detail)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .textSelection(.enabled)
+            }
+        }
     }
 
     private func itemLocation(for row: ScanComparisonRow) -> String {
@@ -740,9 +795,17 @@ struct ScanComparisonView: View {
             return "\(movedFromRelativePath) → \(row.relativePath)"
         }
 
-        let components = row.relativePath.split(separator: "/")
+        return itemLocation(relativePath: row.relativePath, itemKind: row.itemKind)
+    }
+
+    private func itemLocation(for node: ScanComparisonChangeTreeNode) -> String {
+        itemLocation(relativePath: node.relativePath, itemKind: itemKind(for: node))
+    }
+
+    private func itemLocation(relativePath: String, itemKind: String) -> String {
+        let components = relativePath.split(separator: "/")
         let parent = components.dropLast().joined(separator: "/")
-        return parent.isEmpty ? row.itemKind : parent
+        return parent.isEmpty ? itemKind : parent
     }
 
     private func itemSymbol(for row: ScanComparisonRow) -> String {
@@ -756,7 +819,14 @@ struct ScanComparisonView: View {
         if node.isRemainder {
             return "ellipsis.circle"
         }
+        if itemKind(for: node) == "Package" {
+            return "shippingbox.fill"
+        }
         return node.isDirectory ? "folder.fill" : "doc.fill"
+    }
+
+    private func itemKind(for node: ScanComparisonChangeTreeNode) -> String {
+        (node.afterNode ?? node.beforeNode)?.itemKind ?? (node.isDirectory ? "Folder" : "Item")
     }
 
     private func comparisonDate(_ date: Date) -> String {
@@ -797,47 +867,6 @@ private enum ScanComparisonDisplayMode: String, CaseIterable, Identifiable {
             return "Significant"
         case .allChanges:
             return "All Changes"
-        }
-    }
-}
-
-private extension ScanComparisonImpactFilter {
-    var title: String {
-        switch self {
-        case .takingSpace:
-            return "Taking Space"
-        case .freeingSpace:
-            return "Freeing Space"
-        case .moved:
-            return "Moves"
-        case .allActivity:
-            return "Everything"
-        }
-    }
-
-    var systemImageName: String {
-        switch self {
-        case .takingSpace:
-            return "arrow.up.right"
-        case .freeingSpace:
-            return "arrow.down.right"
-        case .moved:
-            return "arrow.left.arrow.right"
-        case .allActivity:
-            return "waveform.path.ecg"
-        }
-    }
-
-    var statusNoun: String {
-        switch self {
-        case .takingSpace:
-            return "storage growth"
-        case .freeingSpace:
-            return "reclaimed storage"
-        case .moved:
-            return "moves"
-        case .allActivity:
-            return "storage activity"
         }
     }
 }

--- a/Radix/Features/Comparison/ScanComparisonView.swift
+++ b/Radix/Features/Comparison/ScanComparisonView.swift
@@ -6,6 +6,11 @@ struct ScanComparisonRowActions {
     let showInBrowser: (ScanComparisonRow) -> Void
     let canShowInBrowser: (ScanComparisonRow) -> Bool
     let copyPath: (ScanComparisonRow) -> Void
+    let revealNode: (ScanComparisonChangeTreeNode) -> Void
+    let canRevealNode: (ScanComparisonChangeTreeNode) -> Bool
+    let showNodeInBrowser: (ScanComparisonChangeTreeNode) -> Void
+    let canShowNodeInBrowser: (ScanComparisonChangeTreeNode) -> Bool
+    let copyNodePath: (ScanComparisonChangeTreeNode) -> Void
 }
 
 struct ScanComparisonView: View {
@@ -17,13 +22,15 @@ struct ScanComparisonView: View {
     let actions: ScanComparisonRowActions
     let onClose: () -> Void
 
-    @State private var filter: ScanComparisonRowFilter = .all
+    @State private var displayMode: ScanComparisonDisplayMode = .significant
+    @State private var impactFilter: ScanComparisonImpactFilter
     @State private var searchText = ""
     @State private var focusedLocationPath: String?
     @State private var sortOrder: [ScanComparisonRowComparator]
     @State private var selection = Set<ScanComparisonRow.ID>()
+    @State private var aggregateSelection = Set<ScanComparisonChangeTreeNode.ID>()
     @State private var displayedRows: [ScanComparisonRow]
-    @State private var isLocationOverviewExpanded = true
+    @State private var projection: ScanComparisonChangeTreeProjection
 
     init(
         comparison: ScanComparison,
@@ -35,13 +42,25 @@ struct ScanComparisonView: View {
         self.onClose = onClose
 
         let sortOrder = Self.initialSortOrder
+        let impactFilter: ScanComparisonImpactFilter = if comparison.summary.allocatedDelta > 0 {
+            .takingSpace
+        } else if comparison.summary.allocatedDelta < 0 {
+            .freeingSpace
+        } else {
+            .allActivity
+        }
+        self._impactFilter = State(initialValue: impactFilter)
         self._sortOrder = State(initialValue: sortOrder)
         self._displayedRows = State(initialValue: ScanComparisonRowQuery(
             changeKind: nil,
+            impactFilter: impactFilter,
             searchText: "",
             sortOrder: sortOrder,
             pathPrefix: nil
         ).applying(to: comparison.rows))
+        self._projection = State(initialValue: comparison.changeTree.significantProjection(
+            impactFilter: impactFilter
+        ))
     }
 
     var body: some View {
@@ -72,14 +91,29 @@ struct ScanComparisonView: View {
         .onChange(of: rowQuery) { _, query in
             refreshDisplayedRows(using: query)
         }
+        .onChange(of: impactFilter) { _, filter in
+            projection = comparison.changeTree.significantProjection(impactFilter: filter)
+            aggregateSelection.removeAll()
+        }
+        .onChange(of: displayMode) { _, mode in
+            if mode == .significant {
+                focusedLocationPath = nil
+                selection.removeAll()
+            } else {
+                aggregateSelection.removeAll()
+            }
+        }
         .onChange(of: comparison.id) { _, _ in
             refreshDisplayedRows(using: rowQuery)
+            projection = comparison.changeTree.significantProjection(impactFilter: impactFilter)
         }
     }
 
     @ViewBuilder
     private var comparisonContent: some View {
-        if displayedRows.isEmpty {
+        if effectiveDisplayMode == .significant, !projection.roots.isEmpty {
+            significantTable
+        } else if displayedRows.isEmpty {
             emptyState
         } else {
             comparisonTable
@@ -109,34 +143,30 @@ struct ScanComparisonView: View {
                 coverageBanner
             }
 
-            if !highlightedLocations.isEmpty {
-                locationOverview
-            }
-
-            HStack(spacing: 12) {
-                Picker("Filter", selection: $filter) {
-                    ForEach(ScanComparisonRowFilter.allCases) { filter in
-                        Text(filterTitle(filter))
-                            .tag(filter)
-                            .disabled(filter != .all && filterCount(filter) == 0)
+            HStack(spacing: 16) {
+                Picker("Detail", selection: $displayMode) {
+                    ForEach(ScanComparisonDisplayMode.allCases) { mode in
+                        Text(mode.title).tag(mode)
                     }
                 }
                 .pickerStyle(.segmented)
                 .labelsHidden()
-                .frame(maxWidth: 520)
+                .frame(width: 240)
+                .accessibilityLabel("Comparison detail")
 
-                if let focusedLocationPath {
-                    Button {
-                        self.focusedLocationPath = nil
-                    } label: {
-                        Label("Showing \(focusedLocationPath)", systemImage: "xmark.circle.fill")
+                Divider()
+                    .frame(height: 22)
+
+                Picker("Show", selection: $impactFilter) {
+                    ForEach(ScanComparisonImpactFilter.allCases) { filter in
+                        Label(filter.title, systemImage: filter.systemImageName).tag(filter)
                     }
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
-                    .lineLimit(1)
                 }
+                .pickerStyle(.menu)
+                .fixedSize()
+                .accessibilityLabel("Show changes")
 
-                Spacer()
+                Spacer(minLength: 16)
 
                 HStack(spacing: 6) {
                     Image(systemName: "magnifyingglass")
@@ -157,11 +187,17 @@ struct ScanComparisonView: View {
                     }
                 }
                 .padding(.horizontal, 8)
-                .frame(width: 250, height: 28)
+                .frame(width: 280, height: 28)
                 .background(.quaternary, in: RoundedRectangle(cornerRadius: 6))
             }
 
-            if let selectedRow {
+            if !comparison.rows.isEmpty {
+                comparisonStatus
+            }
+
+            if effectiveDisplayMode == .significant, let selectedAggregateNode {
+                aggregateSelectionActions(for: selectedAggregateNode)
+            } else if let selectedRow {
                 selectionActions(for: selectedRow)
             }
         }
@@ -257,93 +293,6 @@ struct ScanComparisonView: View {
         }
     }
 
-    private var highlightedLocations: [ScanComparisonLocationChange] {
-        let increases = comparison.topLevelChanges
-            .filter { $0.allocatedDelta > 0 }
-            .sorted { lhs, rhs in
-                lhs.allocatedDelta == rhs.allocatedDelta
-                    ? lhs.relativePath.localizedStandardCompare(rhs.relativePath) == .orderedAscending
-                    : lhs.allocatedDelta > rhs.allocatedDelta
-            }
-        if !increases.isEmpty {
-            return Array(increases.prefix(3))
-        }
-        return Array(comparison.topLevelChanges.prefix(3))
-    }
-
-    private var locationOverviewTitle: String {
-        comparison.topLevelChanges.contains { $0.allocatedDelta > 0 }
-            ? "Largest Increases"
-            : "Largest Changes"
-    }
-
-    private var locationOverview: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Button {
-                isLocationOverviewExpanded.toggle()
-            } label: {
-                HStack(spacing: 8) {
-                    Text(locationOverviewTitle)
-                        .font(.subheadline.weight(.semibold))
-
-                    Spacer()
-
-                    Image(systemName: isLocationOverviewExpanded ? "chevron.down" : "chevron.right")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(.secondary)
-                }
-                .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .accessibilityValue(isLocationOverviewExpanded ? "Expanded" : "Collapsed")
-            .help(isLocationOverviewExpanded ? "Collapse \(locationOverviewTitle)" : "Expand \(locationOverviewTitle)")
-
-            if isLocationOverviewExpanded {
-                ForEach(highlightedLocations) { location in
-                    locationRow(location)
-                }
-            }
-        }
-        .padding(10)
-        .background(.quaternary, in: RoundedRectangle(cornerRadius: 8))
-    }
-
-    private func locationRow(_ location: ScanComparisonLocationChange) -> some View {
-        Button {
-            withAnimation(.snappy(duration: 0.2)) {
-                focusedLocationPath = location.relativePath
-            }
-        } label: {
-            HStack(spacing: 10) {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(location.relativePath)
-                        .font(.subheadline.weight(.medium))
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-
-                    Text("\(location.affectedCount.formatted()) affected item\(location.affectedCount == 1 ? "" : "s")")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-
-                Spacer(minLength: 8)
-
-                Text(signedSize(location.allocatedDelta))
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(deltaColor(location.allocatedDelta))
-                    .monospacedDigit()
-
-                Image(systemName: "chevron.right")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(.tertiary)
-            }
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .padding(.vertical, 2)
-        .help("Show changes in \(location.relativePath)")
-    }
-
     private func sourceSummary(title: String, snapshot: ComparedSnapshotSummary) -> some View {
         HStack(spacing: 5) {
             Text(title)
@@ -386,6 +335,127 @@ struct ScanComparisonView: View {
                 .monospacedDigit()
         }
         .frame(minWidth: 66, alignment: .leading)
+    }
+
+    private var effectiveDisplayMode: ScanComparisonDisplayMode {
+        searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? displayMode
+            : .allChanges
+    }
+
+    private var comparisonStatus: some View {
+        HStack(spacing: 6) {
+            if let focusedLocationPath {
+                Button {
+                    self.focusedLocationPath = nil
+                } label: {
+                    Label(focusedLocationPath, systemImage: "xmark.circle.fill")
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .lineLimit(1)
+                .help("Clear location filter")
+            }
+
+            Image(systemName: effectiveDisplayMode == .significant ? "scope" : "list.bullet")
+                .foregroundStyle(.secondary)
+
+            if effectiveDisplayMode == .significant {
+                Text(significantStatusText)
+            } else {
+                Text("Showing \(displayedRows.count.formatted()) of \(comparison.rows.count.formatted()) filesystem changes.")
+                if !searchText.isEmpty, displayMode == .significant {
+                    Text("Search uses All Changes.")
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Spacer()
+        }
+        .font(.caption)
+        .foregroundStyle(.secondary)
+        .accessibilityElement(children: .combine)
+    }
+
+    private var significantStatusText: String {
+        let percentage = projection.representedFraction.formatted(.percent.precision(.fractionLength(0)))
+        let effect = impactFilter.statusNoun
+        if projection.hiddenRootCount == 0 {
+            return "Showing all meaningful \(effect) contributors; expand folders to trace their source."
+        }
+        return "Named contributors represent \(percentage) of \(effect); \(projection.groupedAffectedCount.formatted()) smaller changes are grouped under Other."
+    }
+
+    private var significantTable: some View {
+        Table(
+            projection.roots,
+            children: \.children,
+            selection: $aggregateSelection
+        ) {
+            TableColumn("Contributor") { node in
+                HStack(spacing: 8) {
+                    Image(systemName: itemSymbol(for: node))
+                        .foregroundStyle(node.isRemainder ? Color.secondary : Color.accentColor)
+                        .frame(width: 16)
+
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text(node.name)
+                            .fontWeight(node.isRemainder ? .regular : .medium)
+                            .lineLimit(1)
+
+                        if node.isRemainder {
+                            Text("Switch to All Changes to inspect every item")
+                        } else if node.relativePath != node.name {
+                            Text(node.relativePath)
+                        }
+                    }
+                    .font(.caption)
+                    .foregroundStyle(node.isRemainder ? .secondary : .primary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                }
+            }
+            .width(min: 280, ideal: 520)
+
+            TableColumn("Taking Space") { node in
+                Text(node.increasedAllocatedSize == 0 ? "–" : "+" + RadixFormatters.size(node.increasedAllocatedSize))
+                    .foregroundStyle(node.increasedAllocatedSize == 0 ? Color.secondary : Color.red)
+                    .monospacedDigit()
+                    .accessibilityLabel("Taking \(RadixFormatters.size(node.increasedAllocatedSize))")
+            }
+            .width(min: 110, ideal: 130)
+
+            TableColumn("Freeing Space") { node in
+                Text(node.reclaimedAllocatedSize == 0 ? "–" : "−" + RadixFormatters.size(node.reclaimedAllocatedSize))
+                    .foregroundStyle(node.reclaimedAllocatedSize == 0 ? Color.secondary : Color.green)
+                    .monospacedDigit()
+                    .accessibilityLabel("Freeing \(RadixFormatters.size(node.reclaimedAllocatedSize))")
+            }
+            .width(min: 110, ideal: 130)
+
+            TableColumn("Net") { node in
+                Text(signedSize(node.allocatedDelta))
+                    .foregroundStyle(deltaColor(node.allocatedDelta))
+                    .monospacedDigit()
+            }
+            .width(min: 100, ideal: 120)
+
+            TableColumn("Changes") { node in
+                Text(node.affectedCount.formatted())
+                    .monospacedDigit()
+                    .accessibilityLabel("\(node.affectedCount.formatted()) affected items")
+            }
+            .width(min: 75, ideal: 90)
+        }
+        .contextMenu(forSelectionType: ScanComparisonChangeTreeNode.ID.self) { ids in
+            aggregateContextMenu(for: ids)
+        } primaryAction: { ids in
+            guard let node = singleAggregateNode(in: ids) else { return }
+            if node.isRemainder {
+                showAllChanges(for: node)
+            } else if actions.canShowNodeInBrowser(node) {
+                actions.showNodeInBrowser(node)
+            }
+        }
     }
 
     private var comparisonTable: some View {
@@ -453,6 +523,56 @@ struct ScanComparisonView: View {
         singleRow(in: selection)
     }
 
+    private var selectedAggregateNode: ScanComparisonChangeTreeNode? {
+        singleAggregateNode(in: aggregateSelection)
+    }
+
+    private func aggregateSelectionActions(for node: ScanComparisonChangeTreeNode) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: itemSymbol(for: node))
+                .foregroundStyle(.secondary)
+
+            Text(node.name)
+                .font(.subheadline.weight(.medium))
+                .lineLimit(1)
+
+            Spacer()
+
+            if node.isRemainder {
+                Button {
+                    showAllChanges(for: node)
+                } label: {
+                    Label("Show All Changes", systemImage: "list.bullet")
+                }
+            } else {
+                Button {
+                    actions.showNodeInBrowser(node)
+                } label: {
+                    Label("Show in Browser", systemImage: "sidebar.squares.left")
+                }
+                .disabled(!actions.canShowNodeInBrowser(node))
+
+                Button {
+                    actions.revealNode(node)
+                } label: {
+                    Label("Reveal in Finder", systemImage: "folder")
+                }
+                .disabled(!actions.canRevealNode(node))
+
+                Button {
+                    actions.copyNodePath(node)
+                } label: {
+                    Label("Copy Path", systemImage: "doc.on.doc")
+                }
+                .disabled(node.fileURL == nil)
+            }
+        }
+        .controlSize(.small)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+        .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 8))
+    }
+
     private func selectionActions(for row: ScanComparisonRow) -> some View {
         HStack(spacing: 8) {
             Image(systemName: itemSymbol(for: row))
@@ -517,6 +637,55 @@ struct ScanComparisonView: View {
         }
     }
 
+    @ViewBuilder
+    private func aggregateContextMenu(for ids: Set<ScanComparisonChangeTreeNode.ID>) -> some View {
+        if let node = singleAggregateNode(in: ids) {
+            if node.isRemainder {
+                Button {
+                    showAllChanges(for: node)
+                } label: {
+                    Label("Show All Changes", systemImage: "list.bullet")
+                }
+            } else {
+                Button {
+                    actions.revealNode(node)
+                } label: {
+                    Label("Reveal in Finder", systemImage: "folder")
+                }
+                .disabled(!actions.canRevealNode(node))
+
+                Button {
+                    actions.showNodeInBrowser(node)
+                } label: {
+                    Label("Show in Browser", systemImage: "sidebar.squares.left")
+                }
+                .disabled(!actions.canShowNodeInBrowser(node))
+
+                Divider()
+
+                Button {
+                    actions.copyNodePath(node)
+                } label: {
+                    Label("Copy Path", systemImage: "doc.on.doc")
+                }
+                .disabled(node.fileURL == nil)
+            }
+        }
+    }
+
+    private func singleAggregateNode(
+        in ids: Set<ScanComparisonChangeTreeNode.ID>
+    ) -> ScanComparisonChangeTreeNode? {
+        guard ids.count == 1, let id = ids.first else { return nil }
+        return projection.node(withID: id)
+    }
+
+    private func showAllChanges(for node: ScanComparisonChangeTreeNode) {
+        displayMode = .allChanges
+        focusedLocationPath = node.relativePath.isEmpty ? nil : node.relativePath
+        aggregateSelection.removeAll()
+    }
+
     private func singleRow(in ids: Set<ScanComparisonRow.ID>) -> ScanComparisonRow? {
         guard ids.count == 1, let id = ids.first else { return nil }
         return comparison.rows.first { $0.id == id }
@@ -542,12 +711,13 @@ struct ScanComparisonView: View {
     private var emptyStateDescription: String {
         comparison.rows.isEmpty
             ? "No tracked size changes were found."
-            : "Adjust filter or search."
+            : "Choose a different view or adjust your search."
     }
 
     private var rowQuery: ScanComparisonRowQuery {
         ScanComparisonRowQuery(
-            changeKind: filter.changeKind,
+            changeKind: nil,
+            impactFilter: impactFilter,
             searchText: searchText,
             sortOrder: sortOrder,
             pathPrefix: focusedLocationPath
@@ -582,29 +752,15 @@ struct ScanComparisonView: View {
         return row.isDirectory ? "folder.fill" : "doc.fill"
     }
 
+    private func itemSymbol(for node: ScanComparisonChangeTreeNode) -> String {
+        if node.isRemainder {
+            return "ellipsis.circle"
+        }
+        return node.isDirectory ? "folder.fill" : "doc.fill"
+    }
+
     private func comparisonDate(_ date: Date) -> String {
         date.formatted(date: .abbreviated, time: .standard)
-    }
-
-    private func filterTitle(_ filter: ScanComparisonRowFilter) -> String {
-        "\(filter.title) \(filterCount(filter).formatted())"
-    }
-
-    private func filterCount(_ filter: ScanComparisonRowFilter) -> Int {
-        switch filter {
-        case .all:
-            return comparison.rows.count
-        case .added:
-            return comparison.summary.addedCount
-        case .removed:
-            return comparison.summary.removedCount
-        case .grew:
-            return comparison.summary.grewCount
-        case .shrank:
-            return comparison.summary.shrankCount
-        case .moved:
-            return comparison.summary.movedCount
-        }
     }
 
     private func signedSize(_ size: Int64) -> String {
@@ -629,49 +785,59 @@ struct ScanComparisonView: View {
     }
 }
 
-private enum ScanComparisonRowFilter: String, CaseIterable, Identifiable {
-    case all
-    case added
-    case removed
-    case grew
-    case shrank
-    case moved
+private enum ScanComparisonDisplayMode: String, CaseIterable, Identifiable {
+    case significant
+    case allChanges
 
-    var id: String {
-        rawValue
-    }
+    var id: String { rawValue }
 
     var title: String {
         switch self {
-        case .all:
-            return "All"
-        case .added:
-            return ScanComparisonChangeKind.added.title
-        case .removed:
-            return ScanComparisonChangeKind.removed.title
-        case .grew:
-            return ScanComparisonChangeKind.grew.title
-        case .shrank:
-            return ScanComparisonChangeKind.shrank.title
+        case .significant:
+            return "Significant"
+        case .allChanges:
+            return "All Changes"
+        }
+    }
+}
+
+private extension ScanComparisonImpactFilter {
+    var title: String {
+        switch self {
+        case .takingSpace:
+            return "Taking Space"
+        case .freeingSpace:
+            return "Freeing Space"
         case .moved:
-            return ScanComparisonChangeKind.moved.title
+            return "Moves"
+        case .allActivity:
+            return "Everything"
         }
     }
 
-    var changeKind: ScanComparisonChangeKind? {
+    var systemImageName: String {
         switch self {
-        case .all:
-            return nil
-        case .added:
-            return .added
-        case .removed:
-            return .removed
-        case .grew:
-            return .grew
-        case .shrank:
-            return .shrank
+        case .takingSpace:
+            return "arrow.up.right"
+        case .freeingSpace:
+            return "arrow.down.right"
         case .moved:
-            return .moved
+            return "arrow.left.arrow.right"
+        case .allActivity:
+            return "waveform.path.ecg"
+        }
+    }
+
+    var statusNoun: String {
+        switch self {
+        case .takingSpace:
+            return "storage growth"
+        case .freeingSpace:
+            return "reclaimed storage"
+        case .moved:
+            return "moves"
+        case .allActivity:
+            return "storage activity"
         }
     }
 }

--- a/Radix/Features/Comparison/ScanComparisonView.swift
+++ b/Radix/Features/Comparison/ScanComparisonView.swift
@@ -8,6 +8,13 @@ struct ScanComparisonRowActions {
     let copyPath: (ScanComparisonRow) -> Void
 }
 
+struct ScanComparisonLocationActions {
+    let reveal: (ScanComparisonLocationChange) -> Void
+    let canReveal: (ScanComparisonLocationChange) -> Bool
+    let showInBrowser: (ScanComparisonLocationChange) -> Void
+    let canShowInBrowser: (ScanComparisonLocationChange) -> Bool
+}
+
 struct ScanComparisonView: View {
     private static let initialSortOrder = [
         ScanComparisonRowComparator.defaultOrder
@@ -15,10 +22,12 @@ struct ScanComparisonView: View {
 
     let comparison: ScanComparison
     let actions: ScanComparisonRowActions
+    let locationActions: ScanComparisonLocationActions
     let onClose: () -> Void
 
     @State private var filter: ScanComparisonRowFilter = .all
     @State private var searchText = ""
+    @State private var focusedLocationPath: String?
     @State private var sortOrder: [ScanComparisonRowComparator]
     @State private var selection = Set<ScanComparisonRow.ID>()
     @State private var displayedRows: [ScanComparisonRow]
@@ -26,10 +35,12 @@ struct ScanComparisonView: View {
     init(
         comparison: ScanComparison,
         actions: ScanComparisonRowActions,
+        locationActions: ScanComparisonLocationActions,
         onClose: @escaping () -> Void
     ) {
         self.comparison = comparison
         self.actions = actions
+        self.locationActions = locationActions
         self.onClose = onClose
 
         let sortOrder = Self.initialSortOrder
@@ -37,7 +48,8 @@ struct ScanComparisonView: View {
         self._displayedRows = State(initialValue: ScanComparisonRowQuery(
             changeKind: nil,
             searchText: "",
-            sortOrder: sortOrder
+            sortOrder: sortOrder,
+            pathPrefix: nil
         ).applying(to: comparison.rows))
     }
 
@@ -77,10 +89,10 @@ struct ScanComparisonView: View {
         VStack(alignment: .leading, spacing: 14) {
             HStack(alignment: .top, spacing: 16) {
                 VStack(alignment: .leading, spacing: 4) {
-                    Text("Snapshot Comparison")
+                    Text("Storage Changes")
                         .font(.title2.weight(.semibold))
 
-                    Text("\(comparison.before.displayName) -> \(comparison.after.displayName)")
+                    Text(storageChangeHeadline)
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
@@ -91,7 +103,7 @@ struct ScanComparisonView: View {
                 Spacer(minLength: 16)
 
                 VStack(alignment: .trailing, spacing: 2) {
-                    Text("Delta")
+                    Text("Tracked Storage")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                     Text(signedSize(comparison.summary.allocatedDelta))
@@ -103,27 +115,33 @@ struct ScanComparisonView: View {
 
             ViewThatFits(in: .horizontal) {
                 HStack(alignment: .top, spacing: 18) {
-                    sourceSummary(title: "Before", snapshot: comparison.before)
+                    sourceSummary(title: "Earlier Scan", snapshot: comparison.before)
                     Image(systemName: "arrow.right")
                         .font(.title3.weight(.semibold))
                         .foregroundStyle(.secondary)
                         .frame(height: 44)
-                    sourceSummary(title: "After", snapshot: comparison.after)
+                    sourceSummary(title: "Later Scan", snapshot: comparison.after)
                     Spacer(minLength: 10)
                     metricStrip
                 }
 
                 VStack(alignment: .leading, spacing: 12) {
                     HStack(alignment: .top, spacing: 18) {
-                        sourceSummary(title: "Before", snapshot: comparison.before)
+                        sourceSummary(title: "Earlier Scan", snapshot: comparison.before)
                         Image(systemName: "arrow.right")
                             .font(.title3.weight(.semibold))
                             .foregroundStyle(.secondary)
                             .frame(height: 44)
-                        sourceSummary(title: "After", snapshot: comparison.after)
+                        sourceSummary(title: "Later Scan", snapshot: comparison.after)
                     }
                     metricStrip
                 }
+            }
+
+            coverageBanner
+
+            if !highlightedLocations.isEmpty {
+                locationOverview
             }
 
             HStack(spacing: 12) {
@@ -135,6 +153,17 @@ struct ScanComparisonView: View {
                 .pickerStyle(.segmented)
                 .frame(maxWidth: 420)
 
+                if let focusedLocationPath {
+                    Button {
+                        self.focusedLocationPath = nil
+                    } label: {
+                        Label("Showing \(focusedLocationPath)", systemImage: "xmark.circle.fill")
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .lineLimit(1)
+                }
+
                 Spacer()
 
                 TextField("Search", text: $searchText)
@@ -144,6 +173,159 @@ struct ScanComparisonView: View {
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 14)
+    }
+
+    private var storageChangeHeadline: String {
+        let delta = comparison.summary.allocatedDelta
+        if delta > 0 {
+            return "Tracked storage increased by \(RadixFormatters.size(delta))."
+        }
+        if delta < 0 {
+            return "Tracked storage decreased by \(RadixFormatters.size(-delta))."
+        }
+        return "Tracked storage did not change."
+    }
+
+    private var coverageBanner: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: coverageSymbolName)
+                .foregroundStyle(coverageColor)
+
+            Text(coverageMessage)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(coverageColor.opacity(0.12), in: RoundedRectangle(cornerRadius: 8))
+    }
+
+    private var coverageMessage: String {
+        switch comparison.coverage.confidence {
+        case .high:
+            return "Comparable: same location, matching scan settings, and complete scans."
+        case .limited:
+            let warningCount = comparison.coverage.beforeWarningCount + comparison.coverage.afterWarningCount
+            if warningCount > 0 {
+                return "Limited coverage: \(warningCount) unreadable location\(warningCount == 1 ? "" : "s"). Missing entries below them are not necessarily deleted."
+            }
+            return "Limited coverage: scan settings are unavailable for one or both scans."
+        case .low:
+            return "Forensic comparison only: scan coverage or settings differ, so totals may not be directly comparable."
+        }
+    }
+
+    private var coverageColor: Color {
+        switch comparison.coverage.confidence {
+        case .high:
+            return .green
+        case .limited:
+            return .orange
+        case .low:
+            return .red
+        }
+    }
+
+    private var coverageSymbolName: String {
+        switch comparison.coverage.confidence {
+        case .high:
+            return "checkmark.seal.fill"
+        case .limited:
+            return "exclamationmark.triangle.fill"
+        case .low:
+            return "exclamationmark.octagon.fill"
+        }
+    }
+
+    private var highlightedLocations: [ScanComparisonLocationChange] {
+        let increases = comparison.topLevelChanges
+            .filter { $0.allocatedDelta > 0 }
+            .sorted { lhs, rhs in
+                lhs.allocatedDelta == rhs.allocatedDelta
+                    ? lhs.relativePath.localizedStandardCompare(rhs.relativePath) == .orderedAscending
+                    : lhs.allocatedDelta > rhs.allocatedDelta
+            }
+        if !increases.isEmpty {
+            return Array(increases.prefix(3))
+        }
+        return Array(comparison.topLevelChanges.prefix(3))
+    }
+
+    private var locationOverviewTitle: String {
+        comparison.topLevelChanges.contains { $0.allocatedDelta > 0 }
+            ? "Largest Increases"
+            : "Largest Changes"
+    }
+
+    private var locationOverview: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text(locationOverviewTitle)
+                    .font(.subheadline.weight(.semibold))
+
+                Spacer()
+
+                Text("\(signedSize(comparison.summary.grossIncreasedAllocatedSize)) added or grew • \(RadixFormatters.size(comparison.summary.grossReclaimedAllocatedSize)) reclaimed")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+            }
+
+            ForEach(highlightedLocations) { location in
+                locationRow(location)
+            }
+        }
+        .padding(10)
+        .background(.quaternary, in: RoundedRectangle(cornerRadius: 8))
+    }
+
+    private func locationRow(_ location: ScanComparisonLocationChange) -> some View {
+        HStack(spacing: 10) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(location.relativePath)
+                    .font(.subheadline.weight(.medium))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+
+                Text("\(location.changedCount.formatted()) change\(location.changedCount == 1 ? "" : "s")")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer(minLength: 8)
+
+            Text(signedSize(location.allocatedDelta))
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(deltaColor(location.allocatedDelta))
+                .monospacedDigit()
+
+            Button("Show Changes") {
+                focusedLocationPath = location.relativePath
+            }
+            .controlSize(.small)
+
+            Button {
+                locationActions.showInBrowser(location)
+            } label: {
+                Label("Show in Browser", systemImage: "sidebar.squares.left")
+            }
+            .labelStyle(.iconOnly)
+            .controlSize(.small)
+            .disabled(!locationActions.canShowInBrowser(location))
+            .help("Show in Browser")
+
+            Button {
+                locationActions.reveal(location)
+            } label: {
+                Label("Reveal Current Location in Finder", systemImage: "folder")
+            }
+            .labelStyle(.iconOnly)
+            .controlSize(.small)
+            .disabled(!locationActions.canReveal(location))
+            .help("Reveal Current Location in Finder")
+        }
+        .padding(.vertical, 2)
     }
 
     private func sourceSummary(title: String, snapshot: ComparedSnapshotSummary) -> some View {
@@ -168,7 +350,7 @@ struct ScanComparisonView: View {
     private var metricStrip: some View {
         ViewThatFits(in: .horizontal) {
             HStack(spacing: 14) {
-                comparisonMetric("Scanned", signedSize(comparison.summary.allocatedDelta))
+                comparisonMetric("Tracked", signedSize(comparison.summary.allocatedDelta))
                 comparisonMetric("Files", signedCount(comparison.summary.fileCountDelta))
                 comparisonMetric("Folders", signedCount(comparison.summary.directoryCountDelta))
                 comparisonMetric("Warnings", signedCount(comparison.summary.warningCountDelta))
@@ -177,7 +359,7 @@ struct ScanComparisonView: View {
 
             Grid(alignment: .leading, horizontalSpacing: 16, verticalSpacing: 8) {
                 GridRow {
-                    comparisonMetric("Scanned", signedSize(comparison.summary.allocatedDelta))
+                    comparisonMetric("Tracked", signedSize(comparison.summary.allocatedDelta))
                     comparisonMetric("Files", signedCount(comparison.summary.fileCountDelta))
                     comparisonMetric("Folders", signedCount(comparison.summary.directoryCountDelta))
                 }
@@ -212,20 +394,20 @@ struct ScanComparisonView: View {
             .width(min: 105, ideal: 120)
 
             TableColumn("Path", sortUsing: ScanComparisonRowComparator(field: .relativePath)) { row in
-                Text(row.relativePath)
+                Text(pathText(for: row))
                     .lineLimit(1)
                     .truncationMode(.middle)
                     .textSelection(.enabled)
             }
             .width(min: 260, ideal: 430)
 
-            TableColumn("Before", sortUsing: ScanComparisonRowComparator(field: .beforeAllocatedSize)) { row in
+            TableColumn("Earlier", sortUsing: ScanComparisonRowComparator(field: .beforeAllocatedSize)) { row in
                 Text(sizeText(row.beforeAllocatedSize))
                     .monospacedDigit()
             }
             .width(min: 105, ideal: 120)
 
-            TableColumn("After", sortUsing: ScanComparisonRowComparator(field: .afterAllocatedSize)) { row in
+            TableColumn("Later", sortUsing: ScanComparisonRowComparator(field: .afterAllocatedSize)) { row in
                 Text(sizeText(row.afterAllocatedSize))
                     .monospacedDigit()
             }
@@ -297,7 +479,7 @@ struct ScanComparisonView: View {
     }
 
     private var emptyStateTitle: String {
-        comparison.rows.isEmpty ? "No Changes" : "No Matching Changes"
+        comparison.rows.isEmpty ? "No Tracked Size Changes" : "No Matching Changes"
     }
 
     private var emptyStateSystemImage: String {
@@ -306,7 +488,7 @@ struct ScanComparisonView: View {
 
     private var emptyStateDescription: String {
         comparison.rows.isEmpty
-            ? "Matched paths have same allocated sizes."
+            ? "No tracked size changes were found."
             : "Adjust filter or search."
     }
 
@@ -314,7 +496,8 @@ struct ScanComparisonView: View {
         ScanComparisonRowQuery(
             changeKind: filter.changeKind,
             searchText: searchText,
-            sortOrder: sortOrder
+            sortOrder: sortOrder,
+            pathPrefix: focusedLocationPath
         )
     }
 
@@ -327,6 +510,13 @@ struct ScanComparisonView: View {
     private func sizeText(_ size: Int64?) -> String {
         guard let size else { return "-" }
         return RadixFormatters.size(size)
+    }
+
+    private func pathText(for row: ScanComparisonRow) -> String {
+        guard let movedFromRelativePath = row.movedFromRelativePath else {
+            return row.relativePath
+        }
+        return "\(movedFromRelativePath) → \(row.relativePath)"
     }
 
     private func signedSize(_ size: Int64) -> String {
@@ -357,6 +547,7 @@ private enum ScanComparisonRowFilter: String, CaseIterable, Identifiable {
     case removed
     case grew
     case shrank
+    case moved
 
     var id: String {
         rawValue
@@ -374,6 +565,8 @@ private enum ScanComparisonRowFilter: String, CaseIterable, Identifiable {
             return ScanComparisonChangeKind.grew.title
         case .shrank:
             return ScanComparisonChangeKind.shrank.title
+        case .moved:
+            return ScanComparisonChangeKind.moved.title
         }
     }
 
@@ -389,6 +582,8 @@ private enum ScanComparisonRowFilter: String, CaseIterable, Identifiable {
             return .grew
         case .shrank:
             return .shrank
+        case .moved:
+            return .moved
         }
     }
 }
@@ -404,6 +599,8 @@ private extension ScanComparisonChangeKind {
             return "arrow.up.circle.fill"
         case .shrank:
             return "arrow.down.circle.fill"
+        case .moved:
+            return "arrow.left.arrow.right.circle.fill"
         }
     }
 
@@ -417,6 +614,8 @@ private extension ScanComparisonChangeKind {
             return .red
         case .shrank:
             return .green
+        case .moved:
+            return .purple
         }
     }
 }

--- a/Radix/Features/Comparison/ScanComparisonView.swift
+++ b/Radix/Features/Comparison/ScanComparisonView.swift
@@ -1,0 +1,412 @@
+import SwiftUI
+
+struct ScanComparisonRowActions {
+    let reveal: (ScanComparisonRow) -> Void
+    let canReveal: (ScanComparisonRow) -> Bool
+    let showInBrowser: (ScanComparisonRow) -> Void
+    let canShowInBrowser: (ScanComparisonRow) -> Bool
+    let copyPath: (ScanComparisonRow) -> Void
+}
+
+struct ScanComparisonView: View {
+    let comparison: ScanComparison
+    let actions: ScanComparisonRowActions
+    let onClose: () -> Void
+
+    @State private var filter: ScanComparisonRowFilter = .all
+    @State private var searchText = ""
+    @State private var sortOrder = [ScanComparisonRowComparator.defaultOrder]
+    @State private var selection = Set<ScanComparisonRow.ID>()
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+
+            Divider()
+
+            if displayedRows.isEmpty {
+                emptyState
+            } else {
+                comparisonTable
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(nsColor: .windowBackgroundColor))
+        .toolbar {
+            ToolbarItem(placement: .automatic) {
+                Button {
+                    onClose()
+                } label: {
+                    Label("Close Comparison", systemImage: "xmark")
+                }
+                .help("Close Comparison")
+            }
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(alignment: .top, spacing: 16) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Snapshot Comparison")
+                        .font(.title2.weight(.semibold))
+
+                    Text("\(comparison.before.displayName) -> \(comparison.after.displayName)")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .textSelection(.enabled)
+                }
+
+                Spacer(minLength: 16)
+
+                VStack(alignment: .trailing, spacing: 2) {
+                    Text("Delta")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text(signedSize(comparison.summary.allocatedDelta))
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(deltaColor(comparison.summary.allocatedDelta))
+                        .monospacedDigit()
+                }
+            }
+
+            ViewThatFits(in: .horizontal) {
+                HStack(alignment: .top, spacing: 18) {
+                    sourceSummary(title: "Before", snapshot: comparison.before)
+                    Image(systemName: "arrow.right")
+                        .font(.title3.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                        .frame(height: 44)
+                    sourceSummary(title: "After", snapshot: comparison.after)
+                    Spacer(minLength: 10)
+                    metricStrip
+                }
+
+                VStack(alignment: .leading, spacing: 12) {
+                    HStack(alignment: .top, spacing: 18) {
+                        sourceSummary(title: "Before", snapshot: comparison.before)
+                        Image(systemName: "arrow.right")
+                            .font(.title3.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                            .frame(height: 44)
+                        sourceSummary(title: "After", snapshot: comparison.after)
+                    }
+                    metricStrip
+                }
+            }
+
+            HStack(spacing: 12) {
+                Picker("Filter", selection: $filter) {
+                    ForEach(ScanComparisonRowFilter.allCases) { filter in
+                        Text(filter.title).tag(filter)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .frame(maxWidth: 420)
+
+                Spacer()
+
+                TextField("Search", text: $searchText)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(width: 240)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+    }
+
+    private func sourceSummary(title: String, snapshot: ComparedSnapshotSummary) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Text(snapshot.displayName)
+                .font(.subheadline.weight(.semibold))
+                .lineLimit(1)
+                .truncationMode(.middle)
+
+            Text(RadixFormatters.date(snapshot.comparisonDate))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+        .frame(minWidth: 160, idealWidth: 220, maxWidth: 260, alignment: .leading)
+    }
+
+    private var metricStrip: some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: 14) {
+                comparisonMetric("Scanned", signedSize(comparison.summary.allocatedDelta))
+                comparisonMetric("Files", signedCount(comparison.summary.fileCountDelta))
+                comparisonMetric("Folders", signedCount(comparison.summary.directoryCountDelta))
+                comparisonMetric("Warnings", signedCount(comparison.summary.warningCountDelta))
+                comparisonMetric("Changed", comparison.summary.changedCount.formatted())
+            }
+
+            Grid(alignment: .leading, horizontalSpacing: 16, verticalSpacing: 8) {
+                GridRow {
+                    comparisonMetric("Scanned", signedSize(comparison.summary.allocatedDelta))
+                    comparisonMetric("Files", signedCount(comparison.summary.fileCountDelta))
+                    comparisonMetric("Folders", signedCount(comparison.summary.directoryCountDelta))
+                }
+                GridRow {
+                    comparisonMetric("Warnings", signedCount(comparison.summary.warningCountDelta))
+                    comparisonMetric("Changed", comparison.summary.changedCount.formatted())
+                    Color.clear.frame(width: 1, height: 1)
+                }
+            }
+        }
+    }
+
+    private func comparisonMetric(_ title: String, _ value: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.subheadline.weight(.semibold))
+                .lineLimit(1)
+                .monospacedDigit()
+        }
+        .frame(minWidth: 78, alignment: .leading)
+    }
+
+    private var comparisonTable: some View {
+        Table(of: ScanComparisonRow.self, selection: $selection, sortOrder: $sortOrder) {
+            TableColumn("Change", sortUsing: ScanComparisonRowComparator(field: .changeKind)) { row in
+                Label(row.kind.title, systemImage: row.kind.systemImageName)
+                    .foregroundStyle(row.kind.tintColor)
+            }
+            .width(min: 105, ideal: 120)
+
+            TableColumn("Path", sortUsing: ScanComparisonRowComparator(field: .relativePath)) { row in
+                Text(row.relativePath)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .textSelection(.enabled)
+            }
+            .width(min: 260, ideal: 430)
+
+            TableColumn("Before", sortUsing: ScanComparisonRowComparator(field: .beforeAllocatedSize)) { row in
+                Text(sizeText(row.beforeAllocatedSize))
+                    .monospacedDigit()
+            }
+            .width(min: 105, ideal: 120)
+
+            TableColumn("After", sortUsing: ScanComparisonRowComparator(field: .afterAllocatedSize)) { row in
+                Text(sizeText(row.afterAllocatedSize))
+                    .monospacedDigit()
+            }
+            .width(min: 105, ideal: 120)
+
+            TableColumn("Delta", sortUsing: ScanComparisonRowComparator(field: .absoluteAllocatedDelta)) { row in
+                Text(signedSize(row.allocatedDelta))
+                    .foregroundStyle(deltaColor(row.allocatedDelta))
+                    .monospacedDigit()
+            }
+            .width(min: 105, ideal: 120)
+
+            TableColumn("Kind", sortUsing: ScanComparisonRowComparator(field: .itemKind)) { row in
+                Text(row.itemKind)
+            }
+            .width(min: 95, ideal: 115)
+        } rows: {
+            ForEach(displayedRows) { row in
+                TableRow(row)
+            }
+        }
+        .contextMenu(forSelectionType: ScanComparisonRow.ID.self) { ids in
+            rowContextMenu(for: ids)
+        } primaryAction: { ids in
+            guard let row = singleRow(in: ids), actions.canReveal(row) else { return }
+            actions.reveal(row)
+        }
+    }
+
+    @ViewBuilder
+    private func rowContextMenu(for ids: Set<ScanComparisonRow.ID>) -> some View {
+        if let row = singleRow(in: ids) {
+            Button {
+                actions.reveal(row)
+            } label: {
+                Label("Reveal in Finder", systemImage: "folder")
+            }
+            .disabled(!actions.canReveal(row))
+
+            Button {
+                actions.showInBrowser(row)
+            } label: {
+                Label("Show in Browser", systemImage: "sidebar.squares.left")
+            }
+            .disabled(!actions.canShowInBrowser(row))
+
+            Divider()
+
+            Button {
+                actions.copyPath(row)
+            } label: {
+                Label("Copy Path", systemImage: "doc.on.doc")
+            }
+        }
+    }
+
+    private func singleRow(in ids: Set<ScanComparisonRow.ID>) -> ScanComparisonRow? {
+        guard ids.count == 1, let id = ids.first else { return nil }
+        return comparison.rows.first { $0.id == id }
+    }
+
+    private var emptyState: some View {
+        ContentUnavailableView(
+            emptyStateTitle,
+            systemImage: emptyStateSystemImage,
+            description: Text(emptyStateDescription)
+        )
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var emptyStateTitle: String {
+        comparison.rows.isEmpty ? "No Changes" : "No Matching Changes"
+    }
+
+    private var emptyStateSystemImage: String {
+        comparison.rows.isEmpty ? "checkmark.circle" : "magnifyingglass"
+    }
+
+    private var emptyStateDescription: String {
+        comparison.rows.isEmpty
+            ? "Matched paths have same allocated sizes."
+            : "Adjust filter or search."
+    }
+
+    private var displayedRows: [ScanComparisonRow] {
+        let filtered = comparison.rows.filter { row in
+            filter.matches(row) && searchMatches(row)
+        }
+        return sorted(filtered)
+    }
+
+    private func searchMatches(_ row: ScanComparisonRow) -> Bool {
+        let trimmedSearchText = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedSearchText.isEmpty else { return true }
+        let query = SearchNormalizer.normalize(trimmedSearchText)
+        return SearchNormalizer.normalize(row.name).contains(query) ||
+            SearchNormalizer.normalize(row.relativePath).contains(query)
+    }
+
+    private func sorted(_ rows: [ScanComparisonRow]) -> [ScanComparisonRow] {
+        rows.sorted { lhs, rhs in
+            for comparator in sortOrder {
+                switch comparator.compare(lhs, rhs) {
+                case .orderedAscending:
+                    return true
+                case .orderedDescending:
+                    return false
+                case .orderedSame:
+                    continue
+                @unknown default:
+                    continue
+                }
+            }
+            return false
+        }
+    }
+
+    private func sizeText(_ size: Int64?) -> String {
+        guard let size else { return "-" }
+        return RadixFormatters.size(size)
+    }
+
+    private func signedSize(_ size: Int64) -> String {
+        guard size != 0 else { return RadixFormatters.size(0) }
+        let prefix = size > 0 ? "+" : "-"
+        return prefix + RadixFormatters.size(abs(size))
+    }
+
+    private func signedCount(_ count: Int) -> String {
+        guard count != 0 else { return "0" }
+        return count > 0 ? "+\(count.formatted())" : "-\(abs(count).formatted())"
+    }
+
+    private func deltaColor(_ delta: Int64) -> Color {
+        if delta > 0 {
+            return .red
+        }
+        if delta < 0 {
+            return .green
+        }
+        return .secondary
+    }
+}
+
+private enum ScanComparisonRowFilter: String, CaseIterable, Identifiable {
+    case all
+    case added
+    case removed
+    case grew
+    case shrank
+
+    var id: String {
+        rawValue
+    }
+
+    var title: String {
+        switch self {
+        case .all:
+            return "All"
+        case .added:
+            return ScanComparisonChangeKind.added.title
+        case .removed:
+            return ScanComparisonChangeKind.removed.title
+        case .grew:
+            return ScanComparisonChangeKind.grew.title
+        case .shrank:
+            return ScanComparisonChangeKind.shrank.title
+        }
+    }
+
+    func matches(_ row: ScanComparisonRow) -> Bool {
+        switch self {
+        case .all:
+            return true
+        case .added:
+            return row.kind == .added
+        case .removed:
+            return row.kind == .removed
+        case .grew:
+            return row.kind == .grew
+        case .shrank:
+            return row.kind == .shrank
+        }
+    }
+}
+
+private extension ScanComparisonChangeKind {
+    var systemImageName: String {
+        switch self {
+        case .added:
+            return "plus.circle.fill"
+        case .removed:
+            return "minus.circle.fill"
+        case .grew:
+            return "arrow.up.circle.fill"
+        case .shrank:
+            return "arrow.down.circle.fill"
+        }
+    }
+
+    var tintColor: Color {
+        switch self {
+        case .added:
+            return .blue
+        case .removed:
+            return .orange
+        case .grew:
+            return .red
+        case .shrank:
+            return .green
+        }
+    }
+}

--- a/Radix/Features/Comparison/ScanComparisonView.swift
+++ b/Radix/Features/Comparison/ScanComparisonView.swift
@@ -59,13 +59,13 @@ struct ScanComparisonView: View {
         .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity)
         .background(Color(nsColor: .windowBackgroundColor))
         .toolbar {
-            ToolbarItem(placement: .automatic) {
+            ToolbarItem(placement: .navigation) {
                 Button {
                     onClose()
                 } label: {
-                    Label("Close Comparison", systemImage: "xmark")
+                    Label("Back to Scan", systemImage: "chevron.backward")
                 }
-                .help("Close Comparison")
+                .help("Back to Scan")
             }
         }
         .onChange(of: rowQuery) { _, query in
@@ -86,34 +86,23 @@ struct ScanComparisonView: View {
     }
 
     private var header: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            Text("Storage Changes")
-                .font(.title2.weight(.semibold))
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .firstTextBaseline, spacing: 16) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Storage Changes")
+                        .font(.title2.weight(.semibold))
 
-            ViewThatFits(in: .horizontal) {
-                HStack(alignment: .top, spacing: 18) {
-                    sourceSummary(title: "Earlier Scan", snapshot: comparison.before)
-                    Image(systemName: "arrow.right")
-                        .font(.title3.weight(.semibold))
-                        .foregroundStyle(.secondary)
-                        .frame(height: 44)
-                    sourceSummary(title: "Later Scan", snapshot: comparison.after)
-                    Spacer(minLength: 10)
-                    metricStrip
+                    Text(changeHeadline)
+                        .font(.title3.weight(.medium))
+                        .foregroundStyle(deltaColor(comparison.summary.allocatedDelta))
                 }
 
-                VStack(alignment: .leading, spacing: 12) {
-                    HStack(alignment: .top, spacing: 18) {
-                        sourceSummary(title: "Earlier Scan", snapshot: comparison.before)
-                        Image(systemName: "arrow.right")
-                            .font(.title3.weight(.semibold))
-                            .foregroundStyle(.secondary)
-                            .frame(height: 44)
-                        sourceSummary(title: "Later Scan", snapshot: comparison.after)
-                    }
-                    metricStrip
-                }
+                Spacer(minLength: 16)
+
+                metricStrip
             }
+
+            scanTimeline
 
             if comparison.coverage.confidence != .high {
                 coverageBanner
@@ -126,11 +115,14 @@ struct ScanComparisonView: View {
             HStack(spacing: 12) {
                 Picker("Filter", selection: $filter) {
                     ForEach(ScanComparisonRowFilter.allCases) { filter in
-                        Text(filter.title).tag(filter)
+                        Text(filterTitle(filter))
+                            .tag(filter)
+                            .disabled(filter != .all && filterCount(filter) == 0)
                     }
                 }
                 .pickerStyle(.segmented)
-                .frame(maxWidth: 420)
+                .labelsHidden()
+                .frame(maxWidth: 520)
 
                 if let focusedLocationPath {
                     Button {
@@ -145,13 +137,71 @@ struct ScanComparisonView: View {
 
                 Spacer()
 
-                TextField("Search", text: $searchText)
-                    .textFieldStyle(.roundedBorder)
-                    .frame(width: 240)
+                HStack(spacing: 6) {
+                    Image(systemName: "magnifyingglass")
+                        .foregroundStyle(.secondary)
+
+                    TextField("Search names and paths", text: $searchText)
+                        .textFieldStyle(.plain)
+
+                    if !searchText.isEmpty {
+                        Button {
+                            searchText = ""
+                        } label: {
+                            Image(systemName: "xmark.circle.fill")
+                                .foregroundStyle(.secondary)
+                        }
+                        .buttonStyle(.plain)
+                        .help("Clear Search")
+                    }
+                }
+                .padding(.horizontal, 8)
+                .frame(width: 250, height: 28)
+                .background(.quaternary, in: RoundedRectangle(cornerRadius: 6))
+            }
+
+            if let selectedRow {
+                selectionActions(for: selectedRow)
             }
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 14)
+    }
+
+    private var changeHeadline: String {
+        let delta = comparison.summary.allocatedDelta
+        if delta > 0 {
+            return "Storage increased by \(RadixFormatters.size(delta))"
+        }
+        if delta < 0 {
+            return "Storage decreased by \(RadixFormatters.size(-delta))"
+        }
+        return "No net storage change"
+    }
+
+    private var scanTimeline: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "clock.arrow.trianglehead.counterclockwise.rotate.90")
+                .foregroundStyle(.secondary)
+
+            sourceSummary(title: "Earlier", snapshot: comparison.before)
+
+            Image(systemName: "arrow.right")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.tertiary)
+
+            sourceSummary(title: "Later", snapshot: comparison.after)
+
+            Spacer(minLength: 8)
+
+            Text("\(signedSize(comparison.summary.grossIncreasedAllocatedSize)) added or grew  •  \(RadixFormatters.size(comparison.summary.grossReclaimedAllocatedSize)) reclaimed")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .monospacedDigit()
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 8))
     }
 
     private var coverageBanner: some View {
@@ -228,17 +278,8 @@ struct ScanComparisonView: View {
 
     private var locationOverview: some View {
         VStack(alignment: .leading, spacing: 8) {
-            HStack {
-                Text(locationOverviewTitle)
-                    .font(.subheadline.weight(.semibold))
-
-                Spacer()
-
-                Text("\(signedSize(comparison.summary.grossIncreasedAllocatedSize)) added or grew • \(RadixFormatters.size(comparison.summary.grossReclaimedAllocatedSize)) reclaimed")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .monospacedDigit()
-            }
+            Text(locationOverviewTitle)
+                .font(.subheadline.weight(.semibold))
 
             ForEach(highlightedLocations) { location in
                 locationRow(location)
@@ -249,82 +290,69 @@ struct ScanComparisonView: View {
     }
 
     private func locationRow(_ location: ScanComparisonLocationChange) -> some View {
-        HStack(spacing: 10) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(location.relativePath)
-                    .font(.subheadline.weight(.medium))
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-
-                Text("\(location.affectedCount.formatted()) affected item\(location.affectedCount == 1 ? "" : "s")")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-
-            Spacer(minLength: 8)
-
-            Text(signedSize(location.allocatedDelta))
-                .font(.subheadline.weight(.semibold))
-                .foregroundStyle(deltaColor(location.allocatedDelta))
-                .monospacedDigit()
-
-            Button("Show Changes") {
+        Button {
+            withAnimation(.snappy(duration: 0.2)) {
                 focusedLocationPath = location.relativePath
             }
-            .controlSize(.small)
+        } label: {
+            HStack(spacing: 10) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(location.relativePath)
+                        .font(.subheadline.weight(.medium))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+
+                    Text("\(location.affectedCount.formatted()) affected item\(location.affectedCount == 1 ? "" : "s")")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer(minLength: 8)
+
+                Text(signedSize(location.allocatedDelta))
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(deltaColor(location.allocatedDelta))
+                    .monospacedDigit()
+
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.tertiary)
+            }
+            .contentShape(Rectangle())
         }
+        .buttonStyle(.plain)
         .padding(.vertical, 2)
+        .help("Show changes in \(location.relativePath)")
     }
 
     private func sourceSummary(title: String, snapshot: ComparedSnapshotSummary) -> some View {
-        VStack(alignment: .leading, spacing: 3) {
+        HStack(spacing: 5) {
             Text(title)
-                .font(.caption)
                 .foregroundStyle(.secondary)
 
             Text(snapshot.displayName)
-                .font(.subheadline.weight(.semibold))
+                .fontWeight(.medium)
                 .lineLimit(1)
                 .truncationMode(.middle)
 
-            Text(RadixFormatters.date(snapshot.comparisonDate))
-                .font(.caption)
+            Text("·")
+                .foregroundStyle(.tertiary)
+
+            Text(comparisonDate(snapshot.comparisonDate))
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
+                .monospacedDigit()
         }
-        .frame(minWidth: 160, idealWidth: 220, maxWidth: 260, alignment: .leading)
+        .font(.caption)
     }
 
     private var metricStrip: some View {
-        ViewThatFits(in: .horizontal) {
-            HStack(spacing: 14) {
-                comparisonMetric("Tracked", signedSize(comparison.summary.allocatedDelta))
-                comparisonMetric("Files", signedCount(comparison.summary.fileCountDelta))
-                comparisonMetric("Folders", signedCount(comparison.summary.directoryCountDelta))
-                comparisonMetric("Warnings", signedCount(comparison.summary.warningCountDelta))
-                comparisonMetric(
-                    "Changed",
-                    comparison.summary.changedCount.formatted()
-                )
+        HStack(spacing: 14) {
+            comparisonMetric("Files", signedCount(comparison.summary.fileCountDelta))
+            comparisonMetric("Folders", signedCount(comparison.summary.directoryCountDelta))
+            comparisonMetric("Modified", comparison.summary.changedCount.formatted())
                 .help("Items present in both scans whose tracked size changed")
-            }
-
-            Grid(alignment: .leading, horizontalSpacing: 16, verticalSpacing: 8) {
-                GridRow {
-                    comparisonMetric("Tracked", signedSize(comparison.summary.allocatedDelta))
-                    comparisonMetric("Files", signedCount(comparison.summary.fileCountDelta))
-                    comparisonMetric("Folders", signedCount(comparison.summary.directoryCountDelta))
-                }
-                GridRow {
-                    comparisonMetric("Warnings", signedCount(comparison.summary.warningCountDelta))
-                    comparisonMetric(
-                        "Changed",
-                        comparison.summary.changedCount.formatted()
-                    )
-                    .help("Items present in both scans whose tracked size changed")
-                    Color.clear.frame(width: 1, height: 1)
-                }
-            }
+            comparisonMetric("Warnings", signedCount(comparison.summary.warningCountDelta))
         }
     }
 
@@ -338,7 +366,7 @@ struct ScanComparisonView: View {
                 .lineLimit(1)
                 .monospacedDigit()
         }
-        .frame(minWidth: 78, alignment: .leading)
+        .frame(minWidth: 66, alignment: .leading)
     }
 
     private var comparisonTable: some View {
@@ -349,13 +377,26 @@ struct ScanComparisonView: View {
             }
             .width(min: 105, ideal: 120)
 
-            TableColumn("Path", sortUsing: ScanComparisonRowComparator(field: .relativePath)) { row in
-                Text(pathText(for: row))
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-                    .textSelection(.enabled)
+            TableColumn("Item", sortUsing: ScanComparisonRowComparator(field: .relativePath)) { row in
+                HStack(spacing: 8) {
+                    Image(systemName: itemSymbol(for: row))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 16)
+
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text(row.name)
+                            .lineLimit(1)
+
+                        Text(itemLocation(for: row))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                            .textSelection(.enabled)
+                    }
+                }
             }
-            .width(min: 260, ideal: 430)
+            .width(min: 280, ideal: 500)
 
             TableColumn("Earlier", sortUsing: ScanComparisonRowComparator(field: .beforeAllocatedSize)) { row in
                 Text(sizeText(row.beforeAllocatedSize))
@@ -375,11 +416,6 @@ struct ScanComparisonView: View {
                     .monospacedDigit()
             }
             .width(min: 105, ideal: 120)
-
-            TableColumn("Kind", sortUsing: ScanComparisonRowComparator(field: .itemKind)) { row in
-                Text(row.itemKind)
-            }
-            .width(min: 95, ideal: 115)
         } rows: {
             ForEach(displayedRows) { row in
                 TableRow(row)
@@ -391,6 +427,48 @@ struct ScanComparisonView: View {
             guard let row = singleRow(in: ids), actions.canReveal(row) else { return }
             actions.reveal(row)
         }
+        .alternatingRowBackgrounds(.disabled)
+    }
+
+    private var selectedRow: ScanComparisonRow? {
+        singleRow(in: selection)
+    }
+
+    private func selectionActions(for row: ScanComparisonRow) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: itemSymbol(for: row))
+                .foregroundStyle(.secondary)
+
+            Text(row.name)
+                .font(.subheadline.weight(.medium))
+                .lineLimit(1)
+
+            Spacer()
+
+            Button {
+                actions.showInBrowser(row)
+            } label: {
+                Label("Show in Browser", systemImage: "sidebar.squares.left")
+            }
+            .disabled(!actions.canShowInBrowser(row))
+
+            Button {
+                actions.reveal(row)
+            } label: {
+                Label("Reveal in Finder", systemImage: "folder")
+            }
+            .disabled(!actions.canReveal(row))
+
+            Button {
+                actions.copyPath(row)
+            } label: {
+                Label("Copy Path", systemImage: "doc.on.doc")
+            }
+        }
+        .controlSize(.small)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+        .background(Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 8))
     }
 
     @ViewBuilder
@@ -468,11 +546,46 @@ struct ScanComparisonView: View {
         return RadixFormatters.size(size)
     }
 
-    private func pathText(for row: ScanComparisonRow) -> String {
-        guard let movedFromRelativePath = row.movedFromRelativePath else {
-            return row.relativePath
+    private func itemLocation(for row: ScanComparisonRow) -> String {
+        if let movedFromRelativePath = row.movedFromRelativePath {
+            return "\(movedFromRelativePath) → \(row.relativePath)"
         }
-        return "\(movedFromRelativePath) → \(row.relativePath)"
+
+        let components = row.relativePath.split(separator: "/")
+        let parent = components.dropLast().joined(separator: "/")
+        return parent.isEmpty ? row.itemKind : parent
+    }
+
+    private func itemSymbol(for row: ScanComparisonRow) -> String {
+        if row.itemKind == "Package" {
+            return "shippingbox.fill"
+        }
+        return row.isDirectory ? "folder.fill" : "doc.fill"
+    }
+
+    private func comparisonDate(_ date: Date) -> String {
+        date.formatted(date: .abbreviated, time: .standard)
+    }
+
+    private func filterTitle(_ filter: ScanComparisonRowFilter) -> String {
+        "\(filter.title) \(filterCount(filter).formatted())"
+    }
+
+    private func filterCount(_ filter: ScanComparisonRowFilter) -> Int {
+        switch filter {
+        case .all:
+            return comparison.rows.count
+        case .added:
+            return comparison.summary.addedCount
+        case .removed:
+            return comparison.summary.removedCount
+        case .grew:
+            return comparison.summary.grewCount
+        case .shrank:
+            return comparison.summary.shrankCount
+        case .moved:
+            return comparison.summary.movedCount
+        }
     }
 
     private func signedSize(_ size: Int64) -> String {

--- a/Radix/Features/Comparison/ScanComparisonView.swift
+++ b/Radix/Features/Comparison/ScanComparisonView.swift
@@ -8,13 +8,6 @@ struct ScanComparisonRowActions {
     let copyPath: (ScanComparisonRow) -> Void
 }
 
-struct ScanComparisonLocationActions {
-    let reveal: (ScanComparisonLocationChange) -> Void
-    let canReveal: (ScanComparisonLocationChange) -> Bool
-    let showInBrowser: (ScanComparisonLocationChange) -> Void
-    let canShowInBrowser: (ScanComparisonLocationChange) -> Bool
-}
-
 struct ScanComparisonView: View {
     private static let initialSortOrder = [
         ScanComparisonRowComparator.defaultOrder
@@ -22,7 +15,6 @@ struct ScanComparisonView: View {
 
     let comparison: ScanComparison
     let actions: ScanComparisonRowActions
-    let locationActions: ScanComparisonLocationActions
     let onClose: () -> Void
 
     @State private var filter: ScanComparisonRowFilter = .all
@@ -35,12 +27,10 @@ struct ScanComparisonView: View {
     init(
         comparison: ScanComparison,
         actions: ScanComparisonRowActions,
-        locationActions: ScanComparisonLocationActions,
         onClose: @escaping () -> Void
     ) {
         self.comparison = comparison
         self.actions = actions
-        self.locationActions = locationActions
         self.onClose = onClose
 
         let sortOrder = Self.initialSortOrder
@@ -97,31 +87,8 @@ struct ScanComparisonView: View {
 
     private var header: some View {
         VStack(alignment: .leading, spacing: 14) {
-            HStack(alignment: .top, spacing: 16) {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Storage Changes")
-                        .font(.title2.weight(.semibold))
-
-                    Text(storageChangeHeadline)
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                        .textSelection(.enabled)
-                }
-
-                Spacer(minLength: 16)
-
-                VStack(alignment: .trailing, spacing: 2) {
-                    Text("Tracked Storage")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                    Text(signedSize(comparison.summary.allocatedDelta))
-                        .font(.subheadline.weight(.semibold))
-                        .foregroundStyle(deltaColor(comparison.summary.allocatedDelta))
-                        .monospacedDigit()
-                }
-            }
+            Text("Storage Changes")
+                .font(.title2.weight(.semibold))
 
             ViewThatFits(in: .horizontal) {
                 HStack(alignment: .top, spacing: 18) {
@@ -148,7 +115,9 @@ struct ScanComparisonView: View {
                 }
             }
 
-            coverageBanner
+            if comparison.coverage.confidence != .high {
+                coverageBanner
+            }
 
             if !highlightedLocations.isEmpty {
                 locationOverview
@@ -183,17 +152,6 @@ struct ScanComparisonView: View {
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 14)
-    }
-
-    private var storageChangeHeadline: String {
-        let delta = comparison.summary.allocatedDelta
-        if delta > 0 {
-            return "Tracked storage increased by \(RadixFormatters.size(delta))."
-        }
-        if delta < 0 {
-            return "Tracked storage decreased by \(RadixFormatters.size(-delta))."
-        }
-        return "Tracked storage did not change."
     }
 
     private var coverageBanner: some View {
@@ -298,7 +256,7 @@ struct ScanComparisonView: View {
                     .lineLimit(1)
                     .truncationMode(.middle)
 
-                Text("\(location.changedCount.formatted()) change\(location.changedCount == 1 ? "" : "s")")
+                Text("\(location.affectedCount.formatted()) affected item\(location.affectedCount == 1 ? "" : "s")")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -314,26 +272,6 @@ struct ScanComparisonView: View {
                 focusedLocationPath = location.relativePath
             }
             .controlSize(.small)
-
-            Button {
-                locationActions.showInBrowser(location)
-            } label: {
-                Label("Show in Browser", systemImage: "sidebar.squares.left")
-            }
-            .labelStyle(.iconOnly)
-            .controlSize(.small)
-            .disabled(!locationActions.canShowInBrowser(location))
-            .help("Show in Browser")
-
-            Button {
-                locationActions.reveal(location)
-            } label: {
-                Label("Reveal Current Location in Finder", systemImage: "folder")
-            }
-            .labelStyle(.iconOnly)
-            .controlSize(.small)
-            .disabled(!locationActions.canReveal(location))
-            .help("Reveal Current Location in Finder")
         }
         .padding(.vertical, 2)
     }
@@ -364,7 +302,11 @@ struct ScanComparisonView: View {
                 comparisonMetric("Files", signedCount(comparison.summary.fileCountDelta))
                 comparisonMetric("Folders", signedCount(comparison.summary.directoryCountDelta))
                 comparisonMetric("Warnings", signedCount(comparison.summary.warningCountDelta))
-                comparisonMetric("Changed", comparison.summary.changedCount.formatted())
+                comparisonMetric(
+                    "Changed",
+                    comparison.summary.changedCount.formatted()
+                )
+                .help("Items present in both scans whose tracked size changed")
             }
 
             Grid(alignment: .leading, horizontalSpacing: 16, verticalSpacing: 8) {
@@ -375,7 +317,11 @@ struct ScanComparisonView: View {
                 }
                 GridRow {
                     comparisonMetric("Warnings", signedCount(comparison.summary.warningCountDelta))
-                    comparisonMetric("Changed", comparison.summary.changedCount.formatted())
+                    comparisonMetric(
+                        "Changed",
+                        comparison.summary.changedCount.formatted()
+                    )
+                    .help("Items present in both scans whose tracked size changed")
                     Color.clear.frame(width: 1, height: 1)
                 }
             }

--- a/Radix/Features/Comparison/ScanComparisonView.swift
+++ b/Radix/Features/Comparison/ScanComparisonView.swift
@@ -23,6 +23,7 @@ struct ScanComparisonView: View {
     @State private var sortOrder: [ScanComparisonRowComparator]
     @State private var selection = Set<ScanComparisonRow.ID>()
     @State private var displayedRows: [ScanComparisonRow]
+    @State private var isLocationOverviewExpanded = true
 
     init(
         comparison: ScanComparison,
@@ -278,11 +279,29 @@ struct ScanComparisonView: View {
 
     private var locationOverview: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text(locationOverviewTitle)
-                .font(.subheadline.weight(.semibold))
+            Button {
+                isLocationOverviewExpanded.toggle()
+            } label: {
+                HStack(spacing: 8) {
+                    Text(locationOverviewTitle)
+                        .font(.subheadline.weight(.semibold))
 
-            ForEach(highlightedLocations) { location in
-                locationRow(location)
+                    Spacer()
+
+                    Image(systemName: isLocationOverviewExpanded ? "chevron.down" : "chevron.right")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityValue(isLocationOverviewExpanded ? "Expanded" : "Collapsed")
+            .help(isLocationOverviewExpanded ? "Collapse \(locationOverviewTitle)" : "Expand \(locationOverviewTitle)")
+
+            if isLocationOverviewExpanded {
+                ForEach(highlightedLocations) { location in
+                    locationRow(location)
+                }
             }
         }
         .padding(10)

--- a/Radix/Features/Comparison/ScanComparisonView.swift
+++ b/Radix/Features/Comparison/ScanComparisonView.swift
@@ -54,18 +54,19 @@ struct ScanComparisonView: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            header
+        GeometryReader { _ in
+            VStack(spacing: 0) {
+                header
 
-            Divider()
+                Divider()
 
-            if displayedRows.isEmpty {
-                emptyState
-            } else {
-                comparisonTable
+                comparisonContent
+                    .frame(minHeight: 0, maxHeight: .infinity)
+                    .clipped()
             }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity)
         .background(Color(nsColor: .windowBackgroundColor))
         .toolbar {
             ToolbarItem(placement: .automatic) {
@@ -82,6 +83,15 @@ struct ScanComparisonView: View {
         }
         .onChange(of: comparison.id) { _, _ in
             refreshDisplayedRows(using: rowQuery)
+        }
+    }
+
+    @ViewBuilder
+    private var comparisonContent: some View {
+        if displayedRows.isEmpty {
+            emptyState
+        } else {
+            comparisonTable
         }
     }
 

--- a/Radix/Features/Workspace/WorkspaceView.swift
+++ b/Radix/Features/Workspace/WorkspaceView.swift
@@ -18,6 +18,8 @@ struct WorkspaceActions {
     let startScan: (ScanTarget) -> Void
     let stopScan: () -> Void
     let rescan: () -> Void
+    let compareWithPreviousScan: () -> Void
+    let canCompareWithPreviousScan: () -> Bool
     let handleDroppedURLs: ([URL]) -> Bool
     let selectNodeImmediately: (String?) -> Void
     let selectNode: (String?) -> Void
@@ -141,6 +143,16 @@ struct WorkspaceView: View {
                     }
                     .disabled(!scanState.canRescan)
                     .help("Rescan")
+
+                    if scanState.snapshot?.isComplete == true {
+                        Button {
+                            actions.compareWithPreviousScan()
+                        } label: {
+                            Label("View Storage Changes", systemImage: "chart.bar.xaxis")
+                        }
+                        .disabled(!actions.canCompareWithPreviousScan())
+                        .help("Compare with the previous compatible scan")
+                    }
                 }
             }
             ToolbarItem(placement: .automatic) { Spacer() }

--- a/Radix/Models/FileNodeRecord.swift
+++ b/Radix/Models/FileNodeRecord.swift
@@ -26,7 +26,7 @@ nonisolated struct FileNodeRecord: Equatable, Identifiable, Sendable {
     let isSynthetic: Bool
     let isAutoSummarized: Bool
 
-    nonisolated init(
+    init(
         id: String,
         url: URL,
         name: String,
@@ -64,7 +64,7 @@ nonisolated struct FileNodeRecord: Equatable, Identifiable, Sendable {
         self.isAutoSummarized = isAutoSummarized
     }
 
-    nonisolated var itemKind: String {
+    var itemKind: String {
         if isSynthetic {
             return "System Data"
         }
@@ -80,11 +80,11 @@ nonisolated struct FileNodeRecord: Equatable, Identifiable, Sendable {
         return isDirectory ? "Folder" : "File"
     }
 
-    nonisolated var supportsFileActions: Bool {
+    var supportsFileActions: Bool {
         !isSynthetic
     }
 
-    nonisolated static func directory(
+    static func directory(
         id: String,
         url: URL,
         name: String,

--- a/Radix/Models/FileNodeRecord.swift
+++ b/Radix/Models/FileNodeRecord.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct FileNodeRecord: Equatable, Identifiable, Sendable {
+nonisolated struct FileNodeRecord: Equatable, Identifiable, Sendable {
     let id: String
     let url: URL
     let name: String

--- a/Radix/Services/AppSystemActions.swift
+++ b/Radix/Services/AppSystemActions.swift
@@ -85,6 +85,7 @@ struct AppSystemActions {
     var presentOpenPanel: () -> ScanTarget?
     var presentExportScanPanel: (String) async -> URL?
     var presentImportScanPanel: () -> URL?
+    var presentComparisonSnapshotPanel: () -> URL?
     var fileExists: (URL) -> Bool
     var verifyTrashIdentity: (FileNodeRecord) -> TrashIdentityVerificationResult
     var asyncVerifyTrashIdentity: (@Sendable (FileNodeRecord) async -> TrashIdentityVerificationResult)?
@@ -142,6 +143,9 @@ struct AppSystemActions {
         },
         presentImportScanPanel: {
             SystemIntegration.presentImportScanPanel()
+        },
+        presentComparisonSnapshotPanel: {
+            SystemIntegration.presentComparisonSnapshotPanel()
         },
         fileExists: { url in
             FileManager.default.fileExists(atPath: url.path)
@@ -202,6 +206,7 @@ struct AppSystemActions {
         presentOpenPanel: { nil },
         presentExportScanPanel: { _ in nil },
         presentImportScanPanel: { nil },
+        presentComparisonSnapshotPanel: { nil },
         fileExists: { _ in false },
         verifyTrashIdentity: { _ in .matches },
         asyncVerifyTrashIdentity: nil,

--- a/Radix/Services/AppSystemActions.swift
+++ b/Radix/Services/AppSystemActions.swift
@@ -85,7 +85,7 @@ struct AppSystemActions {
     var presentOpenPanel: () -> ScanTarget?
     var presentExportScanPanel: (String) async -> URL?
     var presentImportScanPanel: () -> URL?
-    var presentComparisonSnapshotPanel: () -> URL?
+    var presentComparisonSnapshotPanel: () async -> URL?
     var fileExists: (URL) -> Bool
     var verifyTrashIdentity: (FileNodeRecord) -> TrashIdentityVerificationResult
     var asyncVerifyTrashIdentity: (@Sendable (FileNodeRecord) async -> TrashIdentityVerificationResult)?
@@ -145,7 +145,7 @@ struct AppSystemActions {
             SystemIntegration.presentImportScanPanel()
         },
         presentComparisonSnapshotPanel: {
-            SystemIntegration.presentComparisonSnapshotPanel()
+            await SystemIntegration.presentComparisonSnapshotPanel()
         },
         fileExists: { url in
             FileManager.default.fileExists(atPath: url.path)

--- a/Radix/Services/AtomicDirectoryParallelSummary.swift
+++ b/Radix/Services/AtomicDirectoryParallelSummary.swift
@@ -81,7 +81,6 @@ nonisolated private final class AtomicSummaryAccumulator: @unchecked Sendable {
     private var isAccessible = true
     private var warnings: [ScanWarning] = []
     private var hardLinkClaims: [HardLinkClaim] = []
-    private var visitedItemCount = 0
 
     func updateAccessibility(_ readable: Bool) {
         lock.lock()
@@ -104,7 +103,6 @@ nonisolated private final class AtomicSummaryAccumulator: @unchecked Sendable {
         isAccessible = isAccessible && partial.isAccessible
         warnings.append(contentsOf: partial.warnings)
         hardLinkClaims.append(contentsOf: partial.hardLinkClaims)
-        visitedItemCount += partial.visitedItemCount
         lock.unlock()
     }
 
@@ -129,12 +127,6 @@ nonisolated private struct AtomicSummaryPartial: Sendable {
     var isAccessible = true
     var warnings: [ScanWarning] = []
     var hardLinkClaims: [HardLinkClaim] = []
-    var visitedItemCount = 0
-
-    mutating func recordVisitedItem() {
-        visitedItemCount += 1
-    }
-
     mutating func updateAccessibility(_ readable: Bool) {
         isAccessible = isAccessible && readable
     }
@@ -305,7 +297,6 @@ extension AtomicDirectorySummarizer {
         while let nextObject = enumerator.nextObject() {
             try Task.checkCancellation()
             guard let childURL = nextObject as? URL else { continue }
-            partial.recordVisitedItem()
             workerVisitedItemCount += 1
             if workerVisitedItemCount == 1 || workerVisitedItemCount.isMultiple(of: 64) {
                 progressReporter.emit(currentURL: childURL)

--- a/Radix/Services/AtomicDirectoryParallelSummary.swift
+++ b/Radix/Services/AtomicDirectoryParallelSummary.swift
@@ -83,14 +83,6 @@ nonisolated private final class AtomicSummaryAccumulator: @unchecked Sendable {
     private var hardLinkClaims: [HardLinkClaim] = []
     private var visitedItemCount = 0
 
-    func recordVisitedItem() -> Int {
-        lock.lock()
-        visitedItemCount += 1
-        let count = visitedItemCount
-        lock.unlock()
-        return count
-    }
-
     func updateAccessibility(_ readable: Bool) {
         lock.lock()
         isAccessible = isAccessible && readable
@@ -104,16 +96,15 @@ nonisolated private final class AtomicSummaryAccumulator: @unchecked Sendable {
         lock.unlock()
     }
 
-    func accumulateFile(_ metadata: NodeMetadata, url: URL, ownerNodeID: String) {
+    func merge(_ partial: AtomicSummaryPartial) {
         lock.lock()
-        allocatedSize += metadata.allocatedSize
-        logicalSize += metadata.logicalSize
-        if !metadata.isSymbolicLink {
-            descendantFileCount += 1
-        }
-        if let claim = HardLinkDeduplicator.claim(for: metadata, ownerNodeID: ownerNodeID, path: url.path) {
-            hardLinkClaims.append(claim)
-        }
+        allocatedSize += partial.allocatedSize
+        logicalSize += partial.logicalSize
+        descendantFileCount += partial.descendantFileCount
+        isAccessible = isAccessible && partial.isAccessible
+        warnings.append(contentsOf: partial.warnings)
+        hardLinkClaims.append(contentsOf: partial.hardLinkClaims)
+        visitedItemCount += partial.visitedItemCount
         lock.unlock()
     }
 
@@ -128,6 +119,41 @@ nonisolated private final class AtomicSummaryAccumulator: @unchecked Sendable {
             warnings: warnings,
             hardLinkClaims: hardLinkClaims
         )
+    }
+}
+
+nonisolated private struct AtomicSummaryPartial: Sendable {
+    var allocatedSize: Int64 = 0
+    var logicalSize: Int64 = 0
+    var descendantFileCount = 0
+    var isAccessible = true
+    var warnings: [ScanWarning] = []
+    var hardLinkClaims: [HardLinkClaim] = []
+    var visitedItemCount = 0
+
+    mutating func recordVisitedItem() {
+        visitedItemCount += 1
+    }
+
+    mutating func updateAccessibility(_ readable: Bool) {
+        isAccessible = isAccessible && readable
+    }
+
+    mutating func recordWarning(for url: URL, error: Error) {
+        isAccessible = false
+        warnings.append(ScanWarningFactory.makeWarning(for: url, error: error))
+    }
+
+    mutating func accumulateFile(_ metadata: NodeMetadata, url: URL, ownerNodeID: String) {
+        allocatedSize += metadata.allocatedSize
+        logicalSize += metadata.logicalSize
+        if !metadata.isSymbolicLink {
+            descendantFileCount += 1
+        }
+        if metadata.linkCount > 1,
+           let claim = HardLinkDeduplicator.claim(for: metadata, ownerNodeID: ownerNodeID, path: url.path) {
+            hardLinkClaims.append(claim)
+        }
     }
 }
 
@@ -200,6 +226,7 @@ extension AtomicDirectorySummarizer {
         try await withThrowingTaskGroup(of: Void.self) { group in
             for _ in 0..<workerCount {
                 group.addTask {
+                    var workerVisitedItemCount = 0
                     while true {
                         try Task.checkCancellation()
                         guard let item = try queue.take() else { return }
@@ -212,7 +239,8 @@ extension AtomicDirectorySummarizer {
                                 accumulator: accumulator,
                                 queue: queue,
                                 metadataLoader: metadataLoader,
-                                progressReporter: progressReporter
+                                progressReporter: progressReporter,
+                                workerVisitedItemCount: &workerVisitedItemCount
                             )
                             queue.finishCurrentItem()
                         } catch {
@@ -243,7 +271,8 @@ extension AtomicDirectorySummarizer {
         accumulator: AtomicSummaryAccumulator,
         queue: AtomicSummaryWorkQueue,
         metadataLoader: ScanMetadataLoader,
-        progressReporter: AtomicSummaryProgressReporter
+        progressReporter: AtomicSummaryProgressReporter,
+        workerVisitedItemCount: inout Int
     ) throws {
         try Task.checkCancellation()
 
@@ -252,37 +281,33 @@ extension AtomicDirectorySummarizer {
             options.insert(.skipsHiddenFiles)
         }
 
-        let childURLs: [URL]
-        do {
-            let enumerationResult = try ScanEngine.enumeratedDirectoryContents(
-                url: item.url,
-                keys: ScanMetadataLoader.atomicSummaryResourceKeys,
-                options: options,
-                cancellationCheck: { try Task.checkCancellation() },
-                makeEnumerator: { url, keys, options in
-                    FileManager.default.enumerator(
-                        at: url,
-                        includingPropertiesForKeys: keys,
-                        options: options,
-                        errorHandler: { childURL, error in
-                            accumulator.recordWarning(for: childURL, error: error)
-                            return true
-                        }
-                    )
-                }
+        guard let enumerator = FileManager.default.enumerator(
+            at: item.url,
+            includingPropertiesForKeys: ScanMetadataLoader.atomicSummaryResourceKeys,
+            options: options,
+            errorHandler: { childURL, error in
+                accumulator.recordWarning(for: childURL, error: error)
+                return true
+            }
+        ) else {
+            accumulator.recordWarning(
+                for: item.url,
+                error: NSError(
+                    domain: NSCocoaErrorDomain,
+                    code: NSFileReadUnknownError,
+                    userInfo: [NSURLErrorKey: item.url]
+                )
             )
-            childURLs = enumerationResult.urls
-        } catch is CancellationError {
-            throw CancellationError()
-        } catch {
-            accumulator.recordWarning(for: item.url, error: error)
             return
         }
 
-        for childURL in childURLs {
+        var partial = AtomicSummaryPartial()
+        while let nextObject = enumerator.nextObject() {
             try Task.checkCancellation()
-            let visitedItemCount = accumulator.recordVisitedItem()
-            if visitedItemCount == 1 || visitedItemCount.isMultiple(of: 64) {
+            guard let childURL = nextObject as? URL else { continue }
+            partial.recordVisitedItem()
+            workerVisitedItemCount += 1
+            if workerVisitedItemCount == 1 || workerVisitedItemCount.isMultiple(of: 64) {
                 progressReporter.emit(currentURL: childURL)
             }
 
@@ -294,9 +319,9 @@ extension AtomicDirectorySummarizer {
             let childMetadata: NodeMetadata
             do {
                 let values = try childURL.resourceValues(forKeys: ScanMetadataLoader.atomicSummaryResourceKeySet)
-                childMetadata = metadataLoader.metadata(for: childURL, prefetchedResourceValues: values)
+                childMetadata = metadataLoader.atomicSummaryMetadata(for: childURL, prefetchedResourceValues: values)
             } catch {
-                accumulator.recordWarning(for: childURL, error: error)
+                partial.recordWarning(for: childURL, error: error)
                 continue
             }
 
@@ -304,10 +329,10 @@ extension AtomicDirectorySummarizer {
                 continue
             }
 
-            accumulator.updateAccessibility(childMetadata.isReadable)
+            partial.updateAccessibility(childMetadata.isReadable)
 
             guard childMetadata.isDirectory else {
-                accumulator.accumulateFile(childMetadata, url: childURL, ownerNodeID: item.ownerNodeID)
+                partial.accumulateFile(childMetadata, url: childURL, ownerNodeID: item.ownerNodeID)
                 continue
             }
 
@@ -326,5 +351,6 @@ extension AtomicDirectorySummarizer {
                 )
             )
         }
+        accumulator.merge(partial)
     }
 }

--- a/Radix/Services/AtomicDirectorySummaryWalker.swift
+++ b/Radix/Services/AtomicDirectorySummaryWalker.swift
@@ -318,7 +318,8 @@ extension AtomicDirectorySummarizer {
             state.descendantFileCount += 1
         }
 
-        if let claim = HardLinkDeduplicator.claim(for: metadata, ownerNodeID: state.ownerNodeID, path: url.path) {
+        if metadata.linkCount > 1,
+           let claim = HardLinkDeduplicator.claim(for: metadata, ownerNodeID: state.ownerNodeID, path: url.path) {
             state.hardLinkClaims.append(claim)
         }
     }

--- a/Radix/Services/ScanArchiveNodeIO.swift
+++ b/Radix/Services/ScanArchiveNodeIO.swift
@@ -6,7 +6,7 @@
 import CryptoKit
 import Foundation
 
-private enum ScanArchiveNodeIOConstants {
+private nonisolated enum ScanArchiveNodeIOConstants {
     static let readChunkSize = 1024 * 1024
     static let maxNodeLineByteCount = 1024 * 1024
     static let newlineData = Data([0x0A])

--- a/Radix/Services/ScanArchiveProgressReporting.swift
+++ b/Radix/Services/ScanArchiveProgressReporting.swift
@@ -3,7 +3,7 @@
 //  Radix
 //
 
-enum ScanArchiveProgressReporting {
+nonisolated enum ScanArchiveProgressReporting {
     private static let progressReportInterval = 512
 
     nonisolated static func shouldReportProgress(_ completedUnitCount: Int) -> Bool {

--- a/Radix/Services/ScanArchiveService.swift
+++ b/Radix/Services/ScanArchiveService.swift
@@ -133,6 +133,7 @@ nonisolated struct ScanArchivePreview: Identifiable, Sendable {
     let directoryCount: Int
     let accessibleItemCount: Int
     let inaccessibleItemCount: Int
+    let scanOptions: ScanOptions?
 
     var id: URL {
         archiveURL
@@ -160,6 +161,7 @@ nonisolated struct ScanArchivePreview: Identifiable, Sendable {
         self.directoryCount = stats.directoryCount
         self.accessibleItemCount = stats.accessibleItemCount
         self.inaccessibleItemCount = stats.inaccessibleItemCount
+        self.scanOptions = manifest.snapshot.scanOptions
     }
 }
 

--- a/Radix/Services/ScanArchiveTopologyValidator.swift
+++ b/Radix/Services/ScanArchiveTopologyValidator.swift
@@ -3,6 +3,8 @@
 //  Radix
 //
 
+import Foundation
+
 extension ScanArchiveService {
     func validateTopology(
         _ topology: ScanArchiveResolvedTopology,

--- a/Radix/Services/ScanComparisonService.swift
+++ b/Radix/Services/ScanComparisonService.swift
@@ -239,6 +239,8 @@ nonisolated struct ScanComparisonLocationChange: Identifiable, Equatable, Sendab
     let relativePath: String
     let name: String
     let allocatedDelta: Int64
+    let increasedAllocatedSize: Int64
+    let reclaimedAllocatedSize: Int64
     let addedCount: Int
     let removedCount: Int
     let grewCount: Int
@@ -260,9 +262,431 @@ nonisolated struct ScanComparisonLocationChange: Identifiable, Equatable, Sendab
         abs(allocatedDelta)
     }
 
+    var grossChangedAllocatedSize: Int64 {
+        increasedAllocatedSize + reclaimedAllocatedSize
+    }
+
     /// Prefer the current node so an overview can navigate to the location in the active scan.
     var fileURL: URL? {
         (afterNode ?? beforeNode)?.url
+    }
+}
+
+/// A storage-effect facet for comparison evidence.
+///
+/// This is intentionally independent of `ScanComparisonChangeKind`: a moved file can also
+/// consume or reclaim space, so movement and byte impact aren't mutually exclusive concepts.
+nonisolated enum ScanComparisonImpactFilter: String, CaseIterable, Identifiable, Sendable {
+    case takingSpace
+    case freeingSpace
+    case moved
+    case allActivity
+
+    var id: String { rawValue }
+
+    func includes(_ row: ScanComparisonRow) -> Bool {
+        switch self {
+        case .takingSpace:
+            return row.allocatedDelta > 0
+        case .freeingSpace:
+            return row.allocatedDelta < 0
+        case .moved:
+            return row.movedFromRelativePath != nil
+        case .allActivity:
+            return true
+        }
+    }
+}
+
+/// Inclusive change totals for one path in the comparison hierarchy.
+///
+/// Every final, non-overlapping evidence row contributes to each of its path ancestors. Growth
+/// and reclamation remain separate so a high-churn, zero-net folder cannot disappear.
+nonisolated struct ScanComparisonAggregateChange: Identifiable, Equatable, Sendable {
+    let id: String
+    let relativePath: String
+    let name: String
+    let parentPath: String?
+    let childPaths: [String]
+    let directRowID: ScanComparisonRow.ID?
+    let representativeRowID: ScanComparisonRow.ID
+    let beforeNode: FileNodeRecord?
+    let afterNode: FileNodeRecord?
+    let increasedAllocatedSize: Int64
+    let reclaimedAllocatedSize: Int64
+    let addedCount: Int
+    let removedCount: Int
+    let grewCount: Int
+    let shrankCount: Int
+    let movedCount: Int
+    let takingSpaceCount: Int
+    let freeingSpaceCount: Int
+
+    var allocatedDelta: Int64 {
+        increasedAllocatedSize - reclaimedAllocatedSize
+    }
+
+    var grossChangedAllocatedSize: Int64 {
+        increasedAllocatedSize + reclaimedAllocatedSize
+    }
+
+    var affectedCount: Int {
+        addedCount + removedCount + grewCount + shrankCount + movedCount
+    }
+
+    var isDirectory: Bool {
+        (afterNode ?? beforeNode)?.isDirectory ?? !childPaths.isEmpty
+    }
+
+    var itemKind: String {
+        (afterNode ?? beforeNode)?.itemKind ?? (isDirectory ? "Folder" : "Item")
+    }
+
+    var fileURL: URL? {
+        (afterNode ?? beforeNode)?.url
+    }
+
+    func impact(for filter: ScanComparisonImpactFilter) -> Int64 {
+        switch filter {
+        case .takingSpace:
+            return increasedAllocatedSize
+        case .freeingSpace:
+            return reclaimedAllocatedSize
+        case .moved:
+            return Int64(movedCount)
+        case .allActivity:
+            return grossChangedAllocatedSize
+        }
+    }
+}
+
+/// A compact graph of aggregate comparison paths. The service stores the graph rather than a
+/// recursive value tree so huge comparisons don't duplicate nested arrays for every UI facet.
+nonisolated struct ScanComparisonChangeTree: Equatable, Sendable {
+    let rootPaths: [String]
+    let nodesByPath: [String: ScanComparisonAggregateChange]
+
+    static let empty = ScanComparisonChangeTree(rootPaths: [], nodesByPath: [:])
+
+    func node(at relativePath: String) -> ScanComparisonAggregateChange? {
+        nodesByPath[relativePath]
+    }
+
+    func significantProjection(
+        impactFilter: ScanComparisonImpactFilter,
+        coverageTarget: Double = 0.95,
+        maximumNamedChildren: Int = 12
+    ) -> ScanComparisonChangeTreeProjection {
+        let target = min(max(coverageTarget, 0), 1)
+        let maximum = max(1, maximumNamedChildren)
+        let rootSelection = significantSelection(
+            from: rootPaths,
+            impactFilter: impactFilter,
+            coverageTarget: target,
+            maximumNamedChildren: maximum
+        )
+        let roots = projectedNodes(
+            selectedPaths: rootSelection.selected,
+            hiddenPaths: rootSelection.hidden,
+            parentPath: nil,
+            impactFilter: impactFilter,
+            coverageTarget: target,
+            maximumNamedChildren: maximum
+        )
+
+        return ScanComparisonChangeTreeProjection(
+            roots: roots,
+            impactFilter: impactFilter,
+            namedRootCount: rootSelection.selected.count,
+            hiddenRootCount: rootSelection.hidden.count,
+            representedImpact: rootSelection.representedImpact,
+            totalImpact: rootSelection.totalImpact,
+            groupedAffectedCount: roots.reduce(0) { partialResult, node in
+                partialResult + node.groupedAffectedCount
+            }
+        )
+    }
+
+    private func projectedNodes(
+        selectedPaths: [String],
+        hiddenPaths: [String],
+        parentPath: String?,
+        impactFilter: ScanComparisonImpactFilter,
+        coverageTarget: Double,
+        maximumNamedChildren: Int
+    ) -> [ScanComparisonChangeTreeNode] {
+        var projected = selectedPaths.compactMap { path -> ScanComparisonChangeTreeNode? in
+            guard let aggregate = nodesByPath[path] else { return nil }
+            let eligibleChildren = aggregate.childPaths.filter { childPath in
+                guard let child = nodesByPath[childPath] else { return false }
+                return isEligible(child, for: impactFilter)
+            }
+            let selection = significantSelection(
+                from: eligibleChildren,
+                impactFilter: impactFilter,
+                coverageTarget: coverageTarget,
+                maximumNamedChildren: maximumNamedChildren
+            )
+            let children = projectedNodes(
+                selectedPaths: selection.selected,
+                hiddenPaths: selection.hidden,
+                parentPath: path,
+                impactFilter: impactFilter,
+                coverageTarget: coverageTarget,
+                maximumNamedChildren: maximumNamedChildren
+            )
+            return ScanComparisonChangeTreeNode(aggregate: aggregate, children: children)
+        }
+
+        if !hiddenPaths.isEmpty {
+            let hiddenNodes = hiddenPaths.compactMap { nodesByPath[$0] }
+            projected.append(ScanComparisonChangeTreeNode.remainder(
+                parentPath: parentPath,
+                impactFilter: impactFilter,
+                hiddenNodes: hiddenNodes
+            ))
+        }
+        return projected
+    }
+
+    private func significantSelection(
+        from paths: [String],
+        impactFilter: ScanComparisonImpactFilter,
+        coverageTarget: Double,
+        maximumNamedChildren: Int
+    ) -> SignificantSelection {
+        let eligible = paths.compactMap { path -> ScanComparisonAggregateChange? in
+            guard let node = nodesByPath[path], isEligible(node, for: impactFilter) else { return nil }
+            return node
+        }
+        guard !eligible.isEmpty else {
+            return SignificantSelection(selected: [], hidden: [], representedImpact: 0, totalImpact: 0)
+        }
+
+        let selectedIDs: Set<String>
+        switch impactFilter {
+        case .takingSpace:
+            selectedIDs = selectForCoverage(
+                eligible,
+                metric: \.increasedAllocatedSize,
+                coverageTarget: coverageTarget,
+                maximumCount: maximumNamedChildren
+            )
+        case .freeingSpace:
+            selectedIDs = selectForCoverage(
+                eligible,
+                metric: \.reclaimedAllocatedSize,
+                coverageTarget: coverageTarget,
+                maximumCount: maximumNamedChildren
+            )
+        case .moved:
+            selectedIDs = selectForCoverage(
+                eligible,
+                metric: \.movedCount,
+                coverageTarget: coverageTarget,
+                maximumCount: maximumNamedChildren
+            )
+        case .allActivity:
+            let taking = selectForCoverage(
+                eligible,
+                metric: \.increasedAllocatedSize,
+                coverageTarget: coverageTarget,
+                maximumCount: maximumNamedChildren
+            )
+            let freeing = selectForCoverage(
+                eligible,
+                metric: \.reclaimedAllocatedSize,
+                coverageTarget: coverageTarget,
+                maximumCount: maximumNamedChildren
+            )
+            if taking.isEmpty && freeing.isEmpty {
+                selectedIDs = selectForCoverage(
+                    eligible,
+                    metric: \.affectedCount,
+                    coverageTarget: coverageTarget,
+                    maximumCount: maximumNamedChildren
+                )
+            } else {
+                selectedIDs = taking.union(freeing)
+            }
+        }
+
+        let sorted = eligible.sorted { lhs, rhs in
+            let lhsImpact = lhs.impact(for: impactFilter)
+            let rhsImpact = rhs.impact(for: impactFilter)
+            if lhsImpact != rhsImpact { return lhsImpact > rhsImpact }
+            if lhs.grossChangedAllocatedSize != rhs.grossChangedAllocatedSize {
+                return lhs.grossChangedAllocatedSize > rhs.grossChangedAllocatedSize
+            }
+            return lhs.relativePath.localizedStandardCompare(rhs.relativePath) == .orderedAscending
+        }
+        let selected = sorted.filter { selectedIDs.contains($0.id) }
+        let hidden = sorted.filter { !selectedIDs.contains($0.id) }
+        let totalImpact = sorted.reduce(Int64(0)) { $0 + $1.impact(for: impactFilter) }
+        let representedImpact = selected.reduce(Int64(0)) { $0 + $1.impact(for: impactFilter) }
+        return SignificantSelection(
+            selected: selected.map(\.relativePath),
+            hidden: hidden.map(\.relativePath),
+            representedImpact: representedImpact,
+            totalImpact: totalImpact
+        )
+    }
+
+    private func selectForCoverage<Value: BinaryInteger>(
+        _ nodes: [ScanComparisonAggregateChange],
+        metric: KeyPath<ScanComparisonAggregateChange, Value>,
+        coverageTarget: Double,
+        maximumCount: Int
+    ) -> Set<String> {
+        let sorted = nodes.filter { $0[keyPath: metric] > 0 }.sorted { lhs, rhs in
+            let lhsValue = lhs[keyPath: metric]
+            let rhsValue = rhs[keyPath: metric]
+            if lhsValue != rhsValue { return lhsValue > rhsValue }
+            return lhs.relativePath.localizedStandardCompare(rhs.relativePath) == .orderedAscending
+        }
+        let total = sorted.reduce(Double(0)) { $0 + Double($1[keyPath: metric]) }
+        guard total > 0 else { return [] }
+        let target = total * coverageTarget
+        var represented = Double(0)
+        var selected = Set<String>()
+        for node in sorted {
+            guard selected.count < maximumCount, represented < target else { break }
+            selected.insert(node.id)
+            represented += Double(node[keyPath: metric])
+        }
+        return selected
+    }
+
+    private func isEligible(
+        _ node: ScanComparisonAggregateChange,
+        for impactFilter: ScanComparisonImpactFilter
+    ) -> Bool {
+        if node.impact(for: impactFilter) > 0 { return true }
+        return impactFilter == .allActivity && node.movedCount > 0
+    }
+
+    private struct SignificantSelection {
+        let selected: [String]
+        let hidden: [String]
+        let representedImpact: Int64
+        let totalImpact: Int64
+    }
+}
+
+/// A small recursive projection intended for the Significant UI. Hidden siblings are represented
+/// by one synthetic remainder instead of retaining thousands of invisible descendants.
+nonisolated struct ScanComparisonChangeTreeNode: Identifiable, Equatable, Sendable {
+    let id: String
+    let relativePath: String
+    let name: String
+    let increasedAllocatedSize: Int64
+    let reclaimedAllocatedSize: Int64
+    let allocatedDelta: Int64
+    let affectedCount: Int
+    let movedCount: Int
+    let beforeNode: FileNodeRecord?
+    let afterNode: FileNodeRecord?
+    let directRowID: ScanComparisonRow.ID?
+    let isDirectory: Bool
+    let isRemainder: Bool
+    let groupedAffectedCount: Int
+    let children: [ScanComparisonChangeTreeNode]?
+
+    init(aggregate: ScanComparisonAggregateChange, children: [ScanComparisonChangeTreeNode]) {
+        self.id = aggregate.id
+        self.relativePath = aggregate.relativePath
+        self.name = aggregate.name
+        self.increasedAllocatedSize = aggregate.increasedAllocatedSize
+        self.reclaimedAllocatedSize = aggregate.reclaimedAllocatedSize
+        self.allocatedDelta = aggregate.allocatedDelta
+        self.affectedCount = aggregate.affectedCount
+        self.movedCount = aggregate.movedCount
+        self.beforeNode = aggregate.beforeNode
+        self.afterNode = aggregate.afterNode
+        self.directRowID = aggregate.directRowID
+        self.isDirectory = aggregate.isDirectory
+        self.isRemainder = false
+        self.groupedAffectedCount = children.reduce(0) { $0 + $1.groupedAffectedCount }
+        self.children = children.isEmpty ? nil : children
+    }
+
+    private init(
+        id: String,
+        relativePath: String,
+        name: String,
+        increasedAllocatedSize: Int64,
+        reclaimedAllocatedSize: Int64,
+        affectedCount: Int,
+        movedCount: Int,
+        groupedAffectedCount: Int
+    ) {
+        self.id = id
+        self.relativePath = relativePath
+        self.name = name
+        self.increasedAllocatedSize = increasedAllocatedSize
+        self.reclaimedAllocatedSize = reclaimedAllocatedSize
+        self.allocatedDelta = increasedAllocatedSize - reclaimedAllocatedSize
+        self.affectedCount = affectedCount
+        self.movedCount = movedCount
+        self.beforeNode = nil
+        self.afterNode = nil
+        self.directRowID = nil
+        self.isDirectory = false
+        self.isRemainder = true
+        self.groupedAffectedCount = groupedAffectedCount
+        self.children = nil
+    }
+
+    static func remainder(
+        parentPath: String?,
+        impactFilter: ScanComparisonImpactFilter,
+        hiddenNodes: [ScanComparisonAggregateChange]
+    ) -> ScanComparisonChangeTreeNode {
+        let affectedCount = hiddenNodes.reduce(0) { $0 + $1.affectedCount }
+        return ScanComparisonChangeTreeNode(
+            id: "other:\(parentPath ?? "root"):\(impactFilter.rawValue)",
+            relativePath: parentPath ?? "",
+            name: "Other smaller changes",
+            increasedAllocatedSize: hiddenNodes.reduce(0) { $0 + $1.increasedAllocatedSize },
+            reclaimedAllocatedSize: hiddenNodes.reduce(0) { $0 + $1.reclaimedAllocatedSize },
+            affectedCount: affectedCount,
+            movedCount: hiddenNodes.reduce(0) { $0 + $1.movedCount },
+            groupedAffectedCount: affectedCount
+        )
+    }
+
+    var fileURL: URL? {
+        (afterNode ?? beforeNode)?.url
+    }
+
+    func node(withID id: String) -> ScanComparisonChangeTreeNode? {
+        if self.id == id { return self }
+        for child in children ?? [] {
+            if let match = child.node(withID: id) { return match }
+        }
+        return nil
+    }
+}
+
+nonisolated struct ScanComparisonChangeTreeProjection: Equatable, Sendable {
+    let roots: [ScanComparisonChangeTreeNode]
+    let impactFilter: ScanComparisonImpactFilter
+    let namedRootCount: Int
+    let hiddenRootCount: Int
+    let representedImpact: Int64
+    let totalImpact: Int64
+    let groupedAffectedCount: Int
+
+    var representedFraction: Double {
+        guard totalImpact > 0 else { return 1 }
+        return Double(representedImpact) / Double(totalImpact)
+    }
+
+    func node(withID id: String) -> ScanComparisonChangeTreeNode? {
+        for root in roots {
+            if let match = root.node(withID: id) { return match }
+        }
+        return nil
     }
 }
 
@@ -354,6 +778,8 @@ nonisolated struct ScanComparison: Identifiable, Equatable, Sendable {
     let summary: ScanComparisonSummary
     let coverage: ScanComparisonCoverage
     let rows: [ScanComparisonRow]
+    /// Inclusive path rollups built from the final, non-overlapping evidence rows.
+    let changeTree: ScanComparisonChangeTree
     /// Non-overlapping first-level locations derived from `rows`, ordered by impact.
     let topLevelChanges: [ScanComparisonLocationChange]
 
@@ -361,6 +787,7 @@ nonisolated struct ScanComparison: Identifiable, Equatable, Sendable {
         beforeSnapshot: ScanSnapshot,
         afterSnapshot: ScanSnapshot,
         rows: [ScanComparisonRow],
+        changeTree: ScanComparisonChangeTree,
         topLevelChanges: [ScanComparisonLocationChange]
     ) {
         self.id = UUID()
@@ -369,6 +796,7 @@ nonisolated struct ScanComparison: Identifiable, Equatable, Sendable {
         self.rows = rows
         self.summary = ScanComparisonSummary(before: beforeSnapshot, after: afterSnapshot, rows: rows)
         self.coverage = ScanComparisonCoverage(before: beforeSnapshot, after: afterSnapshot)
+        self.changeTree = changeTree
         self.topLevelChanges = topLevelChanges
     }
 }
@@ -505,6 +933,11 @@ nonisolated struct ScanComparisonService: Sendable {
         let sortedRows = rows.sorted { lhs, rhs in
             ScanComparisonRowComparator.defaultOrder.compare(lhs, rhs) == .orderedAscending
         }
+        let changeTree = try Self.changeTree(
+            from: sortedRows,
+            beforeNodes: beforeNodes,
+            afterNodes: afterNodes
+        )
         let topLevelChanges = Self.topLevelChanges(
             from: sortedRows,
             beforeNodes: beforeNodes,
@@ -514,6 +947,7 @@ nonisolated struct ScanComparisonService: Sendable {
             beforeSnapshot: before,
             afterSnapshot: after,
             rows: sortedRows,
+            changeTree: changeTree,
             topLevelChanges: topLevelChanges
         )
     }
@@ -619,6 +1053,139 @@ nonisolated struct ScanComparisonService: Sendable {
         return node.fileIdentity
     }
 
+    private struct AggregateAccumulator {
+        let relativePath: String
+        let parentPath: String?
+        var childPaths = Set<String>()
+        var directRowID: ScanComparisonRow.ID?
+        var representativeRowID: ScanComparisonRow.ID?
+        var increasedAllocatedSize: Int64 = 0
+        var reclaimedAllocatedSize: Int64 = 0
+        var addedCount = 0
+        var removedCount = 0
+        var grewCount = 0
+        var shrankCount = 0
+        var movedCount = 0
+        var takingSpaceCount = 0
+        var freeingSpaceCount = 0
+
+        mutating func include(_ row: ScanComparisonRow, isDirect: Bool) {
+            if representativeRowID == nil {
+                representativeRowID = row.id
+            }
+            if isDirect {
+                directRowID = row.id
+            }
+            if row.allocatedDelta > 0 {
+                increasedAllocatedSize += row.allocatedDelta
+                takingSpaceCount += 1
+            } else if row.allocatedDelta < 0 {
+                reclaimedAllocatedSize += -row.allocatedDelta
+                freeingSpaceCount += 1
+            }
+            switch row.kind {
+            case .added:
+                addedCount += 1
+            case .removed:
+                removedCount += 1
+            case .grew:
+                grewCount += 1
+            case .shrank:
+                shrankCount += 1
+            case .moved:
+                movedCount += 1
+            }
+        }
+    }
+
+    /// Builds inclusive path rollups from the final evidence partition. Using the finalized rows
+    /// is essential: raw directory sizes would double-count materialized descendants and bypass
+    /// warning-boundary and hard-link normalization.
+    private static func changeTree(
+        from rows: [ScanComparisonRow],
+        beforeNodes: [String: FileNodeRecord],
+        afterNodes: [String: FileNodeRecord]
+    ) throws -> ScanComparisonChangeTree {
+        guard !rows.isEmpty else { return .empty }
+        var accumulators: [String: AggregateAccumulator] = [:]
+        accumulators.reserveCapacity(rows.count)
+
+        for row in rows {
+            try Task.checkCancellation()
+            let components = row.relativePath.split(separator: "/", omittingEmptySubsequences: true)
+            var parentPath: String?
+            var path = ""
+            for (index, component) in components.enumerated() {
+                path = path.isEmpty ? String(component) : path + "/" + component
+                var accumulator = accumulators[path] ?? AggregateAccumulator(
+                    relativePath: path,
+                    parentPath: parentPath
+                )
+                accumulator.include(row, isDirect: index == components.count - 1)
+                accumulators[path] = accumulator
+
+                if let parentPath {
+                    var parent = accumulators[parentPath] ?? AggregateAccumulator(
+                        relativePath: parentPath,
+                        parentPath: Self.parentPath(of: parentPath)
+                    )
+                    parent.childPaths.insert(path)
+                    accumulators[parentPath] = parent
+                }
+                parentPath = path
+            }
+        }
+
+        func nodeSort(_ lhsPath: String, _ rhsPath: String) -> Bool {
+            guard let lhs = accumulators[lhsPath], let rhs = accumulators[rhsPath] else {
+                return lhsPath.localizedStandardCompare(rhsPath) == .orderedAscending
+            }
+            let lhsGross = lhs.increasedAllocatedSize + lhs.reclaimedAllocatedSize
+            let rhsGross = rhs.increasedAllocatedSize + rhs.reclaimedAllocatedSize
+            if lhsGross != rhsGross { return lhsGross > rhsGross }
+            return lhsPath.localizedStandardCompare(rhsPath) == .orderedAscending
+        }
+
+        var nodesByPath: [String: ScanComparisonAggregateChange] = [:]
+        nodesByPath.reserveCapacity(accumulators.count)
+        for (path, accumulator) in accumulators {
+            try Task.checkCancellation()
+            guard let representativeRowID = accumulator.representativeRowID else { continue }
+            let displayNode = afterNodes[path] ?? beforeNodes[path]
+            nodesByPath[path] = ScanComparisonAggregateChange(
+                id: path,
+                relativePath: path,
+                name: displayNode?.name ?? URL(filePath: path).lastPathComponent,
+                parentPath: accumulator.parentPath,
+                childPaths: accumulator.childPaths.sorted(by: nodeSort),
+                directRowID: accumulator.directRowID,
+                representativeRowID: representativeRowID,
+                beforeNode: beforeNodes[path],
+                afterNode: afterNodes[path],
+                increasedAllocatedSize: accumulator.increasedAllocatedSize,
+                reclaimedAllocatedSize: accumulator.reclaimedAllocatedSize,
+                addedCount: accumulator.addedCount,
+                removedCount: accumulator.removedCount,
+                grewCount: accumulator.grewCount,
+                shrankCount: accumulator.shrankCount,
+                movedCount: accumulator.movedCount,
+                takingSpaceCount: accumulator.takingSpaceCount,
+                freeingSpaceCount: accumulator.freeingSpaceCount
+            )
+        }
+
+        let rootPaths = accumulators.values
+            .filter { $0.parentPath == nil }
+            .map(\.relativePath)
+            .sorted(by: nodeSort)
+        return ScanComparisonChangeTree(rootPaths: rootPaths, nodesByPath: nodesByPath)
+    }
+
+    private static func parentPath(of relativePath: String) -> String? {
+        guard let slashIndex = relativePath.lastIndex(of: "/") else { return nil }
+        return String(relativePath[..<slashIndex])
+    }
+
     private static func topLevelChanges(
         from rows: [ScanComparisonRow],
         beforeNodes: [String: FileNodeRecord],
@@ -637,9 +1204,16 @@ nonisolated struct ScanComparisonService: Sendable {
 
             var counts: [ScanComparisonChangeKind: Int] = [:]
             var allocatedDelta: Int64 = 0
+            var increasedAllocatedSize: Int64 = 0
+            var reclaimedAllocatedSize: Int64 = 0
             for row in locationRows {
                 counts[row.kind, default: 0] += 1
                 allocatedDelta += row.allocatedDelta
+                if row.allocatedDelta > 0 {
+                    increasedAllocatedSize += row.allocatedDelta
+                } else if row.allocatedDelta < 0 {
+                    reclaimedAllocatedSize += -row.allocatedDelta
+                }
             }
 
             let beforeNode = beforeNodes[relativePath]
@@ -650,6 +1224,8 @@ nonisolated struct ScanComparisonService: Sendable {
                 relativePath: relativePath,
                 name: displayNode?.name ?? URL(filePath: relativePath).lastPathComponent,
                 allocatedDelta: allocatedDelta,
+                increasedAllocatedSize: increasedAllocatedSize,
+                reclaimedAllocatedSize: reclaimedAllocatedSize,
                 addedCount: counts[.added, default: 0],
                 removedCount: counts[.removed, default: 0],
                 grewCount: counts[.grew, default: 0],
@@ -661,6 +1237,9 @@ nonisolated struct ScanComparisonService: Sendable {
             )
         }
         .sorted { lhs, rhs in
+            if lhs.grossChangedAllocatedSize != rhs.grossChangedAllocatedSize {
+                return lhs.grossChangedAllocatedSize > rhs.grossChangedAllocatedSize
+            }
             if lhs.absoluteAllocatedDelta != rhs.absoluteAllocatedDelta {
                 return lhs.absoluteAllocatedDelta > rhs.absoluteAllocatedDelta
             }
@@ -903,6 +1482,7 @@ nonisolated struct ScanComparisonRowComparator: Equatable, SortComparator, Senda
 
 nonisolated struct ScanComparisonRowQuery: Equatable, Sendable {
     let changeKind: ScanComparisonChangeKind?
+    let impactFilter: ScanComparisonImpactFilter
     let searchText: String
     let sortOrder: [ScanComparisonRowComparator]
     /// Limits evidence to one top-level contributor while retaining its full descendant rows.
@@ -910,11 +1490,13 @@ nonisolated struct ScanComparisonRowQuery: Equatable, Sendable {
 
     init(
         changeKind: ScanComparisonChangeKind?,
+        impactFilter: ScanComparisonImpactFilter = .allActivity,
         searchText: String,
         sortOrder: [ScanComparisonRowComparator],
         pathPrefix: String? = nil
     ) {
         self.changeKind = changeKind
+        self.impactFilter = impactFilter
         self.searchText = searchText
         self.sortOrder = sortOrder
         self.pathPrefix = pathPrefix
@@ -926,6 +1508,7 @@ nonisolated struct ScanComparisonRowQuery: Equatable, Sendable {
         )
         let filteredRows = rows.filter { row in
             guard changeKind == nil || row.kind == changeKind else { return false }
+            guard impactFilter.includes(row) else { return false }
             if let pathPrefix, !pathPrefix.isEmpty {
                 guard row.relativePath == pathPrefix || row.relativePath.hasPrefix(pathPrefix + "/") else {
                     return false

--- a/Radix/Services/ScanComparisonService.swift
+++ b/Radix/Services/ScanComparisonService.swift
@@ -535,6 +535,41 @@ nonisolated struct ScanComparisonRowComparator: Equatable, SortComparator, Senda
     }
 }
 
+nonisolated struct ScanComparisonRowQuery: Equatable, Sendable {
+    let changeKind: ScanComparisonChangeKind?
+    let searchText: String
+    let sortOrder: [ScanComparisonRowComparator]
+
+    func applying(to rows: [ScanComparisonRow]) -> [ScanComparisonRow] {
+        let query = SearchNormalizer.normalize(
+            searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        )
+        let filteredRows = rows.filter { row in
+            guard changeKind == nil || row.kind == changeKind else { return false }
+            guard !query.isEmpty else { return true }
+            return SearchNormalizer.normalize(row.name).contains(query)
+                || SearchNormalizer.normalize(row.relativePath).contains(query)
+        }
+
+        guard !sortOrder.isEmpty else { return filteredRows }
+        return filteredRows.sorted { lhs, rhs in
+            for comparator in sortOrder {
+                switch comparator.compare(lhs, rhs) {
+                case .orderedAscending:
+                    return true
+                case .orderedDescending:
+                    return false
+                case .orderedSame:
+                    continue
+                @unknown default:
+                    continue
+                }
+            }
+            return false
+        }
+    }
+}
+
 private nonisolated extension String {
     func trimmingPrefix(_ prefix: String) -> String {
         guard hasPrefix(prefix) else { return self }

--- a/Radix/Services/ScanComparisonService.swift
+++ b/Radix/Services/ScanComparisonService.swift
@@ -31,12 +31,14 @@ nonisolated struct ComparedSnapshotSummary: Equatable, Sendable {
     }
 }
 
-nonisolated enum ScanComparisonChangeKind: String, CaseIterable, Sendable {
+nonisolated enum ScanComparisonChangeKind: String, CaseIterable, Hashable, Identifiable, Sendable {
     case added
     case removed
     case grew
     case shrank
     case moved
+
+    var id: String { rawValue }
 
     var title: String {
         switch self {
@@ -272,32 +274,6 @@ nonisolated struct ScanComparisonLocationChange: Identifiable, Equatable, Sendab
     }
 }
 
-/// A storage-effect facet for comparison evidence.
-///
-/// This is intentionally independent of `ScanComparisonChangeKind`: a moved file can also
-/// consume or reclaim space, so movement and byte impact aren't mutually exclusive concepts.
-nonisolated enum ScanComparisonImpactFilter: String, CaseIterable, Identifiable, Sendable {
-    case takingSpace
-    case freeingSpace
-    case moved
-    case allActivity
-
-    var id: String { rawValue }
-
-    func includes(_ row: ScanComparisonRow) -> Bool {
-        switch self {
-        case .takingSpace:
-            return row.allocatedDelta > 0
-        case .freeingSpace:
-            return row.allocatedDelta < 0
-        case .moved:
-            return row.movedFromRelativePath != nil
-        case .allActivity:
-            return true
-        }
-    }
-}
-
 /// Inclusive change totals for one path in the comparison hierarchy.
 ///
 /// Every final, non-overlapping evidence row contributes to each of its path ancestors. Growth
@@ -319,8 +295,8 @@ nonisolated struct ScanComparisonAggregateChange: Identifiable, Equatable, Senda
     let grewCount: Int
     let shrankCount: Int
     let movedCount: Int
-    let takingSpaceCount: Int
-    let freeingSpaceCount: Int
+    let increasedAllocatedSizeByKind: [ScanComparisonChangeKind: Int64]
+    let reclaimedAllocatedSizeByKind: [ScanComparisonChangeKind: Int64]
 
     var allocatedDelta: Int64 {
         increasedAllocatedSize - reclaimedAllocatedSize
@@ -346,17 +322,42 @@ nonisolated struct ScanComparisonAggregateChange: Identifiable, Equatable, Senda
         (afterNode ?? beforeNode)?.url
     }
 
-    func impact(for filter: ScanComparisonImpactFilter) -> Int64 {
-        switch filter {
-        case .takingSpace:
-            return increasedAllocatedSize
-        case .freeingSpace:
-            return reclaimedAllocatedSize
-        case .moved:
-            return Int64(movedCount)
-        case .allActivity:
-            return grossChangedAllocatedSize
+    func changeCount(for kind: ScanComparisonChangeKind) -> Int {
+        switch kind {
+        case .added: addedCount
+        case .removed: removedCount
+        case .grew: grewCount
+        case .shrank: shrankCount
+        case .moved: movedCount
         }
+    }
+
+    func includes(any changeKinds: Set<ScanComparisonChangeKind>) -> Bool {
+        changeKinds.contains { changeCount(for: $0) > 0 }
+    }
+
+    func increasedAllocatedSize(for changeKinds: Set<ScanComparisonChangeKind>) -> Int64 {
+        changeKinds.reduce(0) { $0 + increasedAllocatedSizeByKind[$1, default: 0] }
+    }
+
+    func reclaimedAllocatedSize(for changeKinds: Set<ScanComparisonChangeKind>) -> Int64 {
+        changeKinds.reduce(0) { $0 + reclaimedAllocatedSizeByKind[$1, default: 0] }
+    }
+
+    func impact(for kind: ScanComparisonChangeKind) -> Int64 {
+        if kind == .moved {
+            return Int64(movedCount)
+        }
+        return increasedAllocatedSizeByKind[kind, default: 0]
+            + reclaimedAllocatedSizeByKind[kind, default: 0]
+    }
+
+    func impact(for changeKinds: Set<ScanComparisonChangeKind>) -> Int64 {
+        let storageKinds = changeKinds.subtracting([.moved])
+        if !storageKinds.isEmpty {
+            return storageKinds.reduce(0) { $0 + impact(for: $1) }
+        }
+        return changeKinds.contains(.moved) ? Int64(movedCount) : 0
     }
 }
 
@@ -373,7 +374,7 @@ nonisolated struct ScanComparisonChangeTree: Equatable, Sendable {
     }
 
     func significantProjection(
-        impactFilter: ScanComparisonImpactFilter,
+        changeKinds: Set<ScanComparisonChangeKind>,
         coverageTarget: Double = 0.95,
         maximumNamedChildren: Int = 12
     ) -> ScanComparisonChangeTreeProjection {
@@ -381,7 +382,7 @@ nonisolated struct ScanComparisonChangeTree: Equatable, Sendable {
         let maximum = max(1, maximumNamedChildren)
         let rootSelection = significantSelection(
             from: rootPaths,
-            impactFilter: impactFilter,
+            changeKinds: changeKinds,
             coverageTarget: target,
             maximumNamedChildren: maximum
         )
@@ -389,14 +390,14 @@ nonisolated struct ScanComparisonChangeTree: Equatable, Sendable {
             selectedPaths: rootSelection.selected,
             hiddenPaths: rootSelection.hidden,
             parentPath: nil,
-            impactFilter: impactFilter,
+            changeKinds: changeKinds,
             coverageTarget: target,
             maximumNamedChildren: maximum
         )
 
         return ScanComparisonChangeTreeProjection(
             roots: roots,
-            impactFilter: impactFilter,
+            changeKinds: changeKinds,
             namedRootCount: rootSelection.selected.count,
             hiddenRootCount: rootSelection.hidden.count,
             representedImpact: rootSelection.representedImpact,
@@ -411,7 +412,7 @@ nonisolated struct ScanComparisonChangeTree: Equatable, Sendable {
         selectedPaths: [String],
         hiddenPaths: [String],
         parentPath: String?,
-        impactFilter: ScanComparisonImpactFilter,
+        changeKinds: Set<ScanComparisonChangeKind>,
         coverageTarget: Double,
         maximumNamedChildren: Int
     ) -> [ScanComparisonChangeTreeNode] {
@@ -419,11 +420,11 @@ nonisolated struct ScanComparisonChangeTree: Equatable, Sendable {
             guard let aggregate = nodesByPath[path] else { return nil }
             let eligibleChildren = aggregate.childPaths.filter { childPath in
                 guard let child = nodesByPath[childPath] else { return false }
-                return isEligible(child, for: impactFilter)
+                return child.includes(any: changeKinds)
             }
             let selection = significantSelection(
                 from: eligibleChildren,
-                impactFilter: impactFilter,
+                changeKinds: changeKinds,
                 coverageTarget: coverageTarget,
                 maximumNamedChildren: maximumNamedChildren
             )
@@ -431,18 +432,22 @@ nonisolated struct ScanComparisonChangeTree: Equatable, Sendable {
                 selectedPaths: selection.selected,
                 hiddenPaths: selection.hidden,
                 parentPath: path,
-                impactFilter: impactFilter,
+                changeKinds: changeKinds,
                 coverageTarget: coverageTarget,
                 maximumNamedChildren: maximumNamedChildren
             )
-            return ScanComparisonChangeTreeNode(aggregate: aggregate, children: children)
+            return ScanComparisonChangeTreeNode(
+                aggregate: aggregate,
+                changeKinds: changeKinds,
+                children: children
+            )
         }
 
         if !hiddenPaths.isEmpty {
             let hiddenNodes = hiddenPaths.compactMap { nodesByPath[$0] }
             projected.append(ScanComparisonChangeTreeNode.remainder(
                 parentPath: parentPath,
-                impactFilter: impactFilter,
+                changeKinds: changeKinds,
                 hiddenNodes: hiddenNodes
             ))
         }
@@ -451,69 +456,40 @@ nonisolated struct ScanComparisonChangeTree: Equatable, Sendable {
 
     private func significantSelection(
         from paths: [String],
-        impactFilter: ScanComparisonImpactFilter,
+        changeKinds: Set<ScanComparisonChangeKind>,
         coverageTarget: Double,
         maximumNamedChildren: Int
     ) -> SignificantSelection {
         let eligible = paths.compactMap { path -> ScanComparisonAggregateChange? in
-            guard let node = nodesByPath[path], isEligible(node, for: impactFilter) else { return nil }
+            guard let node = nodesByPath[path], node.includes(any: changeKinds) else { return nil }
             return node
         }
         guard !eligible.isEmpty else {
             return SignificantSelection(selected: [], hidden: [], representedImpact: 0, totalImpact: 0)
         }
 
-        let selectedIDs: Set<String>
-        switch impactFilter {
-        case .takingSpace:
-            selectedIDs = selectForCoverage(
+        var selectedIDs = Set<String>()
+        for kind in changeKinds {
+            var selectedForKind = selectForCoverage(
                 eligible,
-                metric: \.increasedAllocatedSize,
+                value: { $0.impact(for: kind) },
                 coverageTarget: coverageTarget,
                 maximumCount: maximumNamedChildren
             )
-        case .freeingSpace:
-            selectedIDs = selectForCoverage(
-                eligible,
-                metric: \.reclaimedAllocatedSize,
-                coverageTarget: coverageTarget,
-                maximumCount: maximumNamedChildren
-            )
-        case .moved:
-            selectedIDs = selectForCoverage(
-                eligible,
-                metric: \.movedCount,
-                coverageTarget: coverageTarget,
-                maximumCount: maximumNamedChildren
-            )
-        case .allActivity:
-            let taking = selectForCoverage(
-                eligible,
-                metric: \.increasedAllocatedSize,
-                coverageTarget: coverageTarget,
-                maximumCount: maximumNamedChildren
-            )
-            let freeing = selectForCoverage(
-                eligible,
-                metric: \.reclaimedAllocatedSize,
-                coverageTarget: coverageTarget,
-                maximumCount: maximumNamedChildren
-            )
-            if taking.isEmpty && freeing.isEmpty {
-                selectedIDs = selectForCoverage(
+            if selectedForKind.isEmpty {
+                selectedForKind = selectForCoverage(
                     eligible,
-                    metric: \.affectedCount,
+                    value: { Int64($0.changeCount(for: kind)) },
                     coverageTarget: coverageTarget,
                     maximumCount: maximumNamedChildren
                 )
-            } else {
-                selectedIDs = taking.union(freeing)
             }
+            selectedIDs.formUnion(selectedForKind)
         }
 
         let sorted = eligible.sorted { lhs, rhs in
-            let lhsImpact = lhs.impact(for: impactFilter)
-            let rhsImpact = rhs.impact(for: impactFilter)
+            let lhsImpact = lhs.impact(for: changeKinds)
+            let rhsImpact = rhs.impact(for: changeKinds)
             if lhsImpact != rhsImpact { return lhsImpact > rhsImpact }
             if lhs.grossChangedAllocatedSize != rhs.grossChangedAllocatedSize {
                 return lhs.grossChangedAllocatedSize > rhs.grossChangedAllocatedSize
@@ -522,8 +498,16 @@ nonisolated struct ScanComparisonChangeTree: Equatable, Sendable {
         }
         let selected = sorted.filter { selectedIDs.contains($0.id) }
         let hidden = sorted.filter { !selectedIDs.contains($0.id) }
-        let totalImpact = sorted.reduce(Int64(0)) { $0 + $1.impact(for: impactFilter) }
-        let representedImpact = selected.reduce(Int64(0)) { $0 + $1.impact(for: impactFilter) }
+        var totalImpact = sorted.reduce(Int64(0)) { $0 + $1.impact(for: changeKinds) }
+        var representedImpact = selected.reduce(Int64(0)) { $0 + $1.impact(for: changeKinds) }
+        if totalImpact == 0 {
+            totalImpact = sorted.reduce(0) { partialResult, node in
+                partialResult + Int64(changeKinds.reduce(0) { $0 + node.changeCount(for: $1) })
+            }
+            representedImpact = selected.reduce(0) { partialResult, node in
+                partialResult + Int64(changeKinds.reduce(0) { $0 + node.changeCount(for: $1) })
+            }
+        }
         return SignificantSelection(
             selected: selected.map(\.relativePath),
             hidden: hidden.map(\.relativePath),
@@ -532,19 +516,19 @@ nonisolated struct ScanComparisonChangeTree: Equatable, Sendable {
         )
     }
 
-    private func selectForCoverage<Value: BinaryInteger>(
+    private func selectForCoverage(
         _ nodes: [ScanComparisonAggregateChange],
-        metric: KeyPath<ScanComparisonAggregateChange, Value>,
+        value: (ScanComparisonAggregateChange) -> Int64,
         coverageTarget: Double,
         maximumCount: Int
     ) -> Set<String> {
-        let sorted = nodes.filter { $0[keyPath: metric] > 0 }.sorted { lhs, rhs in
-            let lhsValue = lhs[keyPath: metric]
-            let rhsValue = rhs[keyPath: metric]
+        let sorted = nodes.filter { value($0) > 0 }.sorted { lhs, rhs in
+            let lhsValue = value(lhs)
+            let rhsValue = value(rhs)
             if lhsValue != rhsValue { return lhsValue > rhsValue }
             return lhs.relativePath.localizedStandardCompare(rhs.relativePath) == .orderedAscending
         }
-        let total = sorted.reduce(Double(0)) { $0 + Double($1[keyPath: metric]) }
+        let total = sorted.reduce(Double(0)) { $0 + Double(value($1)) }
         guard total > 0 else { return [] }
         let target = total * coverageTarget
         var represented = Double(0)
@@ -552,17 +536,9 @@ nonisolated struct ScanComparisonChangeTree: Equatable, Sendable {
         for node in sorted {
             guard selected.count < maximumCount, represented < target else { break }
             selected.insert(node.id)
-            represented += Double(node[keyPath: metric])
+            represented += Double(value(node))
         }
         return selected
-    }
-
-    private func isEligible(
-        _ node: ScanComparisonAggregateChange,
-        for impactFilter: ScanComparisonImpactFilter
-    ) -> Bool {
-        if node.impact(for: impactFilter) > 0 { return true }
-        return impactFilter == .allActivity && node.movedCount > 0
     }
 
     private struct SignificantSelection {
@@ -592,15 +568,21 @@ nonisolated struct ScanComparisonChangeTreeNode: Identifiable, Equatable, Sendab
     let groupedAffectedCount: Int
     let children: [ScanComparisonChangeTreeNode]?
 
-    init(aggregate: ScanComparisonAggregateChange, children: [ScanComparisonChangeTreeNode]) {
+    init(
+        aggregate: ScanComparisonAggregateChange,
+        changeKinds: Set<ScanComparisonChangeKind>,
+        children: [ScanComparisonChangeTreeNode]
+    ) {
+        let increasedAllocatedSize = aggregate.increasedAllocatedSize(for: changeKinds)
+        let reclaimedAllocatedSize = aggregate.reclaimedAllocatedSize(for: changeKinds)
         self.id = aggregate.id
         self.relativePath = aggregate.relativePath
         self.name = aggregate.name
-        self.increasedAllocatedSize = aggregate.increasedAllocatedSize
-        self.reclaimedAllocatedSize = aggregate.reclaimedAllocatedSize
-        self.allocatedDelta = aggregate.allocatedDelta
-        self.affectedCount = aggregate.affectedCount
-        self.movedCount = aggregate.movedCount
+        self.increasedAllocatedSize = increasedAllocatedSize
+        self.reclaimedAllocatedSize = reclaimedAllocatedSize
+        self.allocatedDelta = increasedAllocatedSize - reclaimedAllocatedSize
+        self.affectedCount = changeKinds.reduce(0) { $0 + aggregate.changeCount(for: $1) }
+        self.movedCount = changeKinds.contains(.moved) ? aggregate.movedCount : 0
         self.beforeNode = aggregate.beforeNode
         self.afterNode = aggregate.afterNode
         self.directRowID = aggregate.directRowID
@@ -639,18 +621,27 @@ nonisolated struct ScanComparisonChangeTreeNode: Identifiable, Equatable, Sendab
 
     static func remainder(
         parentPath: String?,
-        impactFilter: ScanComparisonImpactFilter,
+        changeKinds: Set<ScanComparisonChangeKind>,
         hiddenNodes: [ScanComparisonAggregateChange]
     ) -> ScanComparisonChangeTreeNode {
-        let affectedCount = hiddenNodes.reduce(0) { $0 + $1.affectedCount }
+        let affectedCount = hiddenNodes.reduce(0) { partialResult, node in
+            partialResult + changeKinds.reduce(0) { $0 + node.changeCount(for: $1) }
+        }
+        let filterID = changeKinds.map(\.rawValue).sorted().joined(separator: ",")
         return ScanComparisonChangeTreeNode(
-            id: "other:\(parentPath ?? "root"):\(impactFilter.rawValue)",
+            id: "other:\(parentPath ?? "root"):\(filterID)",
             relativePath: parentPath ?? "",
             name: "Other smaller changes",
-            increasedAllocatedSize: hiddenNodes.reduce(0) { $0 + $1.increasedAllocatedSize },
-            reclaimedAllocatedSize: hiddenNodes.reduce(0) { $0 + $1.reclaimedAllocatedSize },
+            increasedAllocatedSize: hiddenNodes.reduce(0) {
+                $0 + $1.increasedAllocatedSize(for: changeKinds)
+            },
+            reclaimedAllocatedSize: hiddenNodes.reduce(0) {
+                $0 + $1.reclaimedAllocatedSize(for: changeKinds)
+            },
             affectedCount: affectedCount,
-            movedCount: hiddenNodes.reduce(0) { $0 + $1.movedCount },
+            movedCount: changeKinds.contains(.moved)
+                ? hiddenNodes.reduce(0) { $0 + $1.movedCount }
+                : 0,
             groupedAffectedCount: affectedCount
         )
     }
@@ -670,7 +661,7 @@ nonisolated struct ScanComparisonChangeTreeNode: Identifiable, Equatable, Sendab
 
 nonisolated struct ScanComparisonChangeTreeProjection: Equatable, Sendable {
     let roots: [ScanComparisonChangeTreeNode]
-    let impactFilter: ScanComparisonImpactFilter
+    let changeKinds: Set<ScanComparisonChangeKind>
     let namedRootCount: Int
     let hiddenRootCount: Int
     let representedImpact: Int64
@@ -1066,8 +1057,8 @@ nonisolated struct ScanComparisonService: Sendable {
         var grewCount = 0
         var shrankCount = 0
         var movedCount = 0
-        var takingSpaceCount = 0
-        var freeingSpaceCount = 0
+        var increasedAllocatedSizeByKind: [ScanComparisonChangeKind: Int64] = [:]
+        var reclaimedAllocatedSizeByKind: [ScanComparisonChangeKind: Int64] = [:]
 
         mutating func include(_ row: ScanComparisonRow, isDirect: Bool) {
             if representativeRowID == nil {
@@ -1078,10 +1069,10 @@ nonisolated struct ScanComparisonService: Sendable {
             }
             if row.allocatedDelta > 0 {
                 increasedAllocatedSize += row.allocatedDelta
-                takingSpaceCount += 1
+                increasedAllocatedSizeByKind[row.kind, default: 0] += row.allocatedDelta
             } else if row.allocatedDelta < 0 {
                 reclaimedAllocatedSize += -row.allocatedDelta
-                freeingSpaceCount += 1
+                reclaimedAllocatedSizeByKind[row.kind, default: 0] += -row.allocatedDelta
             }
             switch row.kind {
             case .added:
@@ -1169,8 +1160,8 @@ nonisolated struct ScanComparisonService: Sendable {
                 grewCount: accumulator.grewCount,
                 shrankCount: accumulator.shrankCount,
                 movedCount: accumulator.movedCount,
-                takingSpaceCount: accumulator.takingSpaceCount,
-                freeingSpaceCount: accumulator.freeingSpaceCount
+                increasedAllocatedSizeByKind: accumulator.increasedAllocatedSizeByKind,
+                reclaimedAllocatedSizeByKind: accumulator.reclaimedAllocatedSizeByKind
             )
         }
 
@@ -1481,22 +1472,19 @@ nonisolated struct ScanComparisonRowComparator: Equatable, SortComparator, Senda
 }
 
 nonisolated struct ScanComparisonRowQuery: Equatable, Sendable {
-    let changeKind: ScanComparisonChangeKind?
-    let impactFilter: ScanComparisonImpactFilter
+    let changeKinds: Set<ScanComparisonChangeKind>
     let searchText: String
     let sortOrder: [ScanComparisonRowComparator]
     /// Limits evidence to one top-level contributor while retaining its full descendant rows.
     let pathPrefix: String?
 
     init(
-        changeKind: ScanComparisonChangeKind?,
-        impactFilter: ScanComparisonImpactFilter = .allActivity,
+        changeKinds: Set<ScanComparisonChangeKind> = Set(ScanComparisonChangeKind.allCases),
         searchText: String,
         sortOrder: [ScanComparisonRowComparator],
         pathPrefix: String? = nil
     ) {
-        self.changeKind = changeKind
-        self.impactFilter = impactFilter
+        self.changeKinds = changeKinds
         self.searchText = searchText
         self.sortOrder = sortOrder
         self.pathPrefix = pathPrefix
@@ -1507,8 +1495,7 @@ nonisolated struct ScanComparisonRowQuery: Equatable, Sendable {
             searchText.trimmingCharacters(in: .whitespacesAndNewlines)
         )
         let filteredRows = rows.filter { row in
-            guard changeKind == nil || row.kind == changeKind else { return false }
-            guard impactFilter.includes(row) else { return false }
+            guard changeKinds.contains(row.kind) else { return false }
             if let pathPrefix, !pathPrefix.isEmpty {
                 guard row.relativePath == pathPrefix || row.relativePath.hasPrefix(pathPrefix + "/") else {
                     return false

--- a/Radix/Services/ScanComparisonService.swift
+++ b/Radix/Services/ScanComparisonService.swift
@@ -148,7 +148,9 @@ nonisolated struct ScanComparisonRow: Identifiable, Equatable, Sendable {
         relativePath: String,
         kind: ScanComparisonChangeKind,
         beforeNode: FileNodeRecord?,
-        afterNode: FileNodeRecord?
+        afterNode: FileNodeRecord?,
+        beforeAllocatedSize: Int64? = nil,
+        afterAllocatedSize: Int64? = nil
     ) {
         let displayNode = afterNode ?? beforeNode
         self.id = "\(kind.rawValue):\(relativePath)"
@@ -157,8 +159,8 @@ nonisolated struct ScanComparisonRow: Identifiable, Equatable, Sendable {
         self.kind = kind
         self.beforeNode = beforeNode
         self.afterNode = afterNode
-        self.beforeAllocatedSize = beforeNode?.allocatedSize
-        self.afterAllocatedSize = afterNode?.allocatedSize
+        self.beforeAllocatedSize = beforeNode.map { beforeAllocatedSize ?? $0.allocatedSize }
+        self.afterAllocatedSize = afterNode.map { afterAllocatedSize ?? $0.allocatedSize }
         self.beforeLogicalSize = beforeNode?.logicalSize
         self.afterLogicalSize = afterNode?.logicalSize
         self.isDirectory = displayNode?.isDirectory ?? false
@@ -216,26 +218,43 @@ nonisolated struct ScanComparisonService: Sendable {
         let addedPaths = afterPaths.subtracting(beforePaths)
         let removedPaths = beforePaths.subtracting(afterPaths)
         let sharedPaths = beforePaths.intersection(afterPaths)
+        let materializationBoundaryPaths = Self.materializationBoundaryPaths(
+            sharedPaths: sharedPaths,
+            beforeNodes: beforeNodes,
+            afterNodes: afterNodes,
+            beforeStore: before.treeStore,
+            afterStore: after.treeStore
+        )
+        let allocatedSizes = Self.normalizedAllocatedSizes(
+            beforeNodes: beforeNodes,
+            afterNodes: afterNodes
+        )
 
         rows.reserveCapacity(addedPaths.count + removedPaths.count + sharedPaths.count)
 
-        for relativePath in addedPaths where !Self.hasAncestor(of: relativePath, in: addedPaths) {
+        for relativePath in addedPaths
+        where !Self.hasAncestor(of: relativePath, in: addedPaths)
+            && !Self.hasAncestor(of: relativePath, in: materializationBoundaryPaths) {
             try Task.checkCancellation()
             rows.append(ScanComparisonRow(
                 relativePath: relativePath,
                 kind: .added,
                 beforeNode: nil,
-                afterNode: afterNodes[relativePath]
+                afterNode: afterNodes[relativePath],
+                afterAllocatedSize: allocatedSizes.after[relativePath]
             ))
         }
 
-        for relativePath in removedPaths where !Self.hasAncestor(of: relativePath, in: removedPaths) {
+        for relativePath in removedPaths
+        where !Self.hasAncestor(of: relativePath, in: removedPaths)
+            && !Self.hasAncestor(of: relativePath, in: materializationBoundaryPaths) {
             try Task.checkCancellation()
             rows.append(ScanComparisonRow(
                 relativePath: relativePath,
                 kind: .removed,
                 beforeNode: beforeNodes[relativePath],
-                afterNode: nil
+                afterNode: nil,
+                beforeAllocatedSize: allocatedSizes.before[relativePath]
             ))
         }
 
@@ -255,13 +274,17 @@ nonisolated struct ScanComparisonService: Sendable {
                 && before.treeStore.containsChildren(id: beforeNode.id)
                 && after.treeStore.containsChildren(id: afterNode.id)
             guard !isRedundantDirectory else { continue }
-            let delta = afterNode.allocatedSize - beforeNode.allocatedSize
+            let beforeAllocatedSize = allocatedSizes.before[relativePath] ?? beforeNode.allocatedSize
+            let afterAllocatedSize = allocatedSizes.after[relativePath] ?? afterNode.allocatedSize
+            let delta = afterAllocatedSize - beforeAllocatedSize
             guard delta != 0 else { continue }
             rows.append(ScanComparisonRow(
                 relativePath: relativePath,
                 kind: delta > 0 ? .grew : .shrank,
                 beforeNode: beforeNode,
-                afterNode: afterNode
+                afterNode: afterNode,
+                beforeAllocatedSize: beforeAllocatedSize,
+                afterAllocatedSize: afterAllocatedSize
             ))
         }
 
@@ -311,6 +334,155 @@ nonisolated struct ScanComparisonService: Sendable {
             }
         }
         return false
+    }
+
+    private static func materializationBoundaryPaths(
+        sharedPaths: Set<String>,
+        beforeNodes: [String: FileNodeRecord],
+        afterNodes: [String: FileNodeRecord],
+        beforeStore: FileTreeStore,
+        afterStore: FileTreeStore
+    ) -> Set<String> {
+        Set(sharedPaths.filter { relativePath in
+            guard let beforeNode = beforeNodes[relativePath],
+                  let afterNode = afterNodes[relativePath],
+                  beforeNode.isDirectory,
+                  afterNode.isDirectory else {
+                return false
+            }
+
+            let beforeHasChildren = beforeStore.containsChildren(id: beforeNode.id)
+            let afterHasChildren = afterStore.containsChildren(id: afterNode.id)
+            guard beforeHasChildren != afterHasChildren else { return false }
+
+            return Self.isOpaqueDirectory(beforeNode, hasIndexedChildren: beforeHasChildren)
+                || Self.isOpaqueDirectory(afterNode, hasIndexedChildren: afterHasChildren)
+        })
+    }
+
+    private static func isOpaqueDirectory(
+        _ node: FileNodeRecord,
+        hasIndexedChildren: Bool
+    ) -> Bool {
+        guard node.isDirectory, !hasIndexedChildren else { return false }
+        return node.isAutoSummarized || node.isPackage || !node.isAccessible
+    }
+
+    private static func normalizedAllocatedSizes(
+        beforeNodes: [String: FileNodeRecord],
+        afterNodes: [String: FileNodeRecord]
+    ) -> (
+        before: [String: Int64],
+        after: [String: Int64]
+    ) {
+        let identities = hardLinkIdentities(in: beforeNodes).union(hardLinkIdentities(in: afterNodes))
+        guard !identities.isEmpty else {
+            return (
+                beforeNodes.mapValues(\.allocatedSize),
+                afterNodes.mapValues(\.allocatedSize)
+            )
+        }
+
+        let beforeGroups = hardLinkPathsByIdentity(in: beforeNodes, identities: identities)
+        let afterGroups = hardLinkPathsByIdentity(in: afterNodes, identities: identities)
+        var beforeSizes = beforeNodes.mapValues(\.allocatedSize)
+        var afterSizes = afterNodes.mapValues(\.allocatedSize)
+
+        for identity in identities {
+            let beforePaths = beforeGroups[identity] ?? []
+            let afterPaths = afterGroups[identity] ?? []
+            let sharedPaths = Set(beforePaths).intersection(afterPaths)
+
+            if !sharedPaths.isEmpty, let ownerPath = sharedPaths.min() {
+                normalizeHardLinkGroup(
+                    paths: beforePaths,
+                    ownerPath: ownerPath,
+                    nodes: beforeNodes,
+                    sizes: &beforeSizes
+                )
+                normalizeHardLinkGroup(
+                    paths: afterPaths,
+                    ownerPath: ownerPath,
+                    nodes: afterNodes,
+                    sizes: &afterSizes
+                )
+            } else {
+                if let ownerPath = beforePaths.min() {
+                    normalizeHardLinkGroup(
+                        paths: beforePaths,
+                        ownerPath: ownerPath,
+                        nodes: beforeNodes,
+                        sizes: &beforeSizes
+                    )
+                }
+                if let ownerPath = afterPaths.min() {
+                    normalizeHardLinkGroup(
+                        paths: afterPaths,
+                        ownerPath: ownerPath,
+                        nodes: afterNodes,
+                        sizes: &afterSizes
+                    )
+                }
+            }
+        }
+
+        return (beforeSizes, afterSizes)
+    }
+
+    private static func hardLinkIdentities(
+        in nodes: [String: FileNodeRecord]
+    ) -> Set<FileIdentity> {
+        Set(nodes.values.lazy.compactMap { node in
+            guard !node.isDirectory,
+                  !node.isSymbolicLink,
+                  !node.isSynthetic,
+                  node.linkCount > 1 else {
+                return nil
+            }
+            return node.fileIdentity
+        })
+    }
+
+    private static func hardLinkPathsByIdentity(
+        in nodes: [String: FileNodeRecord],
+        identities: Set<FileIdentity>
+    ) -> [FileIdentity: [String]] {
+        let entries: [(identity: FileIdentity, relativePath: String)] = nodes.compactMap { relativePath, node in
+            guard !node.isDirectory,
+                  !node.isSymbolicLink,
+                  !node.isSynthetic,
+                  let identity = node.fileIdentity,
+                  identities.contains(identity) else {
+                return nil
+            }
+            return (identity, relativePath)
+        }
+        return Dictionary(grouping: entries, by: \.identity)
+            .mapValues { groupedEntries in groupedEntries.map(\.relativePath) }
+    }
+
+    private static func normalizeHardLinkGroup(
+        paths: [String],
+        ownerPath: String,
+        nodes: [String: FileNodeRecord],
+        sizes: inout [String: Int64]
+    ) {
+        let groupAllocatedSize = paths.compactMap { nodes[$0]?.unduplicatedAllocatedSize }.max() ?? 0
+
+        for path in paths {
+            guard let node = nodes[path] else { continue }
+            let normalizedSize = path == ownerPath ? groupAllocatedSize : 0
+            let adjustment = normalizedSize - node.allocatedSize
+            guard adjustment != 0 else { continue }
+
+            sizes[path] = normalizedSize
+            var cursor = path
+            while let slashIndex = cursor.lastIndex(of: "/") {
+                cursor = String(cursor[..<slashIndex])
+                guard sizes[cursor] != nil else { continue }
+                sizes[cursor, default: 0] += adjustment
+            }
+        }
     }
 }
 

--- a/Radix/Services/ScanComparisonService.swift
+++ b/Radix/Services/ScanComparisonService.swift
@@ -142,8 +142,9 @@ nonisolated struct ScanComparisonSummary: Equatable, Sendable {
         afterWarningCount - beforeWarningCount
     }
 
+    /// Items at the same relative path in both scans whose tracked size changed.
     var changedCount: Int {
-        addedCount + removedCount + grewCount + shrankCount + movedCount
+        grewCount + shrankCount
     }
 
     /// Net allocated change that can be attributed to final comparison rows.
@@ -250,7 +251,8 @@ nonisolated struct ScanComparisonLocationChange: Identifiable, Equatable, Sendab
     /// The node at `relativePath` in the after snapshot, when it was indexed.
     let afterNode: FileNodeRecord?
 
-    var changedCount: Int {
+    /// Non-overlapping comparison rows attributed to this location.
+    var affectedCount: Int {
         addedCount + removedCount + grewCount + shrankCount + movedCount
     }
 

--- a/Radix/Services/ScanComparisonService.swift
+++ b/Radix/Services/ScanComparisonService.swift
@@ -36,6 +36,7 @@ nonisolated enum ScanComparisonChangeKind: String, CaseIterable, Sendable {
     case removed
     case grew
     case shrank
+    case moved
 
     var title: String {
         switch self {
@@ -47,6 +48,8 @@ nonisolated enum ScanComparisonChangeKind: String, CaseIterable, Sendable {
             return "Grew"
         case .shrank:
             return "Shrank"
+        case .moved:
+            return "Moved"
         }
     }
 
@@ -60,6 +63,8 @@ nonisolated enum ScanComparisonChangeKind: String, CaseIterable, Sendable {
             return 2
         case .shrank:
             return 3
+        case .moved:
+            return 4
         }
     }
 }
@@ -79,6 +84,11 @@ nonisolated struct ScanComparisonSummary: Equatable, Sendable {
     let removedCount: Int
     let grewCount: Int
     let shrankCount: Int
+    let movedCount: Int
+    /// Sum of positive allocated deltas represented by the final, non-overlapping rows.
+    let grossIncreasedAllocatedSize: Int64
+    /// Sum of reclaimed allocated bytes represented by the final, non-overlapping rows.
+    let grossReclaimedAllocatedSize: Int64
 
     init(before: ScanSnapshot, after: ScanSnapshot, rows: [ScanComparisonRow]) {
         self.beforeAllocatedSize = before.aggregateStats.totalAllocatedSize
@@ -93,13 +103,23 @@ nonisolated struct ScanComparisonSummary: Equatable, Sendable {
         self.afterWarningCount = after.scanWarnings.count
 
         var counts: [ScanComparisonChangeKind: Int] = [:]
+        var grossIncreasedAllocatedSize: Int64 = 0
+        var grossReclaimedAllocatedSize: Int64 = 0
         for row in rows {
             counts[row.kind, default: 0] += 1
+            if row.allocatedDelta > 0 {
+                grossIncreasedAllocatedSize += row.allocatedDelta
+            } else if row.allocatedDelta < 0 {
+                grossReclaimedAllocatedSize += -row.allocatedDelta
+            }
         }
         self.addedCount = counts[.added, default: 0]
         self.removedCount = counts[.removed, default: 0]
         self.grewCount = counts[.grew, default: 0]
         self.shrankCount = counts[.shrank, default: 0]
+        self.movedCount = counts[.moved, default: 0]
+        self.grossIncreasedAllocatedSize = grossIncreasedAllocatedSize
+        self.grossReclaimedAllocatedSize = grossReclaimedAllocatedSize
     }
 
     var allocatedDelta: Int64 {
@@ -123,7 +143,15 @@ nonisolated struct ScanComparisonSummary: Equatable, Sendable {
     }
 
     var changedCount: Int {
-        addedCount + removedCount + grewCount + shrankCount
+        addedCount + removedCount + grewCount + shrankCount + movedCount
+    }
+
+    /// Net allocated change that can be attributed to final comparison rows.
+    ///
+    /// This can differ from `allocatedDelta` when incomplete scan coverage suppresses uncertain
+    /// additions or removals.
+    var attributedAllocatedDelta: Int64 {
+        grossIncreasedAllocatedSize - grossReclaimedAllocatedSize
     }
 }
 
@@ -143,6 +171,11 @@ nonisolated struct ScanComparisonRow: Identifiable, Equatable, Sendable {
     let beforeDescendantFileCount: Int?
     let afterDescendantFileCount: Int?
     let lastModified: Date?
+    /// The former relative path for an unambiguous file move or rename.
+    ///
+    /// A non-`nil` value is only produced when the same `FileIdentity` appears exactly once
+    /// among the visible removed paths and exactly once among the visible added paths.
+    let movedFromRelativePath: String?
 
     init(
         relativePath: String,
@@ -150,10 +183,15 @@ nonisolated struct ScanComparisonRow: Identifiable, Equatable, Sendable {
         beforeNode: FileNodeRecord?,
         afterNode: FileNodeRecord?,
         beforeAllocatedSize: Int64? = nil,
-        afterAllocatedSize: Int64? = nil
+        afterAllocatedSize: Int64? = nil,
+        movedFromRelativePath: String? = nil
     ) {
         let displayNode = afterNode ?? beforeNode
-        self.id = "\(kind.rawValue):\(relativePath)"
+        self.id = if let movedFromRelativePath {
+            "\(kind.rawValue):\(movedFromRelativePath)->\(relativePath)"
+        } else {
+            "\(kind.rawValue):\(relativePath)"
+        }
         self.relativePath = relativePath
         self.name = displayNode?.name ?? URL(filePath: relativePath).lastPathComponent
         self.kind = kind
@@ -168,6 +206,7 @@ nonisolated struct ScanComparisonRow: Identifiable, Equatable, Sendable {
         self.beforeDescendantFileCount = beforeNode?.descendantFileCount
         self.afterDescendantFileCount = afterNode?.descendantFileCount
         self.lastModified = afterNode?.lastModified ?? beforeNode?.lastModified
+        self.movedFromRelativePath = movedFromRelativePath
     }
 
     var allocatedDelta: Int64 {
@@ -189,19 +228,146 @@ nonisolated struct ScanComparisonRow: Identifiable, Equatable, Sendable {
     }
 }
 
+/// A non-overlapping, top-level attribution of the comparison rows.
+///
+/// Each final comparison row belongs to exactly one location: its first relative-path
+/// component. This lets the UI rank locations without summing a directory and its changed
+/// descendants twice. A move belongs to its destination location.
+nonisolated struct ScanComparisonLocationChange: Identifiable, Equatable, Sendable {
+    let id: String
+    let relativePath: String
+    let name: String
+    let allocatedDelta: Int64
+    let addedCount: Int
+    let removedCount: Int
+    let grewCount: Int
+    let shrankCount: Int
+    let movedCount: Int
+    /// A changed row within this location, chosen by the largest absolute allocated delta.
+    let representativeRelativePath: String
+    /// The node at `relativePath` in the before snapshot, when it was indexed.
+    let beforeNode: FileNodeRecord?
+    /// The node at `relativePath` in the after snapshot, when it was indexed.
+    let afterNode: FileNodeRecord?
+
+    var changedCount: Int {
+        addedCount + removedCount + grewCount + shrankCount + movedCount
+    }
+
+    var absoluteAllocatedDelta: Int64 {
+        abs(allocatedDelta)
+    }
+
+    /// Prefer the current node so an overview can navigate to the location in the active scan.
+    var fileURL: URL? {
+        (afterNode ?? beforeNode)?.url
+    }
+}
+
+nonisolated enum ScanComparisonConfidence: String, Equatable, Sendable {
+    /// Both scans are complete, target the same root, use matching known options, and report
+    /// no scan warnings.
+    case high
+    /// The comparison is usable, but warning coverage or unknown scan options limit certainty.
+    case limited
+    /// A fundamental mismatch means the result should be treated as forensic, not a baseline.
+    case low
+}
+
+nonisolated enum ScanComparisonCoverageIssue: Hashable, Sendable {
+    case differentTargets
+    case differentScanOptions
+    case unknownScanOptions
+    case beforeIncomplete
+    case afterIncomplete
+    case beforeWarnings(Int)
+    case afterWarnings(Int)
+}
+
+/// Facts about whether two snapshots cover comparable filesystem state.
+///
+/// This is deliberately descriptive rather than blocking: callers can reserve low-confidence
+/// comparisons for an advanced workflow while still explaining why the result is uncertain.
+nonisolated struct ScanComparisonCoverage: Equatable, Sendable {
+    let confidence: ScanComparisonConfidence
+    let issues: [ScanComparisonCoverageIssue]
+    let beforeWarningCount: Int
+    let afterWarningCount: Int
+    let targetsMatch: Bool
+    let scanOptionsMatch: Bool?
+    let beforeIsComplete: Bool
+    let afterIsComplete: Bool
+
+    init(before: ScanSnapshot, after: ScanSnapshot) {
+        self.beforeWarningCount = before.scanWarnings.count
+        self.afterWarningCount = after.scanWarnings.count
+        self.targetsMatch = before.target.id == after.target.id
+        self.beforeIsComplete = before.isComplete
+        self.afterIsComplete = after.isComplete
+
+        switch (before.scanOptions, after.scanOptions) {
+        case let (beforeOptions?, afterOptions?):
+            self.scanOptionsMatch = beforeOptions == afterOptions
+        default:
+            self.scanOptionsMatch = nil
+        }
+
+        var issues: [ScanComparisonCoverageIssue] = []
+        if !targetsMatch {
+            issues.append(.differentTargets)
+        }
+        if scanOptionsMatch == false {
+            issues.append(.differentScanOptions)
+        } else if scanOptionsMatch == nil {
+            issues.append(.unknownScanOptions)
+        }
+        if !beforeIsComplete {
+            issues.append(.beforeIncomplete)
+        }
+        if !afterIsComplete {
+            issues.append(.afterIncomplete)
+        }
+        if beforeWarningCount > 0 {
+            issues.append(.beforeWarnings(beforeWarningCount))
+        }
+        if afterWarningCount > 0 {
+            issues.append(.afterWarnings(afterWarningCount))
+        }
+        self.issues = issues
+
+        if !targetsMatch || scanOptionsMatch == false || !beforeIsComplete || !afterIsComplete {
+            self.confidence = .low
+        } else if !issues.isEmpty {
+            self.confidence = .limited
+        } else {
+            self.confidence = .high
+        }
+    }
+}
+
 nonisolated struct ScanComparison: Identifiable, Equatable, Sendable {
     let id: UUID
     let before: ComparedSnapshotSummary
     let after: ComparedSnapshotSummary
     let summary: ScanComparisonSummary
+    let coverage: ScanComparisonCoverage
     let rows: [ScanComparisonRow]
+    /// Non-overlapping first-level locations derived from `rows`, ordered by impact.
+    let topLevelChanges: [ScanComparisonLocationChange]
 
-    init(beforeSnapshot: ScanSnapshot, afterSnapshot: ScanSnapshot, rows: [ScanComparisonRow]) {
+    init(
+        beforeSnapshot: ScanSnapshot,
+        afterSnapshot: ScanSnapshot,
+        rows: [ScanComparisonRow],
+        topLevelChanges: [ScanComparisonLocationChange]
+    ) {
         self.id = UUID()
         self.before = ComparedSnapshotSummary(snapshot: beforeSnapshot)
         self.after = ComparedSnapshotSummary(snapshot: afterSnapshot)
         self.rows = rows
         self.summary = ScanComparisonSummary(before: beforeSnapshot, after: afterSnapshot, rows: rows)
+        self.coverage = ScanComparisonCoverage(before: beforeSnapshot, after: afterSnapshot)
+        self.topLevelChanges = topLevelChanges
     }
 }
 
@@ -229,12 +395,49 @@ nonisolated struct ScanComparisonService: Sendable {
             beforeNodes: beforeNodes,
             afterNodes: afterNodes
         )
+        let visibleAddedPaths = Set(addedPaths.filter { relativePath in
+            !Self.hasAncestor(of: relativePath, in: addedPaths)
+                && !Self.hasAncestor(of: relativePath, in: materializationBoundaryPaths)
+        })
+        let visibleRemovedPaths = Set(removedPaths.filter { relativePath in
+            !Self.hasAncestor(of: relativePath, in: removedPaths)
+                && !Self.hasAncestor(of: relativePath, in: materializationBoundaryPaths)
+        })
+        let warningBoundaries = Self.warningBoundaryPaths(in: before)
+            .union(Self.warningBoundaryPaths(in: after))
+        // A warning represents unknown coverage, never proof that a path was created or
+        // deleted. Suppress a collapsed ancestor row too when it contains a warning boundary.
+        let coveredAddedPaths = Set(visibleAddedPaths.filter { relativePath in
+            !Self.overlapsWarningBoundary(relativePath: relativePath, boundaries: warningBoundaries)
+        })
+        let coveredRemovedPaths = Set(visibleRemovedPaths.filter { relativePath in
+            !Self.overlapsWarningBoundary(relativePath: relativePath, boundaries: warningBoundaries)
+        })
+        let movedPathPairs = Self.movedPathPairs(
+            beforeNodes: beforeNodes,
+            afterNodes: afterNodes,
+            removedPaths: coveredRemovedPaths,
+            addedPaths: coveredAddedPaths
+        )
+        let movedRemovedPaths = Set(movedPathPairs.map(\.beforeRelativePath))
+        let movedAddedPaths = Set(movedPathPairs.map(\.afterRelativePath))
 
         rows.reserveCapacity(addedPaths.count + removedPaths.count + sharedPaths.count)
 
-        for relativePath in addedPaths
-        where !Self.hasAncestor(of: relativePath, in: addedPaths)
-            && !Self.hasAncestor(of: relativePath, in: materializationBoundaryPaths) {
+        for movedPathPair in movedPathPairs {
+            try Task.checkCancellation()
+            rows.append(ScanComparisonRow(
+                relativePath: movedPathPair.afterRelativePath,
+                kind: .moved,
+                beforeNode: beforeNodes[movedPathPair.beforeRelativePath],
+                afterNode: afterNodes[movedPathPair.afterRelativePath],
+                beforeAllocatedSize: allocatedSizes.before[movedPathPair.beforeRelativePath],
+                afterAllocatedSize: allocatedSizes.after[movedPathPair.afterRelativePath],
+                movedFromRelativePath: movedPathPair.beforeRelativePath
+            ))
+        }
+
+        for relativePath in coveredAddedPaths.subtracting(movedAddedPaths) {
             try Task.checkCancellation()
             rows.append(ScanComparisonRow(
                 relativePath: relativePath,
@@ -245,9 +448,7 @@ nonisolated struct ScanComparisonService: Sendable {
             ))
         }
 
-        for relativePath in removedPaths
-        where !Self.hasAncestor(of: relativePath, in: removedPaths)
-            && !Self.hasAncestor(of: relativePath, in: materializationBoundaryPaths) {
+        for relativePath in coveredRemovedPaths.subtracting(movedRemovedPaths) {
             try Task.checkCancellation()
             rows.append(ScanComparisonRow(
                 relativePath: relativePath,
@@ -264,15 +465,25 @@ nonisolated struct ScanComparisonService: Sendable {
                   let afterNode = afterNodes[relativePath] else {
                 continue
             }
-            // A directory whose allocated size is the aggregate of indexed descendants has
-            // its grew/shrank delta already accounted for by the leaf rows beneath it, so
-            // emitting the directory too would spam a redundant row for every ancestor of
-            // every changed file. But a leaf-like directory — an auto-summarized subtree or
-            // a package collapsed to a single node — has no indexed children and therefore
-            // no descendant rows, so its change must be reported here or it becomes invisible.
+            // A normal materialized directory's aggregate is already represented by descendant
+            // additions, removals, and size changes. This includes a directory that was empty
+            // in one snapshot and gained or lost indexed children in the other; emitting its
+            // aggregate too would double-count those child rows. Opaque leaf directories remain
+            // direct evidence because their descendants were not indexed.
+            let beforeHasIndexedChildren = before.treeStore.containsChildren(id: beforeNode.id)
+            let afterHasIndexedChildren = after.treeStore.containsChildren(id: afterNode.id)
+            let beforeIsOpaque = Self.isOpaqueDirectory(
+                beforeNode,
+                hasIndexedChildren: beforeHasIndexedChildren
+            )
+            let afterIsOpaque = Self.isOpaqueDirectory(
+                afterNode,
+                hasIndexedChildren: afterHasIndexedChildren
+            )
             let isRedundantDirectory = beforeNode.isDirectory && afterNode.isDirectory
-                && before.treeStore.containsChildren(id: beforeNode.id)
-                && after.treeStore.containsChildren(id: afterNode.id)
+                && !beforeIsOpaque
+                && !afterIsOpaque
+                && (beforeHasIndexedChildren || afterHasIndexedChildren)
             guard !isRedundantDirectory else { continue }
             let beforeAllocatedSize = allocatedSizes.before[relativePath] ?? beforeNode.allocatedSize
             let afterAllocatedSize = allocatedSizes.after[relativePath] ?? afterNode.allocatedSize
@@ -292,7 +503,17 @@ nonisolated struct ScanComparisonService: Sendable {
         let sortedRows = rows.sorted { lhs, rhs in
             ScanComparisonRowComparator.defaultOrder.compare(lhs, rhs) == .orderedAscending
         }
-        return ScanComparison(beforeSnapshot: before, afterSnapshot: after, rows: sortedRows)
+        let topLevelChanges = Self.topLevelChanges(
+            from: sortedRows,
+            beforeNodes: beforeNodes,
+            afterNodes: afterNodes
+        )
+        return ScanComparison(
+            beforeSnapshot: before,
+            afterSnapshot: after,
+            rows: sortedRows,
+            topLevelChanges: topLevelChanges
+        )
     }
 
     private static func indexedNodes(in snapshot: ScanSnapshot) throws -> [String: FileNodeRecord] {
@@ -334,6 +555,149 @@ nonisolated struct ScanComparisonService: Sendable {
             }
         }
         return false
+    }
+
+    private struct MovedPathPair: Sendable {
+        let beforeRelativePath: String
+        let afterRelativePath: String
+    }
+
+    /// Matches only a one-to-one regular-file identity that is visible as both a removal and an
+    /// addition. Hard links, directories, aliases, and synthetic nodes are intentionally
+    /// excluded because a path-level move inference would be ambiguous for them.
+    private static func movedPathPairs(
+        beforeNodes: [String: FileNodeRecord],
+        afterNodes: [String: FileNodeRecord],
+        removedPaths: Set<String>,
+        addedPaths: Set<String>
+    ) -> [MovedPathPair] {
+        let removedCandidates = moveCandidates(in: beforeNodes, paths: removedPaths)
+        let addedCandidates = moveCandidates(in: afterNodes, paths: addedPaths)
+        let removedByIdentity = Dictionary(grouping: removedCandidates, by: \.identity)
+        let addedByIdentity = Dictionary(grouping: addedCandidates, by: \.identity)
+
+        return removedByIdentity.compactMap { identity, removedEntries in
+            guard removedEntries.count == 1,
+                  let addedEntries = addedByIdentity[identity],
+                  addedEntries.count == 1,
+                  let beforeRelativePath = removedEntries.first?.relativePath,
+                  let afterRelativePath = addedEntries.first?.relativePath else {
+                return nil
+            }
+            return MovedPathPair(
+                beforeRelativePath: beforeRelativePath,
+                afterRelativePath: afterRelativePath
+            )
+        }
+        .sorted { lhs, rhs in
+            lhs.afterRelativePath.localizedStandardCompare(rhs.afterRelativePath) == .orderedAscending
+        }
+    }
+
+    private static func moveCandidates(
+        in nodes: [String: FileNodeRecord],
+        paths: Set<String>
+    ) -> [(identity: FileIdentity, relativePath: String)] {
+        paths.compactMap { relativePath in
+            guard let node = nodes[relativePath],
+                  let identity = moveIdentity(for: node) else {
+                return nil
+            }
+            return (identity, relativePath)
+        }
+    }
+
+    private static func moveIdentity(for node: FileNodeRecord) -> FileIdentity? {
+        guard !node.isDirectory,
+              !node.isSymbolicLink,
+              !node.isSynthetic,
+              node.linkCount == 1 else {
+            return nil
+        }
+        return node.fileIdentity
+    }
+
+    private static func topLevelChanges(
+        from rows: [ScanComparisonRow],
+        beforeNodes: [String: FileNodeRecord],
+        afterNodes: [String: FileNodeRecord]
+    ) -> [ScanComparisonLocationChange] {
+        let rowsByLocation = Dictionary(grouping: rows) { row in
+            topLevelPath(for: row.relativePath)
+        }
+
+        return rowsByLocation.compactMap { relativePath, locationRows in
+            guard let representativeRow = locationRows.sorted(by: {
+                ScanComparisonRowComparator.defaultOrder.compare($0, $1) == .orderedAscending
+            }).first else {
+                return nil
+            }
+
+            var counts: [ScanComparisonChangeKind: Int] = [:]
+            var allocatedDelta: Int64 = 0
+            for row in locationRows {
+                counts[row.kind, default: 0] += 1
+                allocatedDelta += row.allocatedDelta
+            }
+
+            let beforeNode = beforeNodes[relativePath]
+            let afterNode = afterNodes[relativePath]
+            let displayNode = afterNode ?? beforeNode
+            return ScanComparisonLocationChange(
+                id: relativePath,
+                relativePath: relativePath,
+                name: displayNode?.name ?? URL(filePath: relativePath).lastPathComponent,
+                allocatedDelta: allocatedDelta,
+                addedCount: counts[.added, default: 0],
+                removedCount: counts[.removed, default: 0],
+                grewCount: counts[.grew, default: 0],
+                shrankCount: counts[.shrank, default: 0],
+                movedCount: counts[.moved, default: 0],
+                representativeRelativePath: representativeRow.relativePath,
+                beforeNode: beforeNode,
+                afterNode: afterNode
+            )
+        }
+        .sorted { lhs, rhs in
+            if lhs.absoluteAllocatedDelta != rhs.absoluteAllocatedDelta {
+                return lhs.absoluteAllocatedDelta > rhs.absoluteAllocatedDelta
+            }
+            return lhs.relativePath.localizedStandardCompare(rhs.relativePath) == .orderedAscending
+        }
+    }
+
+    private static func topLevelPath(for relativePath: String) -> String {
+        guard let slashIndex = relativePath.firstIndex(of: "/") else {
+            return relativePath
+        }
+        return String(relativePath[..<slashIndex])
+    }
+
+    private static func warningBoundaryPaths(in snapshot: ScanSnapshot) -> Set<String> {
+        Set(snapshot.scanWarnings.compactMap { warning in
+            relativeWarningPath(warning.path, rootID: snapshot.treeStore.rootID)
+        })
+    }
+
+    private static func relativeWarningPath(_ warningPath: String, rootID: String) -> String? {
+        guard warningPath == rootID else {
+            return relativePath(for: warningPath, rootID: rootID)
+        }
+        // An empty relative path represents a warning at the scan root and therefore affects
+        // every addition/removal in the snapshot.
+        return ""
+    }
+
+    private static func overlapsWarningBoundary(
+        relativePath: String,
+        boundaries: Set<String>
+    ) -> Bool {
+        boundaries.contains { boundary in
+            guard !boundary.isEmpty else { return true }
+            return relativePath == boundary
+                || relativePath.hasPrefix(boundary + "/")
+                || boundary.hasPrefix(relativePath + "/")
+        }
     }
 
     private static func materializationBoundaryPaths(
@@ -539,6 +903,20 @@ nonisolated struct ScanComparisonRowQuery: Equatable, Sendable {
     let changeKind: ScanComparisonChangeKind?
     let searchText: String
     let sortOrder: [ScanComparisonRowComparator]
+    /// Limits evidence to one top-level contributor while retaining its full descendant rows.
+    let pathPrefix: String?
+
+    init(
+        changeKind: ScanComparisonChangeKind?,
+        searchText: String,
+        sortOrder: [ScanComparisonRowComparator],
+        pathPrefix: String? = nil
+    ) {
+        self.changeKind = changeKind
+        self.searchText = searchText
+        self.sortOrder = sortOrder
+        self.pathPrefix = pathPrefix
+    }
 
     func applying(to rows: [ScanComparisonRow]) -> [ScanComparisonRow] {
         let query = SearchNormalizer.normalize(
@@ -546,6 +924,11 @@ nonisolated struct ScanComparisonRowQuery: Equatable, Sendable {
         )
         let filteredRows = rows.filter { row in
             guard changeKind == nil || row.kind == changeKind else { return false }
+            if let pathPrefix, !pathPrefix.isEmpty {
+                guard row.relativePath == pathPrefix || row.relativePath.hasPrefix(pathPrefix + "/") else {
+                    return false
+                }
+            }
             guard !query.isEmpty else { return true }
             return SearchNormalizer.normalize(row.name).contains(query)
                 || SearchNormalizer.normalize(row.relativePath).contains(query)

--- a/Radix/Services/ScanComparisonService.swift
+++ b/Radix/Services/ScanComparisonService.swift
@@ -1,0 +1,371 @@
+//
+//  ScanComparisonService.swift
+//  Radix
+//
+
+import Foundation
+
+nonisolated struct ComparedSnapshotSummary: Equatable, Sendable {
+    let id: UUID
+    let displayName: String
+    let rootPath: String
+    let startedAt: Date
+    let finishedAt: Date?
+    let sourceURL: URL?
+
+    init(snapshot: ScanSnapshot) {
+        self.id = snapshot.id
+        self.displayName = snapshot.target.displayName
+        self.rootPath = snapshot.target.url.path
+        self.startedAt = snapshot.startedAt
+        self.finishedAt = snapshot.finishedAt
+        if case .imported(let context) = snapshot.source {
+            self.sourceURL = context.sourceURL
+        } else {
+            self.sourceURL = nil
+        }
+    }
+
+    var comparisonDate: Date {
+        finishedAt ?? startedAt
+    }
+}
+
+nonisolated enum ScanComparisonChangeKind: String, CaseIterable, Sendable {
+    case added
+    case removed
+    case grew
+    case shrank
+
+    var title: String {
+        switch self {
+        case .added:
+            return "Added"
+        case .removed:
+            return "Removed"
+        case .grew:
+            return "Grew"
+        case .shrank:
+            return "Shrank"
+        }
+    }
+
+    var sortRank: Int {
+        switch self {
+        case .added:
+            return 0
+        case .removed:
+            return 1
+        case .grew:
+            return 2
+        case .shrank:
+            return 3
+        }
+    }
+}
+
+nonisolated struct ScanComparisonSummary: Equatable, Sendable {
+    let beforeAllocatedSize: Int64
+    let afterAllocatedSize: Int64
+    let beforeLogicalSize: Int64
+    let afterLogicalSize: Int64
+    let beforeFileCount: Int
+    let afterFileCount: Int
+    let beforeDirectoryCount: Int
+    let afterDirectoryCount: Int
+    let beforeWarningCount: Int
+    let afterWarningCount: Int
+    let addedCount: Int
+    let removedCount: Int
+    let grewCount: Int
+    let shrankCount: Int
+
+    init(before: ScanSnapshot, after: ScanSnapshot, rows: [ScanComparisonRow]) {
+        self.beforeAllocatedSize = before.aggregateStats.totalAllocatedSize
+        self.afterAllocatedSize = after.aggregateStats.totalAllocatedSize
+        self.beforeLogicalSize = before.aggregateStats.totalLogicalSize
+        self.afterLogicalSize = after.aggregateStats.totalLogicalSize
+        self.beforeFileCount = before.aggregateStats.fileCount
+        self.afterFileCount = after.aggregateStats.fileCount
+        self.beforeDirectoryCount = before.aggregateStats.directoryCount
+        self.afterDirectoryCount = after.aggregateStats.directoryCount
+        self.beforeWarningCount = before.scanWarnings.count
+        self.afterWarningCount = after.scanWarnings.count
+
+        var counts: [ScanComparisonChangeKind: Int] = [:]
+        for row in rows {
+            counts[row.kind, default: 0] += 1
+        }
+        self.addedCount = counts[.added, default: 0]
+        self.removedCount = counts[.removed, default: 0]
+        self.grewCount = counts[.grew, default: 0]
+        self.shrankCount = counts[.shrank, default: 0]
+    }
+
+    var allocatedDelta: Int64 {
+        afterAllocatedSize - beforeAllocatedSize
+    }
+
+    var logicalDelta: Int64 {
+        afterLogicalSize - beforeLogicalSize
+    }
+
+    var fileCountDelta: Int {
+        afterFileCount - beforeFileCount
+    }
+
+    var directoryCountDelta: Int {
+        afterDirectoryCount - beforeDirectoryCount
+    }
+
+    var warningCountDelta: Int {
+        afterWarningCount - beforeWarningCount
+    }
+
+    var changedCount: Int {
+        addedCount + removedCount + grewCount + shrankCount
+    }
+}
+
+nonisolated struct ScanComparisonRow: Identifiable, Equatable, Sendable {
+    let id: String
+    let relativePath: String
+    let name: String
+    let kind: ScanComparisonChangeKind
+    let beforeNode: FileNodeRecord?
+    let afterNode: FileNodeRecord?
+    let beforeAllocatedSize: Int64?
+    let afterAllocatedSize: Int64?
+    let beforeLogicalSize: Int64?
+    let afterLogicalSize: Int64?
+    let isDirectory: Bool
+    let itemKind: String
+    let beforeDescendantFileCount: Int?
+    let afterDescendantFileCount: Int?
+    let lastModified: Date?
+
+    init(
+        relativePath: String,
+        kind: ScanComparisonChangeKind,
+        beforeNode: FileNodeRecord?,
+        afterNode: FileNodeRecord?
+    ) {
+        let displayNode = afterNode ?? beforeNode
+        self.id = "\(kind.rawValue):\(relativePath)"
+        self.relativePath = relativePath
+        self.name = displayNode?.name ?? URL(filePath: relativePath).lastPathComponent
+        self.kind = kind
+        self.beforeNode = beforeNode
+        self.afterNode = afterNode
+        self.beforeAllocatedSize = beforeNode?.allocatedSize
+        self.afterAllocatedSize = afterNode?.allocatedSize
+        self.beforeLogicalSize = beforeNode?.logicalSize
+        self.afterLogicalSize = afterNode?.logicalSize
+        self.isDirectory = displayNode?.isDirectory ?? false
+        self.itemKind = displayNode?.itemKind ?? "Item"
+        self.beforeDescendantFileCount = beforeNode?.descendantFileCount
+        self.afterDescendantFileCount = afterNode?.descendantFileCount
+        self.lastModified = afterNode?.lastModified ?? beforeNode?.lastModified
+    }
+
+    var allocatedDelta: Int64 {
+        (afterAllocatedSize ?? 0) - (beforeAllocatedSize ?? 0)
+    }
+
+    var logicalDelta: Int64 {
+        (afterLogicalSize ?? 0) - (beforeLogicalSize ?? 0)
+    }
+
+    var absoluteAllocatedDelta: Int64 {
+        abs(allocatedDelta)
+    }
+
+    /// The filesystem location this row points at — the after node when present (added, grew,
+    /// shrank), otherwise the before node (removed). Used for Finder reveal and path copy.
+    var fileURL: URL? {
+        (afterNode ?? beforeNode)?.url
+    }
+}
+
+nonisolated struct ScanComparison: Identifiable, Equatable, Sendable {
+    let id: UUID
+    let before: ComparedSnapshotSummary
+    let after: ComparedSnapshotSummary
+    let summary: ScanComparisonSummary
+    let rows: [ScanComparisonRow]
+
+    init(beforeSnapshot: ScanSnapshot, afterSnapshot: ScanSnapshot, rows: [ScanComparisonRow]) {
+        self.id = UUID()
+        self.before = ComparedSnapshotSummary(snapshot: beforeSnapshot)
+        self.after = ComparedSnapshotSummary(snapshot: afterSnapshot)
+        self.rows = rows
+        self.summary = ScanComparisonSummary(before: beforeSnapshot, after: afterSnapshot, rows: rows)
+    }
+}
+
+nonisolated struct ScanComparisonService: Sendable {
+    func compare(before: ScanSnapshot, after: ScanSnapshot) async throws -> ScanComparison {
+        try Task.checkCancellation()
+        let beforeNodes = try Self.indexedNodes(in: before)
+        let afterNodes = try Self.indexedNodes(in: after)
+        try Task.checkCancellation()
+
+        var rows: [ScanComparisonRow] = []
+        let beforePaths = Set(beforeNodes.keys)
+        let afterPaths = Set(afterNodes.keys)
+        let addedPaths = afterPaths.subtracting(beforePaths)
+        let removedPaths = beforePaths.subtracting(afterPaths)
+        let sharedPaths = beforePaths.intersection(afterPaths)
+
+        rows.reserveCapacity(addedPaths.count + removedPaths.count + sharedPaths.count)
+
+        for relativePath in addedPaths where !Self.hasAncestor(of: relativePath, in: addedPaths) {
+            try Task.checkCancellation()
+            rows.append(ScanComparisonRow(
+                relativePath: relativePath,
+                kind: .added,
+                beforeNode: nil,
+                afterNode: afterNodes[relativePath]
+            ))
+        }
+
+        for relativePath in removedPaths where !Self.hasAncestor(of: relativePath, in: removedPaths) {
+            try Task.checkCancellation()
+            rows.append(ScanComparisonRow(
+                relativePath: relativePath,
+                kind: .removed,
+                beforeNode: beforeNodes[relativePath],
+                afterNode: nil
+            ))
+        }
+
+        for relativePath in sharedPaths {
+            try Task.checkCancellation()
+            guard let beforeNode = beforeNodes[relativePath],
+                  let afterNode = afterNodes[relativePath] else {
+                continue
+            }
+            // A directory whose allocated size is the aggregate of indexed descendants has
+            // its grew/shrank delta already accounted for by the leaf rows beneath it, so
+            // emitting the directory too would spam a redundant row for every ancestor of
+            // every changed file. But a leaf-like directory — an auto-summarized subtree or
+            // a package collapsed to a single node — has no indexed children and therefore
+            // no descendant rows, so its change must be reported here or it becomes invisible.
+            let isRedundantDirectory = beforeNode.isDirectory && afterNode.isDirectory
+                && before.treeStore.containsChildren(id: beforeNode.id)
+                && after.treeStore.containsChildren(id: afterNode.id)
+            guard !isRedundantDirectory else { continue }
+            let delta = afterNode.allocatedSize - beforeNode.allocatedSize
+            guard delta != 0 else { continue }
+            rows.append(ScanComparisonRow(
+                relativePath: relativePath,
+                kind: delta > 0 ? .grew : .shrank,
+                beforeNode: beforeNode,
+                afterNode: afterNode
+            ))
+        }
+
+        try Task.checkCancellation()
+        let sortedRows = rows.sorted { lhs, rhs in
+            ScanComparisonRowComparator.defaultOrder.compare(lhs, rhs) == .orderedAscending
+        }
+        return ScanComparison(beforeSnapshot: before, afterSnapshot: after, rows: sortedRows)
+    }
+
+    private static func indexedNodes(in snapshot: ScanSnapshot) throws -> [String: FileNodeRecord] {
+        var nodesByRelativePath: [String: FileNodeRecord] = [:]
+        nodesByRelativePath.reserveCapacity(max(snapshot.treeStore.nodeCount - 1, 0))
+
+        try snapshot.treeStore.forEachIndexedNodeID(excludingRoot: true) { nodeID in
+            try Task.checkCancellation()
+            guard let node = snapshot.treeStore.node(id: nodeID),
+                  let relativePath = Self.relativePath(for: node.id, rootID: snapshot.treeStore.rootID) else {
+                return
+            }
+            nodesByRelativePath[relativePath] = node
+        }
+
+        return nodesByRelativePath
+    }
+
+    static func relativePath(for nodeID: String, rootID: String) -> String? {
+        guard nodeID != rootID else { return nil }
+
+        if rootID == "/" {
+            let relativePath = nodeID.trimmingPrefix("/")
+            return relativePath.isEmpty ? nil : relativePath
+        }
+
+        let rootPrefix = rootID.hasSuffix("/") ? rootID : rootID + "/"
+        guard nodeID.hasPrefix(rootPrefix) else { return nil }
+        let relativePath = String(nodeID.dropFirst(rootPrefix.count))
+        return relativePath.isEmpty ? nil : relativePath
+    }
+
+    private static func hasAncestor(of relativePath: String, in paths: Set<String>) -> Bool {
+        var cursor = relativePath
+        while let slashIndex = cursor.lastIndex(of: "/") {
+            cursor = String(cursor[..<slashIndex])
+            if paths.contains(cursor) {
+                return true
+            }
+        }
+        return false
+    }
+}
+
+nonisolated struct ScanComparisonRowComparator: Equatable, SortComparator, Sendable {
+    enum Field: Equatable, Sendable {
+        case changeKind
+        case relativePath
+        case beforeAllocatedSize
+        case afterAllocatedSize
+        case allocatedDelta
+        case absoluteAllocatedDelta
+        case itemKind
+    }
+
+    static let defaultOrder = ScanComparisonRowComparator(field: .absoluteAllocatedDelta, order: .reverse)
+
+    let field: Field
+    var order: SortOrder = .forward
+
+    func compare(_ lhs: ScanComparisonRow, _ rhs: ScanComparisonRow) -> ComparisonResult {
+        let result: ComparisonResult = switch field {
+        case .changeKind:
+            FileNodeSortComparison.compare(lhs.kind.sortRank, rhs.kind.sortRank)
+        case .relativePath:
+            lhs.relativePath.localizedStandardCompare(rhs.relativePath)
+        case .beforeAllocatedSize:
+            FileNodeSortComparison.compareOptional(lhs.beforeAllocatedSize, rhs.beforeAllocatedSize)
+        case .afterAllocatedSize:
+            FileNodeSortComparison.compareOptional(lhs.afterAllocatedSize, rhs.afterAllocatedSize)
+        case .allocatedDelta:
+            FileNodeSortComparison.compare(lhs.allocatedDelta, rhs.allocatedDelta)
+        case .absoluteAllocatedDelta:
+            FileNodeSortComparison.compare(lhs.absoluteAllocatedDelta, rhs.absoluteAllocatedDelta)
+        case .itemKind:
+            lhs.itemKind.localizedStandardCompare(rhs.itemKind)
+        }
+
+        let orderedResult = FileNodeSortComparison.applying(order, to: result)
+        switch orderedResult {
+        case .orderedSame:
+            return FileNodeSortComparison.fallback(
+                lhsName: lhs.name,
+                lhsID: lhs.relativePath,
+                rhsName: rhs.name,
+                rhsID: rhs.relativePath
+            )
+        default:
+            return orderedResult
+        }
+    }
+}
+
+private nonisolated extension String {
+    func trimmingPrefix(_ prefix: String) -> String {
+        guard hasPrefix(prefix) else { return self }
+        return String(dropFirst(prefix.count))
+    }
+}

--- a/Radix/Services/ScanEngine.swift
+++ b/Radix/Services/ScanEngine.swift
@@ -115,6 +115,11 @@ actor ScanEngine {
         #endif
     }
 
+    private struct ClassifiedDirectoryEntriesChunk: Sendable {
+        let index: Int
+        let entries: [DirectoryEntry]
+    }
+
     private struct DirectoryTraversalSuccess: Sendable {
         let item: ScanWorkItem
         let itemKey: Int
@@ -626,7 +631,7 @@ actor ScanEngine {
             )
         ]
         // Maps a key to its completed result (leaf or assembled directory).
-        var completedByKey: [Int: CompletedDirScan] = [:]
+        var completedByKey: [CompletedDirScan?] = []
         // Maps parent key → child keys, built during phase 1.
         var childrenKeysByKey: [Int: [Int]] = [:]
         var seenScannedNodeIDs = Set<String>()
@@ -655,6 +660,7 @@ actor ScanEngine {
 
                     let itemKey = nextKey
                     nextKey += 1
+                    completedByKey.append(nil)
 
                     // Register this child with its parent (skip root which has parentKey -1).
                     if item.parentKey >= 0 {
@@ -818,9 +824,14 @@ actor ScanEngine {
                     metrics.enumeratedDirectoryCount += 1
                     releasePendingDirectoryIfNeeded(for: item, metrics: &metrics)
                     var childDirectoryCount = 0
-                    for childEntry in childEntries
-                    where Self.isLikelyTraversableDirectory(entry: childEntry) {
-                        childDirectoryCount += 1
+                    var totalWeightUnits = 0.0
+                    for childEntry in childEntries {
+                        if Self.isLikelyTraversableDirectory(entry: childEntry) {
+                            childDirectoryCount += 1
+                            totalWeightUnits += Self.directoryChildWeightUnits
+                        } else {
+                            totalWeightUnits += 1
+                        }
                     }
                     metrics.discoveredDirectoryCount += childDirectoryCount
                     metrics.pendingDirectoryCount += childDirectoryCount
@@ -911,12 +922,6 @@ actor ScanEngine {
                         metrics.recalculateProgress()
                     }
 
-                    // Split this directory's progress weight among its children.
-                    var totalWeightUnits = 0.0
-                    for childEntry in childEntries {
-                        totalWeightUnits += Self.traversalWeightUnits(for: childEntry)
-                    }
-
                     // Enqueue children onto the stack. Each child records its parent key.
                     for (offset, childEntry) in childEntries.enumerated() {
                         if offset.isMultiple(of: 256) {
@@ -1003,12 +1008,11 @@ actor ScanEngine {
         let finalizationTotal = max(completedByKey.count, 1)
         let finalizationProgressInterval = 512
         var finalizedItems = 0
-        var resolvedNodeByKey: [Int: FileNodeRecord] = [:]
+        var resolvedNodeByKey = Array<FileNodeRecord?>(repeating: nil, count: nextKey)
         var childIDsByID: [String: [String]] = [:]
         var parentIDByID: [String: String] = [:]
         var nodesByID: [String: FileNodeRecord] = [:]
         var aggregateStats = AggregateStatsAccumulator()
-        resolvedNodeByKey.reserveCapacity(completedByKey.count)
         childIDsByID.reserveCapacity(completedByKey.count)
         parentIDByID.reserveCapacity(completedByKey.count)
         nodesByID.reserveCapacity(completedByKey.count)
@@ -1019,7 +1023,8 @@ actor ScanEngine {
             if finalizedItems.isMultiple(of: 256) {
                 try Task.checkCancellation()
             }
-            guard let completed = completedByKey.removeValue(forKey: key) else { continue }
+            guard let completed = completedByKey[key] else { continue }
+            completedByKey[key] = nil
             finalizedItems += 1
 
             if completed.isTraversable {
@@ -1031,23 +1036,53 @@ actor ScanEngine {
                     if offset.isMultiple(of: 256) {
                         try Task.checkCancellation()
                     }
-                    if let childNode = resolvedNodeByKey.removeValue(forKey: childKey) {
+                    if let childNode = resolvedNodeByKey[childKey] {
                         childNodes.append(childNode)
+                        resolvedNodeByKey[childKey] = nil
                     }
                 }
                 let sortedChildren = FileTreeStore.sortedChildren(Self.uniqueNodesForAssembly(childNodes))
                 try Task.checkCancellation()
-                let assembled = FileNodeRecord.directory(
-                    id: completed.url.path,
+                let directoryID = completed.url.path
+                var allocatedSize: Int64 = 0
+                var logicalSize: Int64 = 0
+                var descendantFileCount = 0
+                var childrenAreAccessible = true
+                var sortedChildIDs: [String] = []
+                sortedChildIDs.reserveCapacity(sortedChildren.count)
+                for (offset, child) in sortedChildren.enumerated() {
+                    if offset.isMultiple(of: 256) {
+                        try Task.checkCancellation()
+                    }
+                    allocatedSize += child.allocatedSize
+                    logicalSize += child.logicalSize
+                    childrenAreAccessible = childrenAreAccessible && child.isAccessible
+                    if child.isDirectory {
+                        descendantFileCount += child.descendantFileCount
+                    } else if !child.isSymbolicLink && !child.isSynthetic {
+                        descendantFileCount += 1
+                    }
+                    sortedChildIDs.append(child.id)
+                    parentIDByID[child.id] = directoryID
+                }
+
+                let assembled = FileNodeRecord(
+                    id: directoryID,
                     url: completed.url,
                     name: ScanTarget.displayName(for: completed.url),
-                    children: sortedChildren,
+                    isDirectory: true,
+                    isSymbolicLink: false,
+                    allocatedSize: allocatedSize,
+                    logicalSize: logicalSize,
+                    descendantFileCount: descendantFileCount,
                     lastModified: completed.metadata.lastModified,
                     fileIdentity: completed.metadata.fileIdentity,
                     linkCount: completed.metadata.linkCount,
                     isPackage: completed.metadata.isPackage,
-                    isAccessible: completed.metadata.isReadable,
-                    childrenAreSorted: true
+                    isAccessible: completed.metadata.isReadable && childrenAreAccessible,
+                    isSelfAccessible: completed.metadata.isReadable,
+                    isSynthetic: false,
+                    isAutoSummarized: false
                 )
                 if insertNode(
                     assembled,
@@ -1059,15 +1094,6 @@ actor ScanEngine {
                     aggregateStats.include(assembled, hasChildren: !sortedChildren.isEmpty)
                 }
 
-                var sortedChildIDs: [String] = []
-                sortedChildIDs.reserveCapacity(sortedChildren.count)
-                for (offset, child) in sortedChildren.enumerated() {
-                    if offset.isMultiple(of: 256) {
-                        try Task.checkCancellation()
-                    }
-                    sortedChildIDs.append(child.id)
-                    parentIDByID[child.id] = assembled.id
-                }
                 childIDsByID[assembled.id] = sortedChildIDs
 
                 metrics.completedItems = min(metrics.discoveredItems, metrics.completedItems + 1)
@@ -1247,7 +1273,7 @@ actor ScanEngine {
         warnings: inout [ScanWarning],
         continuation: AsyncThrowingStream<ScanProgressEvent, Error>.Continuation,
         emissionState: inout ScanEmissionState,
-        completedByKey: inout [Int: CompletedDirScan]
+        completedByKey: inout [CompletedDirScan?]
     ) {
         let isDirectory = Self.isLikelyTraversableDirectory(
             metadata: item.metadata,
@@ -1405,14 +1431,14 @@ actor ScanEngine {
               contents.count >= ScanConcurrencyPolicy.directoryClassificationParallelThreshold else {
             return try classifiedDirectoryEntries(
                 contents,
-                offset: 0,
+                range: contents.indices,
                 under: parentURL,
                 behavior: behavior,
                 exclusionMatcher: exclusionMatcher,
                 resourceKeys: resourceKeys,
                 metadataLoader: metadataLoader,
                 cancellationCheck: cancellationCheck
-            ).map(\.entry)
+            )
         }
 
         let workerCount = min(max(1, workerLimit), contents.count)
@@ -1420,19 +1446,20 @@ actor ScanEngine {
             ScanConcurrencyPolicy.directoryClassificationParallelThreshold,
             (contents.count + workerCount - 1) / workerCount
         )
-        var classifiedEntries: [(offset: Int, entry: DirectoryEntry)] = []
-        classifiedEntries.reserveCapacity(contents.count)
+        let chunkCount = (contents.count + chunkSize - 1) / chunkSize
+        var chunks = Array<[DirectoryEntry]?>(repeating: nil, count: chunkCount)
 
-        try await withThrowingTaskGroup(of: [(offset: Int, entry: DirectoryEntry)].self) { group in
+        try await withThrowingTaskGroup(of: ClassifiedDirectoryEntriesChunk.self) { group in
+            var chunkIndex = 0
             var chunkStart = 0
             while chunkStart < contents.count {
                 let chunkEnd = min(chunkStart + chunkSize, contents.count)
-                let chunk = Array(contents[chunkStart..<chunkEnd])
-                let offset = chunkStart
+                let range = chunkStart..<chunkEnd
+                let index = chunkIndex
                 group.addTask {
-                    try classifiedDirectoryEntries(
-                        chunk,
-                        offset: offset,
+                    let entries = try classifiedDirectoryEntries(
+                        contents,
+                        range: range,
                         under: parentURL,
                         behavior: behavior,
                         exclusionMatcher: exclusionMatcher,
@@ -1440,36 +1467,44 @@ actor ScanEngine {
                         metadataLoader: metadataLoader,
                         cancellationCheck: cancellationCheck
                     )
+                    return ClassifiedDirectoryEntriesChunk(index: index, entries: entries)
                 }
+                chunkIndex += 1
                 chunkStart = chunkEnd
             }
 
-            for try await chunkEntries in group {
-                classifiedEntries.append(contentsOf: chunkEntries)
+            for try await chunk in group {
+                chunks[chunk.index] = chunk.entries
             }
         }
 
-        classifiedEntries.sort { $0.offset < $1.offset }
-        return classifiedEntries.map(\.entry)
+        var entries: [DirectoryEntry] = []
+        entries.reserveCapacity(contents.count)
+        for chunk in chunks {
+            guard let chunk else { continue }
+            entries.append(contentsOf: chunk)
+        }
+        return entries
     }
 
     private nonisolated static func classifiedDirectoryEntries(
         _ contents: [URL],
-        offset: Int,
+        range: Range<Int>,
         under parentURL: URL,
         behavior: ScanBehavior,
         exclusionMatcher: ScanExclusionMatcher,
         resourceKeys: Set<URLResourceKey>,
         metadataLoader: ScanMetadataLoader,
         cancellationCheck: CancellationCheck
-    ) throws -> [(offset: Int, entry: DirectoryEntry)] {
-        var entries: [(offset: Int, entry: DirectoryEntry)] = []
-        entries.reserveCapacity(contents.count)
+    ) throws -> [DirectoryEntry] {
+        var entries: [DirectoryEntry] = []
+        entries.reserveCapacity(range.count)
 
-        for (localOffset, childURL) in contents.enumerated() {
-            if localOffset.isMultiple(of: 64) {
+        for index in range {
+            if index.isMultiple(of: 64) {
                 try cancellationCheck()
             }
+            let childURL = contents[index]
             guard includedChildURL(childURL, under: parentURL, behavior: behavior) else {
                 continue
             }
@@ -1485,7 +1520,7 @@ actor ScanEngine {
                 continue
             }
 
-            entries.append((offset + localOffset, DirectoryEntry(url: childURL, metadata: childMetadata)))
+            entries.append(DirectoryEntry(url: childURL, metadata: childMetadata))
         }
 
         try cancellationCheck()
@@ -1564,10 +1599,13 @@ actor ScanEngine {
                 url: url,
                 metadata: metadata
             )
+            let hardLinkClaim = metadata.linkCount > 1
+                ? HardLinkDeduplicator.claim(for: metadata, ownerNodeID: node.id, path: url.path)
+                : nil
             return (
                 node,
                 [],
-                HardLinkDeduplicator.claim(for: metadata, ownerNodeID: node.id, path: url.path).map { [$0] } ?? [],
+                hardLinkClaim.map { [$0] } ?? [],
                 nil
             )
         }
@@ -1588,10 +1626,13 @@ actor ScanEngine {
                 url: url,
                 metadata: metadata
             )
+            let hardLinkClaim = metadata.linkCount > 1
+                ? HardLinkDeduplicator.claim(for: metadata, ownerNodeID: node.id, path: url.path)
+                : nil
             return (
                 node,
                 [],
-                HardLinkDeduplicator.claim(for: metadata, ownerNodeID: node.id, path: url.path).map { [$0] } ?? [],
+                hardLinkClaim.map { [$0] } ?? [],
                 nil
             )
         }

--- a/Radix/Services/ScanExclusionMatcher.swift
+++ b/Radix/Services/ScanExclusionMatcher.swift
@@ -17,6 +17,7 @@ nonisolated struct ScanExclusionMatcher: Sendable {
     private let rootPath: String
     private let patterns: [CompiledPattern]
     private let cloudLocations: [CloudLocation]
+    private let hasActiveRule: Bool
 
     init(
         patterns: [String],
@@ -42,9 +43,8 @@ nonisolated struct ScanExclusionMatcher: Sendable {
         iCloudDriveRootPath: String = ScanOptions.defaultICloudDriveRootPath
     ) {
         let normalizedRootPath = Self.normalizedRootPath(rootPath)
-        self.rootPath = normalizedRootPath
-        self.patterns = Self.normalizedPatterns(patterns).compactMap(CompiledPattern.init(rawPattern:))
-        self.cloudLocations = [
+        let compiledPatterns = Self.normalizedPatterns(patterns).compactMap(CompiledPattern.init(rawPattern:))
+        let cloudLocations = [
             Self.cloudLocation(
                 configuredRootPath: cloudStorageRootPath,
                 userRelativeComponents: ["Library", "CloudStorage"],
@@ -58,10 +58,14 @@ nonisolated struct ScanExclusionMatcher: Sendable {
                 includeCloudStorage: includeCloudStorage
             )
         ]
+        self.rootPath = normalizedRootPath
+        self.patterns = compiledPatterns
+        self.cloudLocations = cloudLocations
+        self.hasActiveRule = !compiledPatterns.isEmpty || cloudLocations.contains { $0.isActive }
     }
 
     var isEmpty: Bool {
-        patterns.isEmpty && !cloudLocations.contains { $0.isActive }
+        !hasActiveRule
     }
 
     var hasUserExclusions: Bool {
@@ -69,6 +73,7 @@ nonisolated struct ScanExclusionMatcher: Sendable {
     }
 
     func excludes(_ url: URL, isDirectory: Bool) -> Bool {
+        guard hasActiveRule else { return false }
         let normalizedPath = url.standardizedFileURL.path
         return excludes(normalizedPath: normalizedPath, isDirectory: isDirectory)
     }

--- a/Radix/Services/ScanMetadataLoader.swift
+++ b/Radix/Services/ScanMetadataLoader.swift
@@ -273,21 +273,34 @@ nonisolated struct ScanMetadataLoader: Sendable {
             #endif
             throw error
         }
-        return metadata(for: url, prefetchedResourceValues: values)
+        return atomicSummaryMetadata(for: url, prefetchedResourceValues: values)
     }
 
     nonisolated func metadata(
         for url: URL,
         prefetchedResourceValues values: URLResourceValues,
-        includeVolumeDetails: Bool = false
+        includeVolumeDetails: Bool = false,
+        loadsSymbolicLinkFileSystemInfo: Bool = true
     ) -> NodeMetadata {
         Self.nodeMetadata(
             for: url,
             resourceValues: values,
             includeVolumeDetails: includeVolumeDetails,
+            loadsSymbolicLinkFileSystemInfo: loadsSymbolicLinkFileSystemInfo,
             diagnostics: diagnostics,
             linkCountCapabilityCache: linkCountCapabilityCache,
             fileSystemInfoProvider: fileSystemInfoProvider
+        )
+    }
+
+    nonisolated func atomicSummaryMetadata(
+        for url: URL,
+        prefetchedResourceValues values: URLResourceValues
+    ) -> NodeMetadata {
+        metadata(
+            for: url,
+            prefetchedResourceValues: values,
+            loadsSymbolicLinkFileSystemInfo: false
         )
     }
 
@@ -295,6 +308,7 @@ nonisolated struct ScanMetadataLoader: Sendable {
         for url: URL,
         resourceValues values: URLResourceValues,
         includeVolumeDetails: Bool = false,
+        loadsSymbolicLinkFileSystemInfo: Bool,
         diagnostics: ScanDiagnosticsContext? = nil,
         linkCountCapabilityCache: LinkCountCapabilityCache,
         fileSystemInfoProvider: FileSystemInfoProvider
@@ -307,7 +321,7 @@ nonisolated struct ScanMetadataLoader: Sendable {
         let isReadable = values.isReadable ?? false
         var fileIdentity = Self.fileIdentity(from: values.fileResourceIdentifier)
         var linkCount = values.linkCount.map(UInt64.init) ?? 1
-        if isSymbolicLink {
+        if isSymbolicLink && loadsSymbolicLinkFileSystemInfo {
             let fileSystemInfo = fileSystemInfoProvider(url, diagnostics)
             fileIdentity = fileSystemInfo.identity
             linkCount = fileSystemInfo.linkCount

--- a/Radix/Services/SystemIntegration.swift
+++ b/Radix/Services/SystemIntegration.swift
@@ -140,7 +140,7 @@ enum SystemIntegration {
     }
 
     @MainActor
-    static func presentComparisonSnapshotPanel() -> URL? {
+    static func presentComparisonSnapshotPanel() async -> URL? {
         let panel = NSOpenPanel()
         panel.allowedContentTypes = [radixScanArchiveContentType]
         panel.allowsMultipleSelection = false
@@ -150,10 +150,29 @@ enum SystemIntegration {
         panel.prompt = "Choose"
         panel.message = "Choose a Radix scan snapshot."
 
-        guard panel.runModal() == .OK else {
-            return nil
+        return await withCheckedContinuation { continuation in
+            let completionHandler: (NSApplication.ModalResponse) -> Void = { response in
+                let selectedURL = response == .OK ? panel.url : nil
+                DispatchQueue.main.async {
+                    continuation.resume(returning: selectedURL)
+                }
+            }
+
+            if let parentWindow = comparisonPanelParentWindow {
+                panel.beginSheetModal(for: parentWindow, completionHandler: completionHandler)
+            } else {
+                panel.begin(completionHandler: completionHandler)
+            }
         }
-        return panel.url
+    }
+
+    @MainActor
+    private static var comparisonPanelParentWindow: NSWindow? {
+        NSApp.keyWindow ??
+            NSApp.mainWindow ??
+            NSApp.windows.first { window in
+                window.isVisible && !window.isMiniaturized
+            }
     }
 
     @MainActor

--- a/Radix/Services/SystemIntegration.swift
+++ b/Radix/Services/SystemIntegration.swift
@@ -141,6 +141,8 @@ enum SystemIntegration {
 
     @MainActor
     static func presentComparisonSnapshotPanel() async -> URL? {
+        guard !Task.isCancelled else { return nil }
+
         let panel = NSOpenPanel()
         panel.allowedContentTypes = [radixScanArchiveContentType]
         panel.allowsMultipleSelection = false
@@ -150,18 +152,18 @@ enum SystemIntegration {
         panel.prompt = "Choose"
         panel.message = "Choose a Radix scan snapshot."
 
-        return await withCheckedContinuation { continuation in
-            let completionHandler: (NSApplication.ModalResponse) -> Void = { response in
-                let selectedURL = response == .OK ? panel.url : nil
-                DispatchQueue.main.async {
-                    continuation.resume(returning: selectedURL)
-                }
-            }
-
-            if let parentWindow = comparisonPanelParentWindow {
-                panel.beginSheetModal(for: parentWindow, completionHandler: completionHandler)
-            } else {
-                panel.begin(completionHandler: completionHandler)
+        let cancellationState = ExportPanelCancellationState()
+        let presentation = ExportPanelPresentation(
+            panel: panel,
+            parentWindow: comparisonPanelParentWindow,
+            cancellationState: cancellationState
+        )
+        return await withTaskCancellationHandler {
+            await presentation.begin()
+        } onCancel: {
+            cancellationState.cancel()
+            Task { @MainActor in
+                presentation.cancel()
             }
         }
     }

--- a/Radix/Services/SystemIntegration.swift
+++ b/Radix/Services/SystemIntegration.swift
@@ -140,6 +140,23 @@ enum SystemIntegration {
     }
 
     @MainActor
+    static func presentComparisonSnapshotPanel() -> URL? {
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [radixScanArchiveContentType]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = true
+        panel.canCreateDirectories = false
+        panel.prompt = "Choose"
+        panel.message = "Choose a Radix scan snapshot."
+
+        guard panel.runModal() == .OK else {
+            return nil
+        }
+        return panel.url
+    }
+
+    @MainActor
     private static var exportPanelParentWindow: NSWindow? {
         NSApp.mainWindow ??
             NSApp.keyWindow ??

--- a/Radix/ViewModels/AppModel.swift
+++ b/Radix/ViewModels/AppModel.swift
@@ -1120,6 +1120,18 @@ final class AppModel: ObservableObject {
         }
     }
 
+    func dropComparisonSnapshot(_ sourceURL: URL, for slot: ScanComparisonSlot) {
+        guard pendingComparisonSetup != nil else { return }
+        guard pendingComparisonSetup?.loadingSlot == nil else { return }
+        guard sourceURL.pathExtension.lowercased() == ScanArchiveService.fileExtension else {
+            pendingComparisonSetup?.errorMessage =
+                "Drop a .\(ScanArchiveService.fileExtension) saved scan."
+            return
+        }
+
+        previewComparisonSnapshot(from: sourceURL, for: slot)
+    }
+
     func useCurrentScanForComparisonSlot(_ slot: ScanComparisonSlot) {
         guard var setup = pendingComparisonSetup else { return }
         guard canUseCurrentScanInComparisonSetup,

--- a/Radix/ViewModels/AppModel.swift
+++ b/Radix/ViewModels/AppModel.swift
@@ -1109,7 +1109,10 @@ final class AppModel: ObservableObject {
     }
 
     func swapPendingComparisonSetup() {
-        pendingComparisonSetup?.swap()
+        guard var setup = pendingComparisonSetup else { return }
+        setup.swap()
+        setup.errorMessage = setup.validationMessage
+        pendingComparisonSetup = setup
     }
 
     func cancelComparisonSetup() {

--- a/Radix/ViewModels/AppModel.swift
+++ b/Radix/ViewModels/AppModel.swift
@@ -437,6 +437,7 @@ final class AppModel: ObservableObject {
     private var deferredNavigationContextSnapshotID: UUID?
     private var postTrashRemovalTask: Task<Void, Never>?
     private var exportPanelTask: Task<Void, Never>?
+    private var comparisonPanelTask: Task<Void, Never>?
     private var snapshotArchiveTask: Task<Void, Never>?
     private var snapshotArchiveProgressTask: Task<Void, Never>?
     private var exportConfirmationDismissTask: Task<Void, Never>?
@@ -516,6 +517,8 @@ final class AppModel: ObservableObject {
         targetCapacityDescriptionsRefreshTask = nil
         exportPanelTask?.cancel()
         exportPanelTask = nil
+        comparisonPanelTask?.cancel()
+        comparisonPanelTask = nil
         isExportPanelPresented = false
         cancelArchiveOperation()
         dismissExportConfirmation()
@@ -715,7 +718,7 @@ final class AppModel: ObservableObject {
             !isArchiveOperationInProgress
     }
 
-    var canImportScanSnapshot: Bool {
+    private var canPresentScanSnapshotPanel: Bool {
         !scanCoordinator.isScanning &&
             !isExportPanelPresented &&
             !isArchiveOperationInProgress &&
@@ -723,12 +726,12 @@ final class AppModel: ObservableObject {
             pendingImportPreview == nil
     }
 
+    var canImportScanSnapshot: Bool {
+        canPresentScanSnapshotPanel
+    }
+
     var canCompareScanSnapshots: Bool {
-        !scanCoordinator.isScanning &&
-            !isExportPanelPresented &&
-            !isArchiveOperationInProgress &&
-            pendingComparisonSetup == nil &&
-            pendingImportPreview == nil
+        canPresentScanSnapshotPanel
     }
 
     var canUseWorkspaceCommands: Bool {
@@ -1146,7 +1149,9 @@ final class AppModel: ObservableObject {
         guard pendingComparisonSetup?.loadingSlot == nil else { return }
         let setupID = pendingComparisonSetup?.id
 
-        Task { @MainActor [weak self] in
+        comparisonPanelTask?.cancel()
+        comparisonPanelTask = Task { @MainActor [weak self] in
+            defer { self?.comparisonPanelTask = nil }
             guard let self,
                   let sourceURL = await self.dependencies.systemActions.presentComparisonSnapshotPanel(),
                   self.pendingComparisonSetup?.id == setupID,
@@ -1288,46 +1293,6 @@ final class AppModel: ObservableObject {
                 let setup = try await Self.value(cancelling: setupTask)
                 guard !Task.isCancelled,
                       self.isCurrentArchiveOperation(id: operationID) else { return }
-                self.pendingComparisonSetup = setup
-                self.lastErrorMessage = nil
-            } catch is CancellationError {
-                return
-            } catch {
-                self.presentError(error, title: "Comparison Failed")
-            }
-        }
-    }
-
-    private func previewCurrentScanComparison(sourceURL: URL, currentSnapshot: ScanSnapshot) {
-        cancelArchiveOperation()
-        pendingComparisonSetup = nil
-        let currentSnapshotID = currentSnapshot.id
-        let operationID = beginArchiveOperation(
-            kind: .compare,
-            title: "Preparing Comparison",
-            message: "Reading snapshot",
-            progressReporter: nil
-        )
-        snapshotArchiveTask = Task { @MainActor [weak self] in
-            guard let self else { return }
-            defer {
-                self.finishArchiveOperation(id: operationID)
-            }
-
-            do {
-                let archiveService = self.dependencies.scanArchiveService
-                let setupTask = Task.detached(priority: .utility) {
-                    let preview = try await archiveService.previewSnapshot(from: sourceURL)
-                    try Task.checkCancellation()
-                    return ScanComparisonSetup(
-                        before: ScanComparisonCandidate(preview: preview),
-                        after: ScanComparisonCandidate(snapshot: currentSnapshot)
-                    )
-                }
-                let setup = try await Self.value(cancelling: setupTask)
-                guard !Task.isCancelled,
-                      self.isCurrentArchiveOperation(id: operationID),
-                      self.scanCoordinator.snapshot?.id == currentSnapshotID else { return }
                 self.pendingComparisonSetup = setup
                 self.lastErrorMessage = nil
             } catch is CancellationError {

--- a/Radix/ViewModels/AppModel.swift
+++ b/Radix/ViewModels/AppModel.swift
@@ -1032,6 +1032,45 @@ final class AppModel: ObservableObject {
         showComparisonNodeInBrowser(beforeNode: row.beforeNode, afterNode: row.afterNode)
     }
 
+    func canRevealComparisonChangeNodeInFinder(_ node: ScanComparisonChangeTreeNode) -> Bool {
+        guard let currentNode = currentScanNode(for: node.beforeNode, afterNode: node.afterNode) else {
+            return false
+        }
+        return dependencies.systemActions.fileExists(currentNode.url)
+    }
+
+    func revealComparisonChangeNodeInFinder(_ node: ScanComparisonChangeTreeNode) {
+        guard let currentNode = currentScanNode(for: node.beforeNode, afterNode: node.afterNode) else {
+            presentError(FileActionError.currentComparisonSnapshotUnavailable)
+            return
+        }
+        guard dependencies.systemActions.fileExists(currentNode.url) else {
+            presentError(FileActionError.unavailable(path: currentNode.url.path))
+            return
+        }
+        dependencies.systemActions.reveal(currentNode.url)
+    }
+
+    func copyComparisonChangeNodePath(_ node: ScanComparisonChangeTreeNode) {
+        guard let url = node.fileURL else {
+            presentError(FileActionError.unsupported)
+            return
+        }
+        do {
+            try dependencies.systemActions.copyPath(url)
+        } catch {
+            presentError(error)
+        }
+    }
+
+    func canShowComparisonChangeNodeInBrowser(_ node: ScanComparisonChangeTreeNode) -> Bool {
+        canShowComparisonNodeInBrowser(beforeNode: node.beforeNode, afterNode: node.afterNode)
+    }
+
+    func showComparisonChangeNodeInBrowser(_ node: ScanComparisonChangeTreeNode) {
+        showComparisonNodeInBrowser(beforeNode: node.beforeNode, afterNode: node.afterNode)
+    }
+
     func canRevealComparisonLocationInFinder(_ location: ScanComparisonLocationChange) -> Bool {
         guard let node = currentScanNode(for: location.beforeNode, afterNode: location.afterNode) else {
             return false

--- a/Radix/ViewModels/AppModel.swift
+++ b/Radix/ViewModels/AppModel.swift
@@ -659,6 +659,10 @@ final class AppModel: ObservableObject {
             pendingImportPreview == nil
     }
 
+    var canUseWorkspaceCommands: Bool {
+        scanComparison == nil
+    }
+
     var canCompareCurrentScanWithSnapshot: Bool {
         canCompareScanSnapshots &&
             scanCoordinator.snapshot?.isComplete == true &&
@@ -1210,6 +1214,7 @@ final class AppModel: ObservableObject {
                    self.scanCoordinator.snapshot?.id != currentSnapshotID {
                     return
                 }
+                self.quickLookController.closePreview()
                 self.scanComparison = comparison
                 self.lastErrorMessage = nil
             } catch is CancellationError {
@@ -3058,6 +3063,7 @@ extension AppModel: AppQuickLookControllerDelegate {
 
     var isQuickLookKeyboardShortcutBlocked: Bool {
         showsOnboarding ||
+            !canUseWorkspaceCommands ||
             pendingTrashNode != nil ||
             pendingTrashSelection != nil ||
             navigationModel.selectedNodeIDs.count > 1

--- a/Radix/ViewModels/AppModel.swift
+++ b/Radix/ViewModels/AppModel.swift
@@ -1191,7 +1191,6 @@ final class AppModel: ObservableObject {
         after: ScanComparisonCandidate? = nil
     ) {
         cancelArchiveOperation()
-        scanComparison = nil
         pendingComparisonSetup = ScanComparisonSetup(before: before, after: after)
     }
 
@@ -1257,7 +1256,6 @@ final class AppModel: ObservableObject {
 
     private func previewArchiveSnapshotComparison(sourceURLs: [URL]) {
         cancelArchiveOperation()
-        scanComparison = nil
         pendingComparisonSetup = nil
         let operationID = beginArchiveOperation(
             kind: .compare,
@@ -1299,7 +1297,6 @@ final class AppModel: ObservableObject {
 
     private func previewCurrentScanComparison(sourceURL: URL, currentSnapshot: ScanSnapshot) {
         cancelArchiveOperation()
-        scanComparison = nil
         pendingComparisonSetup = nil
         let currentSnapshotID = currentSnapshot.id
         let operationID = beginArchiveOperation(

--- a/Radix/ViewModels/AppModel.swift
+++ b/Radix/ViewModels/AppModel.swift
@@ -12,6 +12,7 @@ enum ArchiveOperationKind: String, Equatable, Sendable {
     case export
     case importPreview
     case `import`
+    case compare
 }
 
 struct ArchiveOperationState: Identifiable, Equatable, Sendable {
@@ -29,6 +30,151 @@ struct ArchiveOperationState: Identifiable, Equatable, Sendable {
 struct ExportConfirmationState: Identifiable, Equatable, Sendable {
     let id: UUID
     let archiveURL: URL
+}
+
+nonisolated enum ScanComparisonCandidateSource: Equatable, Sendable {
+    case archive(URL)
+    case currentSnapshot(UUID)
+}
+
+nonisolated enum ScanComparisonSlot: String, CaseIterable, Identifiable, Sendable {
+    case before
+    case after
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .before:
+            return "Before"
+        case .after:
+            return "After"
+        }
+    }
+}
+
+nonisolated struct ScanComparisonCandidate: Identifiable, Equatable, Sendable {
+    let id: UUID
+    let source: ScanComparisonCandidateSource
+    let displayName: String
+    let path: String
+    let scanDate: Date
+    let totalAllocatedSize: Int64
+    let fileCount: Int
+    let directoryCount: Int
+    let warningCount: Int
+
+    init(preview: ScanArchivePreview) {
+        self.id = UUID()
+        self.source = .archive(preview.archiveURL)
+        self.displayName = preview.target.displayName
+        self.path = preview.target.path
+        self.scanDate = preview.finishedAt ?? preview.startedAt
+        self.totalAllocatedSize = preview.totalAllocatedSize
+        self.fileCount = preview.fileCount
+        self.directoryCount = preview.directoryCount
+        self.warningCount = preview.warningCount
+    }
+
+    init(snapshot: ScanSnapshot) {
+        self.id = snapshot.id
+        self.source = .currentSnapshot(snapshot.id)
+        self.displayName = snapshot.target.displayName
+        self.path = snapshot.target.url.path
+        self.scanDate = snapshot.finishedAt ?? snapshot.startedAt
+        self.totalAllocatedSize = snapshot.aggregateStats.totalAllocatedSize
+        self.fileCount = snapshot.aggregateStats.fileCount
+        self.directoryCount = snapshot.aggregateStats.directoryCount
+        self.warningCount = snapshot.scanWarnings.count
+    }
+
+    var isCurrentScan: Bool {
+        if case .currentSnapshot = source {
+            return true
+        }
+        return false
+    }
+}
+
+nonisolated struct ScanComparisonSetup: Identifiable, Equatable, Sendable {
+    let id: UUID
+    var before: ScanComparisonCandidate?
+    var after: ScanComparisonCandidate?
+    var loadingSlot: ScanComparisonSlot?
+    var errorMessage: String?
+
+    init(
+        before: ScanComparisonCandidate? = nil,
+        after: ScanComparisonCandidate? = nil,
+        loadingSlot: ScanComparisonSlot? = nil,
+        errorMessage: String? = nil
+    ) {
+        self.id = UUID()
+        self.before = before
+        self.after = after
+        self.loadingSlot = loadingSlot
+        self.errorMessage = errorMessage
+    }
+
+    var canCompare: Bool {
+        guard loadingSlot == nil,
+              let before,
+              let after else {
+            return false
+        }
+        return before.source != after.source
+    }
+
+    var validationMessage: String? {
+        guard let before,
+              let after else {
+            return nil
+        }
+        if before.source == after.source {
+            return "Choose two different snapshots."
+        }
+        return nil
+    }
+
+    var resolvedCandidates: (before: ScanComparisonCandidate, after: ScanComparisonCandidate)? {
+        guard let before,
+              let after else {
+            return nil
+        }
+        return (before, after)
+    }
+
+    var currentSnapshotID: UUID? {
+        if case .currentSnapshot(let id)? = before?.source {
+            return id
+        }
+        if case .currentSnapshot(let id)? = after?.source {
+            return id
+        }
+        return nil
+    }
+
+    func candidate(for slot: ScanComparisonSlot) -> ScanComparisonCandidate? {
+        switch slot {
+        case .before:
+            return before
+        case .after:
+            return after
+        }
+    }
+
+    mutating func setCandidate(_ candidate: ScanComparisonCandidate?, for slot: ScanComparisonSlot) {
+        switch slot {
+        case .before:
+            before = candidate
+        case .after:
+            after = candidate
+        }
+    }
+
+    mutating func swap() {
+        Swift.swap(&before, &after)
+    }
 }
 
 struct DiscardPileState: Equatable, Sendable {
@@ -95,6 +241,7 @@ final class AppModel: ObservableObject {
         case selectMultiple(Set<FileNodeRecord.ID>, primary: FileNodeRecord.ID?)
         case focus(FileNodeRecord.ID?)
         case selectAndFocus(FileNodeRecord.ID)
+        case reveal(FileNodeRecord.ID)
         case navigateBack
         case navigateForward
         case navigateToParent
@@ -114,6 +261,7 @@ final class AppModel: ObservableObject {
         case folderRequiredForDrop
         case fullDiskAccessSettingsUnavailable
         case readOnlySnapshot
+        case currentComparisonSnapshotUnavailable
 
         var alertTitle: String? {
             switch self {
@@ -151,6 +299,8 @@ final class AppModel: ObservableObject {
                 return "Radix could not open Full Disk Access settings."
             case .readOnlySnapshot:
                 return "Imported snapshots are read-only."
+            case .currentComparisonSnapshotUnavailable:
+                return "Current scan changed. Start the comparison again."
             }
         }
     }
@@ -185,6 +335,8 @@ final class AppModel: ObservableObject {
     }
     @Published private(set) var archiveOperation: ArchiveOperationState?
     @Published private(set) var exportConfirmation: ExportConfirmationState?
+    @Published private(set) var scanComparison: ScanComparison?
+    @Published var pendingComparisonSetup: ScanComparisonSetup?
     @Published var pendingImportPreview: ScanArchivePreview?
     @Published var pendingTrashNode: FileNodeRecord?
     @Published var pendingTrashSelection: PendingTrashSelection?
@@ -295,6 +447,7 @@ final class AppModel: ObservableObject {
         isExportPanelPresented = false
         cancelArchiveOperation()
         dismissExportConfirmation()
+        pendingComparisonSetup = nil
         pendingImportPreview = nil
         quickLookController.setWorkspaceWindowNumber(nil)
         scanCoordinator.stopScan()
@@ -494,7 +647,27 @@ final class AppModel: ObservableObject {
         !scanCoordinator.isScanning &&
             !isExportPanelPresented &&
             !isArchiveOperationInProgress &&
+            pendingComparisonSetup == nil &&
             pendingImportPreview == nil
+    }
+
+    var canCompareScanSnapshots: Bool {
+        !scanCoordinator.isScanning &&
+            !isExportPanelPresented &&
+            !isArchiveOperationInProgress &&
+            pendingComparisonSetup == nil &&
+            pendingImportPreview == nil
+    }
+
+    var canCompareCurrentScanWithSnapshot: Bool {
+        canCompareScanSnapshots &&
+            scanCoordinator.snapshot?.isComplete == true &&
+            scanCoordinator.snapshotSource.allowsFileMutation
+    }
+
+    var canUseCurrentScanInComparisonSetup: Bool {
+        scanCoordinator.snapshot?.isComplete == true &&
+            scanCoordinator.snapshotSource.allowsFileMutation
     }
 
     private var canConfirmImportPreview: Bool {
@@ -636,10 +809,406 @@ final class AppModel: ObservableObject {
         if isArchiveOperationInProgress {
             return "Cancel the current archive operation before importing a snapshot."
         }
+        if pendingComparisonSetup != nil {
+            return "Finish or cancel the current comparison setup before importing a snapshot."
+        }
         if pendingImportPreview != nil {
             return "Finish or cancel the current import preview before importing another snapshot."
         }
         return "Radix cannot import a snapshot right now."
+    }
+
+    private var comparisonUnavailableMessage: String {
+        if scanCoordinator.isScanning {
+            return "Stop the current scan before comparing snapshots."
+        }
+        if isExportPanelPresented {
+            return "Finish choosing an export location before comparing snapshots."
+        }
+        if isArchiveOperationInProgress {
+            return "Cancel the current archive operation before comparing snapshots."
+        }
+        if pendingComparisonSetup != nil {
+            return "Finish or cancel the current comparison setup before comparing snapshots."
+        }
+        if pendingImportPreview != nil {
+            return "Finish or cancel the current import preview before comparing snapshots."
+        }
+        return "Radix cannot compare snapshots right now."
+    }
+
+    func compareScanSnapshots() {
+        guard canCompareScanSnapshots else {
+            presentErrorMessage(comparisonUnavailableMessage)
+            return
+        }
+        beginComparisonSetup()
+    }
+
+    func compareScanSnapshots(from sourceURLs: [URL]) {
+        guard canCompareScanSnapshots else {
+            presentErrorMessage(comparisonUnavailableMessage)
+            return
+        }
+        guard sourceURLs.count == 2 else {
+            presentErrorMessage("Choose exactly two Radix scan snapshots to compare.")
+            return
+        }
+
+        previewArchiveSnapshotComparison(sourceURLs: sourceURLs)
+    }
+
+    func compareCurrentScanWithSnapshot() {
+        guard canCompareCurrentScanWithSnapshot,
+              let currentSnapshot = scanCoordinator.snapshot else {
+            presentErrorMessage(currentScanComparisonUnavailableMessage)
+            return
+        }
+        beginComparisonSetup(after: ScanComparisonCandidate(snapshot: currentSnapshot))
+    }
+
+    func compareCurrentScan(with sourceURL: URL) {
+        guard canCompareCurrentScanWithSnapshot,
+              let currentSnapshot = scanCoordinator.snapshot else {
+            presentErrorMessage(currentScanComparisonUnavailableMessage)
+            return
+        }
+        beginComparisonSetup(after: ScanComparisonCandidate(snapshot: currentSnapshot))
+        previewComparisonSnapshot(from: sourceURL, for: .before)
+    }
+
+    private var currentScanComparisonUnavailableMessage: String {
+        if !canCompareScanSnapshots {
+            return comparisonUnavailableMessage
+        }
+        return "Complete a live scan before comparing it with a snapshot."
+    }
+
+    func closeScanComparison() {
+        scanComparison = nil
+    }
+
+    func canRevealComparisonRowInFinder(_ row: ScanComparisonRow) -> Bool {
+        guard let url = row.fileURL else { return false }
+        return dependencies.systemActions.fileExists(url)
+    }
+
+    func revealComparisonRowInFinder(_ row: ScanComparisonRow) {
+        guard let url = row.fileURL else {
+            presentError(FileActionError.unsupported)
+            return
+        }
+        guard dependencies.systemActions.fileExists(url) else {
+            presentError(FileActionError.unavailable(path: url.path))
+            return
+        }
+        dependencies.systemActions.reveal(url)
+    }
+
+    func copyComparisonRowPath(_ row: ScanComparisonRow) {
+        guard let url = row.fileURL else {
+            presentError(FileActionError.unsupported)
+            return
+        }
+        do {
+            try dependencies.systemActions.copyPath(url)
+        } catch {
+            presentError(error)
+        }
+    }
+
+    func canShowComparisonRowInBrowser(_ row: ScanComparisonRow) -> Bool {
+        guard let nodeID = currentScanNodeID(for: row) else { return false }
+        return isVisibleNavigationNode(nodeID)
+    }
+
+    func showComparisonRowInBrowser(_ row: ScanComparisonRow) {
+        guard let nodeID = currentScanNodeID(for: row) else {
+            presentError(FileActionError.currentComparisonSnapshotUnavailable)
+            return
+        }
+        // Don't tear down the comparison unless the reveal will actually land — a node that
+        // is hidden (e.g. in the discard pile) would be filtered by performNavigationAction,
+        // leaving the user on an empty browser with their comparison gone.
+        guard isVisibleNavigationNode(nodeID) else { return }
+        closeScanComparison()
+        revealAfterViewUpdate(nodeID: nodeID)
+    }
+
+    /// The node ID for a comparison row within the current live scan, or nil when the row's
+    /// side is not the current scan (e.g. comparing two imported archives) or the node is gone.
+    private func currentScanNodeID(for row: ScanComparisonRow) -> String? {
+        guard let comparison = scanComparison,
+              let currentSnapshotID = scanCoordinator.snapshot?.id else {
+            return nil
+        }
+        if comparison.after.id == currentSnapshotID, let node = row.afterNode {
+            return node.id
+        }
+        if comparison.before.id == currentSnapshotID, let node = row.beforeNode {
+            return node.id
+        }
+        return nil
+    }
+
+    func swapPendingComparisonSetup() {
+        pendingComparisonSetup?.swap()
+    }
+
+    func cancelComparisonSetup() {
+        guard pendingComparisonSetup != nil else { return }
+        cancelArchiveOperation()
+        pendingComparisonSetup = nil
+    }
+
+    func confirmComparisonSetup() {
+        guard let setup = pendingComparisonSetup else { return }
+        guard setup.canCompare,
+              setup.resolvedCandidates != nil else {
+            var updatedSetup = setup
+            updatedSetup.errorMessage = setup.validationMessage ?? "Choose two snapshots to compare."
+            pendingComparisonSetup = updatedSetup
+            return
+        }
+        if let currentSnapshotID = setup.currentSnapshotID,
+           scanCoordinator.snapshot?.id != currentSnapshotID {
+            pendingComparisonSetup = nil
+            presentError(FileActionError.currentComparisonSnapshotUnavailable)
+            return
+        }
+
+        pendingComparisonSetup = nil
+        startComparison(setup)
+    }
+
+    func chooseComparisonSnapshot(for slot: ScanComparisonSlot) {
+        guard pendingComparisonSetup != nil else { return }
+        guard pendingComparisonSetup?.loadingSlot == nil else { return }
+        guard let sourceURL = dependencies.systemActions.presentComparisonSnapshotPanel() else { return }
+        previewComparisonSnapshot(from: sourceURL, for: slot)
+    }
+
+    func useCurrentScanForComparisonSlot(_ slot: ScanComparisonSlot) {
+        guard var setup = pendingComparisonSetup else { return }
+        guard canUseCurrentScanInComparisonSetup,
+              let snapshot = scanCoordinator.snapshot else {
+            setup.errorMessage = "Complete a live scan before using it in a comparison."
+            pendingComparisonSetup = setup
+            return
+        }
+        setup.setCandidate(ScanComparisonCandidate(snapshot: snapshot), for: slot)
+        setup.errorMessage = setup.validationMessage
+        pendingComparisonSetup = setup
+    }
+
+    func clearComparisonSlot(_ slot: ScanComparisonSlot) {
+        guard var setup = pendingComparisonSetup else { return }
+        setup.setCandidate(nil, for: slot)
+        setup.errorMessage = nil
+        pendingComparisonSetup = setup
+    }
+
+    private func beginComparisonSetup(
+        before: ScanComparisonCandidate? = nil,
+        after: ScanComparisonCandidate? = nil
+    ) {
+        cancelArchiveOperation()
+        scanComparison = nil
+        pendingComparisonSetup = ScanComparisonSetup(before: before, after: after)
+    }
+
+    private func previewComparisonSnapshot(from sourceURL: URL, for slot: ScanComparisonSlot) {
+        guard var setup = pendingComparisonSetup,
+              setup.loadingSlot == nil else {
+            return
+        }
+
+        cancelArchiveOperation()
+        setup.loadingSlot = slot
+        setup.errorMessage = nil
+        setup.setCandidate(nil, for: slot)
+        pendingComparisonSetup = setup
+        let setupID = setup.id
+
+        snapshotArchiveTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer {
+                self.clearComparisonSetupLoadingSlot(setupID: setupID, slot: slot)
+            }
+
+            do {
+                let archiveService = self.dependencies.scanArchiveService
+                let previewTask = Task.detached(priority: .utility) {
+                    try await archiveService.previewSnapshot(from: sourceURL)
+                }
+                let preview = try await Self.value(cancelling: previewTask)
+                guard !Task.isCancelled,
+                      var currentSetup = self.pendingComparisonSetup,
+                      currentSetup.id == setupID,
+                      currentSetup.loadingSlot == slot else {
+                    return
+                }
+                currentSetup.setCandidate(ScanComparisonCandidate(preview: preview), for: slot)
+                currentSetup.loadingSlot = nil
+                currentSetup.errorMessage = currentSetup.validationMessage
+                self.pendingComparisonSetup = currentSetup
+                self.lastErrorMessage = nil
+            } catch is CancellationError {
+                return
+            } catch {
+                guard var currentSetup = self.pendingComparisonSetup,
+                      currentSetup.id == setupID else {
+                    return
+                }
+                currentSetup.loadingSlot = nil
+                currentSetup.errorMessage = error.localizedDescription
+                self.pendingComparisonSetup = currentSetup
+            }
+        }
+    }
+
+    private func clearComparisonSetupLoadingSlot(setupID: UUID, slot: ScanComparisonSlot) {
+        guard var setup = pendingComparisonSetup,
+              setup.id == setupID,
+              setup.loadingSlot == slot else {
+            return
+        }
+        setup.loadingSlot = nil
+        pendingComparisonSetup = setup
+    }
+
+    private func previewArchiveSnapshotComparison(sourceURLs: [URL]) {
+        cancelArchiveOperation()
+        scanComparison = nil
+        pendingComparisonSetup = nil
+        let operationID = beginArchiveOperation(
+            kind: .compare,
+            title: "Preparing Comparison",
+            message: "Reading snapshots",
+            progressReporter: nil
+        )
+        snapshotArchiveTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer {
+                self.finishArchiveOperation(id: operationID)
+            }
+
+            do {
+                let archiveService = self.dependencies.scanArchiveService
+                let setupTask = Task.detached(priority: .utility) {
+                    let first = try await archiveService.previewSnapshot(from: sourceURLs[0])
+                    try Task.checkCancellation()
+                    let second = try await archiveService.previewSnapshot(from: sourceURLs[1])
+                    try Task.checkCancellation()
+                    let candidates = Self.orderedComparisonCandidates(
+                        ScanComparisonCandidate(preview: first),
+                        ScanComparisonCandidate(preview: second)
+                    )
+                    return ScanComparisonSetup(before: candidates.before, after: candidates.after)
+                }
+                let setup = try await Self.value(cancelling: setupTask)
+                guard !Task.isCancelled,
+                      self.isCurrentArchiveOperation(id: operationID) else { return }
+                self.pendingComparisonSetup = setup
+                self.lastErrorMessage = nil
+            } catch is CancellationError {
+                return
+            } catch {
+                self.presentError(error, title: "Comparison Failed")
+            }
+        }
+    }
+
+    private func previewCurrentScanComparison(sourceURL: URL, currentSnapshot: ScanSnapshot) {
+        cancelArchiveOperation()
+        scanComparison = nil
+        pendingComparisonSetup = nil
+        let currentSnapshotID = currentSnapshot.id
+        let operationID = beginArchiveOperation(
+            kind: .compare,
+            title: "Preparing Comparison",
+            message: "Reading snapshot",
+            progressReporter: nil
+        )
+        snapshotArchiveTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer {
+                self.finishArchiveOperation(id: operationID)
+            }
+
+            do {
+                let archiveService = self.dependencies.scanArchiveService
+                let setupTask = Task.detached(priority: .utility) {
+                    let preview = try await archiveService.previewSnapshot(from: sourceURL)
+                    try Task.checkCancellation()
+                    return ScanComparisonSetup(
+                        before: ScanComparisonCandidate(preview: preview),
+                        after: ScanComparisonCandidate(snapshot: currentSnapshot)
+                    )
+                }
+                let setup = try await Self.value(cancelling: setupTask)
+                guard !Task.isCancelled,
+                      self.isCurrentArchiveOperation(id: operationID),
+                      self.scanCoordinator.snapshot?.id == currentSnapshotID else { return }
+                self.pendingComparisonSetup = setup
+                self.lastErrorMessage = nil
+            } catch is CancellationError {
+                return
+            } catch {
+                self.presentError(error, title: "Comparison Failed")
+            }
+        }
+    }
+
+    private func startComparison(_ setup: ScanComparisonSetup) {
+        guard let candidates = setup.resolvedCandidates else { return }
+        cancelArchiveOperation()
+        scanComparison = nil
+        let currentSnapshot = scanCoordinator.snapshot
+        let operationID = beginArchiveOperation(
+            kind: .compare,
+            title: "Comparing Snapshots",
+            message: "Reading archives",
+            progressReporter: nil
+        )
+        snapshotArchiveTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer {
+                self.finishArchiveOperation(id: operationID)
+            }
+
+            do {
+                let archiveService = self.dependencies.scanArchiveService
+                let comparisonTask = Task.detached(priority: .utility) {
+                    let before = try await Self.snapshot(
+                        for: candidates.before.source,
+                        archiveService: archiveService,
+                        currentSnapshot: currentSnapshot
+                    )
+                    try Task.checkCancellation()
+                    let after = try await Self.snapshot(
+                        for: candidates.after.source,
+                        archiveService: archiveService,
+                        currentSnapshot: currentSnapshot
+                    )
+                    try Task.checkCancellation()
+                    return try await ScanComparisonService().compare(before: before, after: after)
+                }
+                let comparison = try await Self.value(cancelling: comparisonTask)
+                guard !Task.isCancelled,
+                      self.isCurrentArchiveOperation(id: operationID) else { return }
+                if let currentSnapshotID = setup.currentSnapshotID,
+                   self.scanCoordinator.snapshot?.id != currentSnapshotID {
+                    return
+                }
+                self.scanComparison = comparison
+                self.lastErrorMessage = nil
+            } catch is CancellationError {
+                return
+            } catch {
+                self.presentError(error, title: "Comparison Failed")
+            }
+        }
     }
 
     func confirmImportPreview() {
@@ -808,6 +1377,37 @@ final class AppModel: ObservableObject {
             try await task.value
         } onCancel: {
             task.cancel()
+        }
+    }
+
+    nonisolated private static func orderedComparisonCandidates(
+        _ lhs: ScanComparisonCandidate,
+        _ rhs: ScanComparisonCandidate
+    ) -> (before: ScanComparisonCandidate, after: ScanComparisonCandidate) {
+        let lhsDate = lhs.scanDate
+        let rhsDate = rhs.scanDate
+        if lhsDate == rhsDate {
+            return lhs.path.localizedStandardCompare(rhs.path) == .orderedDescending
+                ? (rhs, lhs)
+                : (lhs, rhs)
+        }
+        return lhsDate < rhsDate ? (lhs, rhs) : (rhs, lhs)
+    }
+
+    nonisolated private static func snapshot(
+        for source: ScanComparisonCandidateSource,
+        archiveService: any ScanArchiveServicing,
+        currentSnapshot: ScanSnapshot?
+    ) async throws -> ScanSnapshot {
+        switch source {
+        case .archive(let url):
+            return try await archiveService.importSnapshot(from: url).snapshot
+        case .currentSnapshot(let id):
+            guard let currentSnapshot,
+                  currentSnapshot.id == id else {
+                throw FileActionError.currentComparisonSnapshotUnavailable
+            }
+            return currentSnapshot
         }
     }
 
@@ -983,6 +1583,10 @@ final class AppModel: ObservableObject {
         scheduleDeferredNavigationAction(.selectAndFocus(nodeID))
     }
 
+    func revealAfterViewUpdate(nodeID: String) {
+        scheduleDeferredNavigationAction(.reveal(nodeID))
+    }
+
     func clearSelection() {
         cancelDeferredNavigationAction()
         performNavigationAction(.clearSelection)
@@ -1062,6 +1666,9 @@ final class AppModel: ObservableObject {
         case .selectAndFocus(let nodeID):
             guard isVisibleNavigationNode(nodeID) else { return }
             navigationModel.selectAndFocus(nodeID: nodeID)
+        case .reveal(let nodeID):
+            guard isVisibleNavigationNode(nodeID) else { return }
+            navigationModel.reveal(nodeID: nodeID)
         case .navigateBack:
             navigationModel.navigateBack()
         case .navigateForward:
@@ -2125,7 +2732,9 @@ final class AppModel: ObservableObject {
 
     private func prepareForScan(_ target: ScanTarget) {
         lastErrorMessage = nil
+        scanComparison = nil
         navigationModel.reset()
+        pendingComparisonSetup = nil
         pendingImportPreview = nil
         pendingTrashNode = nil
         pendingTrashSelection = nil
@@ -2157,7 +2766,9 @@ final class AppModel: ObservableObject {
 
     private func prepareForImportedSnapshot() {
         lastErrorMessage = nil
+        scanComparison = nil
         navigationModel.reset()
+        pendingComparisonSetup = nil
         pendingImportPreview = nil
         pendingTrashNode = nil
         pendingTrashSelection = nil

--- a/Radix/ViewModels/AppModel.swift
+++ b/Radix/ViewModels/AppModel.swift
@@ -984,8 +984,17 @@ final class AppModel: ObservableObject {
     func chooseComparisonSnapshot(for slot: ScanComparisonSlot) {
         guard pendingComparisonSetup != nil else { return }
         guard pendingComparisonSetup?.loadingSlot == nil else { return }
-        guard let sourceURL = dependencies.systemActions.presentComparisonSnapshotPanel() else { return }
-        previewComparisonSnapshot(from: sourceURL, for: slot)
+        let setupID = pendingComparisonSetup?.id
+
+        Task { @MainActor [weak self] in
+            guard let self,
+                  let sourceURL = await self.dependencies.systemActions.presentComparisonSnapshotPanel(),
+                  self.pendingComparisonSetup?.id == setupID,
+                  self.pendingComparisonSetup?.loadingSlot == nil else {
+                return
+            }
+            self.previewComparisonSnapshot(from: sourceURL, for: slot)
+        }
     }
 
     func useCurrentScanForComparisonSlot(_ slot: ScanComparisonSlot) {

--- a/Radix/ViewModels/AppModel.swift
+++ b/Radix/ViewModels/AppModel.swift
@@ -46,28 +46,10 @@ nonisolated enum ScanComparisonSlot: String, CaseIterable, Identifiable, Sendabl
     var title: String {
         switch self {
         case .before:
-            return "Before"
+            return "Earlier Scan"
         case .after:
-            return "After"
+            return "Later Scan"
         }
-    }
-}
-
-nonisolated enum ScanComparisonCompatibilityWarning: Hashable, Sendable {
-    case unrelatedRoots
-    case differentScanOptions
-
-    var message: String {
-        switch self {
-        case .unrelatedRoots:
-            return "These snapshots scan unrelated roots, so the reported changes may not be meaningful."
-        case .differentScanOptions:
-            return "These snapshots use different scan options, so totals and file changes may not be directly comparable."
-        }
-    }
-
-    var symbolName: String {
-        "exclamationmark.triangle.fill"
     }
 }
 
@@ -76,6 +58,7 @@ nonisolated struct ScanComparisonCandidate: Identifiable, Equatable, Sendable {
     let source: ScanComparisonCandidateSource
     let displayName: String
     let path: String
+    let targetKind: ScanTargetKind
     let scanDate: Date
     let totalAllocatedSize: Int64
     let fileCount: Int
@@ -88,6 +71,7 @@ nonisolated struct ScanComparisonCandidate: Identifiable, Equatable, Sendable {
         self.source = .archive(preview.archiveURL)
         self.displayName = preview.target.displayName
         self.path = preview.target.path
+        self.targetKind = preview.target.kind
         self.scanDate = preview.finishedAt ?? preview.startedAt
         self.totalAllocatedSize = preview.totalAllocatedSize
         self.fileCount = preview.fileCount
@@ -101,6 +85,7 @@ nonisolated struct ScanComparisonCandidate: Identifiable, Equatable, Sendable {
         self.source = .currentSnapshot(snapshot.id)
         self.displayName = snapshot.target.displayName
         self.path = snapshot.target.url.path
+        self.targetKind = snapshot.target.kind
         self.scanDate = snapshot.finishedAt ?? snapshot.startedAt
         self.totalAllocatedSize = snapshot.aggregateStats.totalAllocatedSize
         self.fileCount = snapshot.aggregateStats.fileCount
@@ -143,7 +128,7 @@ nonisolated struct ScanComparisonSetup: Identifiable, Equatable, Sendable {
               let after else {
             return false
         }
-        return before.source != after.source
+        return before.source != after.source && validationMessage == nil
     }
 
     var validationMessage: String? {
@@ -152,28 +137,24 @@ nonisolated struct ScanComparisonSetup: Identifiable, Equatable, Sendable {
             return nil
         }
         if before.source == after.source {
-            return "Choose two different snapshots."
+            return "Choose two different scans."
         }
-        return nil
-    }
-
-    var compatibilityWarnings: [ScanComparisonCompatibilityWarning] {
-        guard let before,
-              let after,
-              before.source != after.source else {
-            return []
+        guard before.targetKind == after.targetKind,
+              Self.normalizedRootPath(before.path) == Self.normalizedRootPath(after.path) else {
+            return "Choose scans of the same location."
         }
-
-        var warnings: [ScanComparisonCompatibilityWarning] = []
-        if !Self.rootsAreRelated(before.path, after.path) {
-            warnings.append(.unrelatedRoots)
+        if before.scanDate > after.scanDate {
+            return "The earlier scan must precede the later scan."
         }
         if let beforeOptions = before.scanOptions,
            let afterOptions = after.scanOptions,
            beforeOptions != afterOptions {
-            warnings.append(.differentScanOptions)
+            return "Choose scans made with the same scan settings."
         }
-        return warnings
+        if (before.scanOptions == nil) != (after.scanOptions == nil) {
+            return "One scan is missing its settings, so these scans cannot be compared safely."
+        }
+        return nil
     }
 
     var resolvedCandidates: (before: ScanComparisonCandidate, after: ScanComparisonCandidate)? {
@@ -203,6 +184,16 @@ nonisolated struct ScanComparisonSetup: Identifiable, Equatable, Sendable {
         }
     }
 
+    func canAssignCurrentScan(to slot: ScanComparisonSlot) -> Bool {
+        let otherCandidate = switch slot {
+        case .before:
+            after
+        case .after:
+            before
+        }
+        return otherCandidate?.isCurrentScan != true
+    }
+
     mutating func setCandidate(_ candidate: ScanComparisonCandidate?, for slot: ScanComparisonSlot) {
         switch slot {
         case .before:
@@ -216,17 +207,10 @@ nonisolated struct ScanComparisonSetup: Identifiable, Equatable, Sendable {
         Swift.swap(&before, &after)
     }
 
-    private static func rootsAreRelated(_ firstPath: String, _ secondPath: String) -> Bool {
-        let first = URL(filePath: firstPath, directoryHint: .isDirectory)
+    private static func normalizedRootPath(_ path: String) -> String {
+        URL(filePath: path, directoryHint: .isDirectory)
             .standardizedFileURL
             .path
-        let second = URL(filePath: secondPath, directoryHint: .isDirectory)
-            .standardizedFileURL
-            .path
-
-        guard first != second else { return true }
-        guard first != "/", second != "/" else { return true }
-        return first.hasPrefix(second + "/") || second.hasPrefix(first + "/")
     }
 }
 
@@ -425,6 +409,10 @@ final class AppModel: ObservableObject {
     private var snapshotArchiveTask: Task<Void, Never>?
     private var snapshotArchiveProgressTask: Task<Void, Never>?
     private var exportConfirmationDismissTask: Task<Void, Never>?
+    /// The completed live scan immediately preceding the active scan. Keeping this in memory
+    /// makes a rescan comparison available without silently writing another full archive.
+    private var previousScanComparisonBaseline: ScanSnapshot?
+    private var pendingScanComparisonBaseline: ScanSnapshot?
     private var postTrashRemovalRequests: [PostTrashRemovalRequest] = []
     private var fullDiskAccessRefreshTask: Task<Void, Never>?
     private var targetCapacityDescriptionsRefreshTask: Task<Void, Never>?
@@ -722,6 +710,18 @@ final class AppModel: ObservableObject {
             scanCoordinator.snapshotSource.allowsFileMutation
     }
 
+    var canCompareCurrentScanWithPreviousScan: Bool {
+        guard canCompareScanSnapshots,
+              let currentSnapshot = scanCoordinator.snapshot,
+              let previousSnapshot = previousScanComparisonBaseline,
+              currentSnapshot.isComplete,
+              currentSnapshot.source.allowsFileMutation else {
+            return false
+        }
+
+        return Self.canUseAsComparisonBaseline(previousSnapshot, for: currentSnapshot)
+    }
+
     var canUseCurrentScanInComparisonSetup: Bool {
         scanCoordinator.snapshot?.isComplete == true &&
             scanCoordinator.snapshotSource.allowsFileMutation
@@ -924,6 +924,17 @@ final class AppModel: ObservableObject {
         beginComparisonSetup(after: ScanComparisonCandidate(snapshot: currentSnapshot))
     }
 
+    func compareCurrentScanWithPreviousScan() {
+        guard canCompareCurrentScanWithPreviousScan,
+              let beforeSnapshot = previousScanComparisonBaseline,
+              let afterSnapshot = scanCoordinator.snapshot else {
+            presentErrorMessage("Rescan this location with the same scan options before comparing it with the previous scan.")
+            return
+        }
+
+        startLiveScanComparison(before: beforeSnapshot, after: afterSnapshot)
+    }
+
     func compareCurrentScan(with sourceURL: URL) {
         guard canCompareCurrentScanWithSnapshot,
               let currentSnapshot = scanCoordinator.snapshot else {
@@ -946,20 +957,22 @@ final class AppModel: ObservableObject {
     }
 
     func canRevealComparisonRowInFinder(_ row: ScanComparisonRow) -> Bool {
-        guard let url = row.fileURL else { return false }
-        return dependencies.systemActions.fileExists(url)
+        guard let node = currentScanNode(for: row.beforeNode, afterNode: row.afterNode) else {
+            return false
+        }
+        return dependencies.systemActions.fileExists(node.url)
     }
 
     func revealComparisonRowInFinder(_ row: ScanComparisonRow) {
-        guard let url = row.fileURL else {
-            presentError(FileActionError.unsupported)
+        guard let node = currentScanNode(for: row.beforeNode, afterNode: row.afterNode) else {
+            presentError(FileActionError.currentComparisonSnapshotUnavailable)
             return
         }
-        guard dependencies.systemActions.fileExists(url) else {
-            presentError(FileActionError.unavailable(path: url.path))
+        guard dependencies.systemActions.fileExists(node.url) else {
+            presentError(FileActionError.unavailable(path: node.url.path))
             return
         }
-        dependencies.systemActions.reveal(url)
+        dependencies.systemActions.reveal(node.url)
     }
 
     func copyComparisonRowPath(_ row: ScanComparisonRow) {
@@ -975,12 +988,55 @@ final class AppModel: ObservableObject {
     }
 
     func canShowComparisonRowInBrowser(_ row: ScanComparisonRow) -> Bool {
-        guard let nodeID = currentScanNodeID(for: row) else { return false }
-        return isVisibleNavigationNode(nodeID)
+        canShowComparisonNodeInBrowser(beforeNode: row.beforeNode, afterNode: row.afterNode)
     }
 
     func showComparisonRowInBrowser(_ row: ScanComparisonRow) {
-        guard let nodeID = currentScanNodeID(for: row) else {
+        showComparisonNodeInBrowser(beforeNode: row.beforeNode, afterNode: row.afterNode)
+    }
+
+    func canRevealComparisonLocationInFinder(_ location: ScanComparisonLocationChange) -> Bool {
+        guard let node = currentScanNode(for: location.beforeNode, afterNode: location.afterNode) else {
+            return false
+        }
+        return dependencies.systemActions.fileExists(node.url)
+    }
+
+    func revealComparisonLocationInFinder(_ location: ScanComparisonLocationChange) {
+        guard let node = currentScanNode(for: location.beforeNode, afterNode: location.afterNode) else {
+            presentError(FileActionError.currentComparisonSnapshotUnavailable)
+            return
+        }
+        guard dependencies.systemActions.fileExists(node.url) else {
+            presentError(FileActionError.unavailable(path: node.url.path))
+            return
+        }
+        dependencies.systemActions.reveal(node.url)
+    }
+
+    func canShowComparisonLocationInBrowser(_ location: ScanComparisonLocationChange) -> Bool {
+        canShowComparisonNodeInBrowser(beforeNode: location.beforeNode, afterNode: location.afterNode)
+    }
+
+    func showComparisonLocationInBrowser(_ location: ScanComparisonLocationChange) {
+        showComparisonNodeInBrowser(beforeNode: location.beforeNode, afterNode: location.afterNode)
+    }
+
+    private func canShowComparisonNodeInBrowser(
+        beforeNode: FileNodeRecord?,
+        afterNode: FileNodeRecord?
+    ) -> Bool {
+        guard let nodeID = currentScanNodeID(beforeNode: beforeNode, afterNode: afterNode) else {
+            return false
+        }
+        return isVisibleNavigationNode(nodeID)
+    }
+
+    private func showComparisonNodeInBrowser(
+        beforeNode: FileNodeRecord?,
+        afterNode: FileNodeRecord?
+    ) {
+        guard let nodeID = currentScanNodeID(beforeNode: beforeNode, afterNode: afterNode) else {
             presentError(FileActionError.currentComparisonSnapshotUnavailable)
             return
         }
@@ -994,18 +1050,28 @@ final class AppModel: ObservableObject {
 
     /// The node ID for a comparison row within the current live scan, or nil when the row's
     /// side is not the current scan (e.g. comparing two imported archives) or the node is gone.
-    private func currentScanNodeID(for row: ScanComparisonRow) -> String? {
+    private func currentScanNode(
+        for beforeNode: FileNodeRecord?,
+        afterNode: FileNodeRecord?
+    ) -> FileNodeRecord? {
         guard let comparison = scanComparison,
               let currentSnapshotID = scanCoordinator.snapshot?.id else {
             return nil
         }
-        if comparison.after.id == currentSnapshotID, let node = row.afterNode {
-            return node.id
+        if comparison.after.id == currentSnapshotID, let afterNode {
+            return afterNode
         }
-        if comparison.before.id == currentSnapshotID, let node = row.beforeNode {
-            return node.id
+        if comparison.before.id == currentSnapshotID, let beforeNode {
+            return beforeNode
         }
         return nil
+    }
+
+    private func currentScanNodeID(
+        beforeNode: FileNodeRecord?,
+        afterNode: FileNodeRecord?
+    ) -> String? {
+        currentScanNode(for: beforeNode, afterNode: afterNode)?.id
     }
 
     func swapPendingComparisonSetup() {
@@ -1023,7 +1089,7 @@ final class AppModel: ObservableObject {
         guard setup.canCompare,
               setup.resolvedCandidates != nil else {
             var updatedSetup = setup
-            updatedSetup.errorMessage = setup.validationMessage ?? "Choose two snapshots to compare."
+            updatedSetup.errorMessage = setup.validationMessage ?? "Choose two scans to compare."
             pendingComparisonSetup = updatedSetup
             return
         }
@@ -1265,6 +1331,43 @@ final class AppModel: ObservableObject {
                       self.isCurrentArchiveOperation(id: operationID) else { return }
                 if let currentSnapshotID = setup.currentSnapshotID,
                    self.scanCoordinator.snapshot?.id != currentSnapshotID {
+                    return
+                }
+                self.quickLookController.closePreview()
+                self.scanComparison = comparison
+                self.lastErrorMessage = nil
+            } catch is CancellationError {
+                return
+            } catch {
+                self.presentError(error, title: "Comparison Failed")
+            }
+        }
+    }
+
+    private func startLiveScanComparison(before: ScanSnapshot, after: ScanSnapshot) {
+        cancelArchiveOperation()
+        scanComparison = nil
+        let currentSnapshotID = after.id
+        let operationID = beginArchiveOperation(
+            kind: .compare,
+            title: "Comparing Scans",
+            message: "Finding storage changes",
+            progressReporter: nil
+        )
+        snapshotArchiveTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer {
+                self.finishArchiveOperation(id: operationID)
+            }
+
+            do {
+                let comparisonTask = Task.detached(priority: .utility) {
+                    try await ScanComparisonService().compare(before: before, after: after)
+                }
+                let comparison = try await Self.value(cancelling: comparisonTask)
+                guard !Task.isCancelled,
+                      self.isCurrentArchiveOperation(id: operationID),
+                      self.scanCoordinator.snapshot?.id == currentSnapshotID else {
                     return
                 }
                 self.quickLookController.closePreview()
@@ -1581,10 +1684,78 @@ final class AppModel: ObservableObject {
     private func startScanNow(_ target: ScanTarget) {
         cancelArchiveOperation()
         let options = scanOptions(for: target)
+        previousScanComparisonBaseline = nil
+        pendingScanComparisonBaseline = comparisonBaseline(
+            for: target,
+            options: options,
+            currentSnapshot: scanCoordinator.snapshot
+        )
         sidebarScanCacheController.prepareForScanStart(target: target, options: options)
         scanCoordinator.startScan(target, options: options) {
             prepareForScan(target)
         }
+    }
+
+    private func comparisonBaseline(
+        for target: ScanTarget,
+        options: ScanOptions,
+        currentSnapshot: ScanSnapshot?
+    ) -> ScanSnapshot? {
+        guard let currentSnapshot,
+              currentSnapshot.isComplete,
+              currentSnapshot.source.allowsFileMutation,
+              currentSnapshot.target.kind == target.kind,
+              Self.normalizedTargetPath(currentSnapshot.target) == Self.normalizedTargetPath(target),
+              currentSnapshot.scanOptions == options else {
+            return nil
+        }
+        return currentSnapshot
+    }
+
+    private func retainComparisonBaseline(for completedSnapshot: ScanSnapshot) {
+        defer { pendingScanComparisonBaseline = nil }
+        guard let pendingScanComparisonBaseline,
+              Self.canUseAsComparisonBaseline(pendingScanComparisonBaseline, for: completedSnapshot) else {
+            previousScanComparisonBaseline = nil
+            return
+        }
+
+        previousScanComparisonBaseline = pendingScanComparisonBaseline
+    }
+
+    nonisolated private static func canUseAsComparisonBaseline(
+        _ previousSnapshot: ScanSnapshot,
+        for currentSnapshot: ScanSnapshot
+    ) -> Bool {
+        guard previousSnapshot.id != currentSnapshot.id,
+              previousSnapshot.isComplete,
+              currentSnapshot.isComplete,
+              previousSnapshot.source.allowsFileMutation,
+              currentSnapshot.source.allowsFileMutation,
+              previousSnapshot.target.kind == currentSnapshot.target.kind,
+              normalizedTargetPath(previousSnapshot.target) == normalizedTargetPath(currentSnapshot.target),
+              let previousOptions = previousSnapshot.scanOptions,
+              let currentOptions = currentSnapshot.scanOptions,
+              previousOptions == currentOptions else {
+            return false
+        }
+
+        let previousDate = previousSnapshot.finishedAt ?? previousSnapshot.startedAt
+        let currentDate = currentSnapshot.finishedAt ?? currentSnapshot.startedAt
+        guard previousDate <= currentDate else { return false }
+
+        if let previousRootIdentity = previousSnapshot.root.fileIdentity,
+           let currentRootIdentity = currentSnapshot.root.fileIdentity,
+           previousRootIdentity != currentRootIdentity {
+            return false
+        }
+        return true
+    }
+
+    nonisolated private static func normalizedTargetPath(_ target: ScanTarget) -> String {
+        URL(filePath: target.url.path, directoryHint: .isDirectory)
+            .standardizedFileURL
+            .path
     }
 
     func rescan() {
@@ -1610,6 +1781,7 @@ final class AppModel: ObservableObject {
         cancelDeferredNavigationContextUpdate()
         cancelPostTrashSnapshotRemoval()
         clearOptimisticTrashVisibility()
+        pendingScanComparisonBaseline = nil
         sidebarScanCacheController.cancelPendingSidebarTargetRestore()
         sidebarScanCacheController.clearActiveScanTracking()
         if resetState, scanCoordinator.snapshot == nil {
@@ -2822,6 +2994,8 @@ final class AppModel: ObservableObject {
         sidebarScanCacheController.cancelPendingSidebarTargetRestore()
         sidebarScanCacheController.clearActiveScanTracking()
         sidebarScanCacheController.clearDisplayedSnapshot()
+        previousScanComparisonBaseline = nil
+        pendingScanComparisonBaseline = nil
 
         deferredNavigationContextSnapshotID = snapshot.id
         scanCoordinator.restoreCompletedSnapshot(snapshot) {
@@ -2841,6 +3015,8 @@ final class AppModel: ObservableObject {
         pendingTrashSelection = nil
         discardPile = DiscardPileState()
         clearOptimisticTrashVisibility()
+        previousScanComparisonBaseline = nil
+        pendingScanComparisonBaseline = nil
         sidebarModel.setActiveTargetID(nil)
         quickLookController.closePreview()
     }
@@ -2922,6 +3098,7 @@ final class AppModel: ObservableObject {
     private func observeScanCoordinator() {
         scanCoordinator.onScanFinished = { [weak self] snapshot in
             self?.recordCompletedScan(snapshot)
+            self?.retainComparisonBaseline(for: snapshot)
         }
 
         scanCoordinator.$snapshot

--- a/Radix/ViewModels/AppModel.swift
+++ b/Radix/ViewModels/AppModel.swift
@@ -35,6 +35,23 @@ struct ExportConfirmationState: Identifiable, Equatable, Sendable {
 nonisolated enum ScanComparisonCandidateSource: Equatable, Sendable {
     case archive(URL)
     case currentSnapshot(UUID)
+    case retainedSnapshot(ScanSnapshot)
+
+    static func == (
+        lhs: ScanComparisonCandidateSource,
+        rhs: ScanComparisonCandidateSource
+    ) -> Bool {
+        switch (lhs, rhs) {
+        case (.archive(let lhsURL), .archive(let rhsURL)):
+            return lhsURL == rhsURL
+        case (.currentSnapshot(let lhsID), .currentSnapshot(let rhsID)):
+            return lhsID == rhsID
+        case (.retainedSnapshot(let lhsSnapshot), .retainedSnapshot(let rhsSnapshot)):
+            return lhsSnapshot.id == rhsSnapshot.id
+        default:
+            return false
+        }
+    }
 }
 
 nonisolated enum ScanComparisonSlot: String, CaseIterable, Identifiable, Sendable {
@@ -83,6 +100,20 @@ nonisolated struct ScanComparisonCandidate: Identifiable, Equatable, Sendable {
     init(snapshot: ScanSnapshot) {
         self.id = snapshot.id
         self.source = .currentSnapshot(snapshot.id)
+        self.displayName = snapshot.target.displayName
+        self.path = snapshot.target.url.path
+        self.targetKind = snapshot.target.kind
+        self.scanDate = snapshot.finishedAt ?? snapshot.startedAt
+        self.totalAllocatedSize = snapshot.aggregateStats.totalAllocatedSize
+        self.fileCount = snapshot.aggregateStats.fileCount
+        self.directoryCount = snapshot.aggregateStats.directoryCount
+        self.warningCount = snapshot.scanWarnings.count
+        self.scanOptions = snapshot.scanOptions
+    }
+
+    init(retainedSnapshot snapshot: ScanSnapshot) {
+        self.id = snapshot.id
+        self.source = .retainedSnapshot(snapshot)
         self.displayName = snapshot.target.displayName
         self.path = snapshot.target.url.path
         self.targetKind = snapshot.target.kind
@@ -932,7 +963,10 @@ final class AppModel: ObservableObject {
             return
         }
 
-        startLiveScanComparison(before: beforeSnapshot, after: afterSnapshot)
+        beginComparisonSetup(
+            before: ScanComparisonCandidate(retainedSnapshot: beforeSnapshot),
+            after: ScanComparisonCandidate(snapshot: afterSnapshot)
+        )
     }
 
     func compareCurrentScan(with sourceURL: URL) {
@@ -1356,43 +1390,6 @@ final class AppModel: ObservableObject {
         }
     }
 
-    private func startLiveScanComparison(before: ScanSnapshot, after: ScanSnapshot) {
-        cancelArchiveOperation()
-        scanComparison = nil
-        let currentSnapshotID = after.id
-        let operationID = beginArchiveOperation(
-            kind: .compare,
-            title: "Comparing Scans",
-            message: "Finding storage changes",
-            progressReporter: nil
-        )
-        snapshotArchiveTask = Task { @MainActor [weak self] in
-            guard let self else { return }
-            defer {
-                self.finishArchiveOperation(id: operationID)
-            }
-
-            do {
-                let comparisonTask = Task.detached(priority: .utility) {
-                    try await ScanComparisonService().compare(before: before, after: after)
-                }
-                let comparison = try await Self.value(cancelling: comparisonTask)
-                guard !Task.isCancelled,
-                      self.isCurrentArchiveOperation(id: operationID),
-                      self.scanCoordinator.snapshot?.id == currentSnapshotID else {
-                    return
-                }
-                self.quickLookController.closePreview()
-                self.scanComparison = comparison
-                self.lastErrorMessage = nil
-            } catch is CancellationError {
-                return
-            } catch {
-                self.presentError(error, title: "Comparison Failed")
-            }
-        }
-    }
-
     func confirmImportPreview() {
         guard canConfirmImportPreview,
               let preview = pendingImportPreview else {
@@ -1590,6 +1587,8 @@ final class AppModel: ObservableObject {
                 throw FileActionError.currentComparisonSnapshotUnavailable
             }
             return currentSnapshot
+        case .retainedSnapshot(let snapshot):
+            return snapshot
         }
     }
 

--- a/Radix/ViewModels/AppModel.swift
+++ b/Radix/ViewModels/AppModel.swift
@@ -53,6 +53,24 @@ nonisolated enum ScanComparisonSlot: String, CaseIterable, Identifiable, Sendabl
     }
 }
 
+nonisolated enum ScanComparisonCompatibilityWarning: Hashable, Sendable {
+    case unrelatedRoots
+    case differentScanOptions
+
+    var message: String {
+        switch self {
+        case .unrelatedRoots:
+            return "These snapshots scan unrelated roots, so the reported changes may not be meaningful."
+        case .differentScanOptions:
+            return "These snapshots use different scan options, so totals and file changes may not be directly comparable."
+        }
+    }
+
+    var symbolName: String {
+        "exclamationmark.triangle.fill"
+    }
+}
+
 nonisolated struct ScanComparisonCandidate: Identifiable, Equatable, Sendable {
     let id: UUID
     let source: ScanComparisonCandidateSource
@@ -63,6 +81,7 @@ nonisolated struct ScanComparisonCandidate: Identifiable, Equatable, Sendable {
     let fileCount: Int
     let directoryCount: Int
     let warningCount: Int
+    let scanOptions: ScanOptions?
 
     init(preview: ScanArchivePreview) {
         self.id = UUID()
@@ -74,6 +93,7 @@ nonisolated struct ScanComparisonCandidate: Identifiable, Equatable, Sendable {
         self.fileCount = preview.fileCount
         self.directoryCount = preview.directoryCount
         self.warningCount = preview.warningCount
+        self.scanOptions = preview.scanOptions
     }
 
     init(snapshot: ScanSnapshot) {
@@ -86,6 +106,7 @@ nonisolated struct ScanComparisonCandidate: Identifiable, Equatable, Sendable {
         self.fileCount = snapshot.aggregateStats.fileCount
         self.directoryCount = snapshot.aggregateStats.directoryCount
         self.warningCount = snapshot.scanWarnings.count
+        self.scanOptions = snapshot.scanOptions
     }
 
     var isCurrentScan: Bool {
@@ -136,6 +157,25 @@ nonisolated struct ScanComparisonSetup: Identifiable, Equatable, Sendable {
         return nil
     }
 
+    var compatibilityWarnings: [ScanComparisonCompatibilityWarning] {
+        guard let before,
+              let after,
+              before.source != after.source else {
+            return []
+        }
+
+        var warnings: [ScanComparisonCompatibilityWarning] = []
+        if !Self.rootsAreRelated(before.path, after.path) {
+            warnings.append(.unrelatedRoots)
+        }
+        if let beforeOptions = before.scanOptions,
+           let afterOptions = after.scanOptions,
+           beforeOptions != afterOptions {
+            warnings.append(.differentScanOptions)
+        }
+        return warnings
+    }
+
     var resolvedCandidates: (before: ScanComparisonCandidate, after: ScanComparisonCandidate)? {
         guard let before,
               let after else {
@@ -174,6 +214,19 @@ nonisolated struct ScanComparisonSetup: Identifiable, Equatable, Sendable {
 
     mutating func swap() {
         Swift.swap(&before, &after)
+    }
+
+    private static func rootsAreRelated(_ firstPath: String, _ secondPath: String) -> Bool {
+        let first = URL(filePath: firstPath, directoryHint: .isDirectory)
+            .standardizedFileURL
+            .path
+        let second = URL(filePath: secondPath, directoryHint: .isDirectory)
+            .standardizedFileURL
+            .path
+
+        guard first != second else { return true }
+        guard first != "/", second != "/" else { return true }
+        return first.hasPrefix(second + "/") || second.hasPrefix(first + "/")
     }
 }
 

--- a/Radix/ViewModels/WorkspaceNavigationModel.swift
+++ b/Radix/ViewModels/WorkspaceNavigationModel.swift
@@ -166,6 +166,29 @@ private extension WorkspaceNavigationState {
         return next.refreshedDerivedState()
     }
 
+    func revealing(_ nodeID: FileNodeRecord.ID) -> WorkspaceNavigationState {
+        guard fileTreeStore?.node(id: nodeID) != nil else {
+            return selecting(nil)
+        }
+
+        // Reveal the node in context: focus its containing folder (so the file list
+        // shows its siblings) and select it. Unlike selectingAndFocusing, this does not
+        // zoom into the node itself, which would show an empty view for a file.
+        let focusTarget = fileTreeStore?.parent(of: nodeID)?.id ?? nodeID
+        var next = self
+        if next.focusedNodeID != focusTarget {
+            if let currentFocusID = next.focusedNodeID {
+                next.focusBackStack.append(currentFocusID)
+            }
+            next.focusForwardStack.removeAll()
+            next.focusedNodeID = focusTarget
+        }
+        next.selectedNodeID = nodeID
+        next.selectedNodeIDs = [nodeID]
+
+        return next.refreshedDerivedState()
+    }
+
     func settingFocusedNodeID(_ nodeID: FileNodeRecord.ID?) -> WorkspaceNavigationState {
         guard let nodeID else {
             var next = self
@@ -487,6 +510,10 @@ final class WorkspaceNavigationModel: ObservableObject {
 
     func selectAndFocus(nodeID: String) {
         publish(state.selectingAndFocusing(nodeID))
+    }
+
+    func reveal(nodeID: String) {
+        publish(state.revealing(nodeID))
     }
 
     func setFocusedNodeID(_ nodeID: String?) {

--- a/RadixCoreTests/AppModelDependencyTests.swift
+++ b/RadixCoreTests/AppModelDependencyTests.swift
@@ -2438,6 +2438,49 @@ final class AppModelDependencyTests: XCTestCase {
     }
 
     @MainActor
+    func testDroppedComparisonSnapshotLoadsIntoRequestedSlot() async throws {
+        let archiveURL = URL(filePath: "/tmp/dropped.radixscan", directoryHint: .isDirectory)
+        let snapshot = makeComparisonSnapshot(
+            rootPath: "/dropped-root",
+            fileSize: 10,
+            sourceURL: archiveURL
+        )
+        let archiveService = try SpyScanArchiveService(
+            previewResultsByURL: [
+                archiveURL: makeArchivePreview(archiveURL: archiveURL, snapshot: snapshot),
+            ]
+        )
+        let model = AppModel(dependencies: makeDependencies(scanArchiveService: archiveService))
+
+        model.compareScanSnapshots()
+        model.dropComparisonSnapshot(archiveURL, for: .after)
+
+        try await waitForAppModelCondition("dropped comparison snapshot loaded") {
+            model.pendingComparisonSetup?.after?.displayName == snapshot.target.displayName
+        }
+
+        XCTAssertNil(model.pendingComparisonSetup?.before)
+        let previewedURLs = await archiveService.previewedURLsSnapshot()
+        XCTAssertEqual(previewedURLs, [archiveURL])
+    }
+
+    @MainActor
+    func testDroppedComparisonSnapshotRejectsOtherFileTypes() async throws {
+        let archiveService = SpyScanArchiveService()
+        let model = AppModel(dependencies: makeDependencies(scanArchiveService: archiveService))
+
+        model.compareScanSnapshots()
+        model.dropComparisonSnapshot(URL(filePath: "/tmp/not-a-scan.zip"), for: .before)
+
+        XCTAssertEqual(
+            model.pendingComparisonSetup?.errorMessage,
+            "Drop a .radixscan saved scan."
+        )
+        let previewedURLs = await archiveService.previewedURLsSnapshot()
+        XCTAssertTrue(previewedURLs.isEmpty)
+    }
+
+    @MainActor
     func testComparisonSetupRejectsReverseChronologicalOrder() async throws {
         let oldURL = URL(filePath: "/tmp/swap-old.radixscan", directoryHint: .isDirectory)
         let newURL = URL(filePath: "/tmp/swap-new.radixscan", directoryHint: .isDirectory)

--- a/RadixCoreTests/AppModelDependencyTests.swift
+++ b/RadixCoreTests/AppModelDependencyTests.swift
@@ -2379,6 +2379,18 @@ final class AppModelDependencyTests: XCTestCase {
         XCTAssertEqual(model.scanComparison?.rows.first?.kind, .grew)
         XCTAssertEqual(model.scanComparison?.rows.first?.allocatedDelta, 25)
         XCTAssertNil(model.scanState.snapshot)
+
+        let activeComparisonID = try XCTUnwrap(model.scanComparison?.id)
+
+        model.compareScanSnapshots()
+
+        XCTAssertEqual(model.scanComparison?.id, activeComparisonID)
+        XCTAssertNotNil(model.pendingComparisonSetup)
+
+        model.cancelComparisonSetup()
+
+        XCTAssertEqual(model.scanComparison?.id, activeComparisonID)
+        XCTAssertNil(model.pendingComparisonSetup)
     }
 
     @MainActor

--- a/RadixCoreTests/AppModelDependencyTests.swift
+++ b/RadixCoreTests/AppModelDependencyTests.swift
@@ -2456,6 +2456,52 @@ final class AppModelDependencyTests: XCTestCase {
 
         XCTAssertFalse(model.canCompareCurrentScanWithSnapshot)
     }
+
+    func testComparisonSetupWarnsAboutUnrelatedRootsAndDifferentScanOptions() {
+        var beforeOptions = ScanOptions()
+        beforeOptions.includeHiddenFiles = true
+        var afterOptions = beforeOptions
+        afterOptions.treatPackagesAsDirectories = true
+
+        let setup = ScanComparisonSetup(
+            before: ScanComparisonCandidate(snapshot: makeComparisonSnapshot(
+                rootPath: "/Users/example/Documents",
+                fileSize: 10,
+                scanOptions: beforeOptions
+            )),
+            after: ScanComparisonCandidate(snapshot: makeComparisonSnapshot(
+                rootPath: "/Volumes/Backup/Documents",
+                fileSize: 20,
+                scanOptions: afterOptions
+            ))
+        )
+
+        XCTAssertTrue(setup.canCompare)
+        XCTAssertEqual(
+            setup.compatibilityWarnings,
+            [.unrelatedRoots, .differentScanOptions]
+        )
+    }
+
+    func testComparisonSetupDoesNotWarnForRelatedRootsWithMatchingScanOptions() {
+        var options = ScanOptions()
+        options.exclusionPatterns = ["*.tmp"]
+
+        let setup = ScanComparisonSetup(
+            before: ScanComparisonCandidate(snapshot: makeComparisonSnapshot(
+                rootPath: "/Users/example",
+                fileSize: 10,
+                scanOptions: options
+            )),
+            after: ScanComparisonCandidate(snapshot: makeComparisonSnapshot(
+                rootPath: "/Users/example/Documents",
+                fileSize: 20,
+                scanOptions: options
+            ))
+        )
+
+        XCTAssertTrue(setup.compatibilityWarnings.isEmpty)
+    }
 }
 
 @MainActor
@@ -2655,7 +2701,8 @@ private func makeComparisonSnapshot(
     fileSize: Int64,
     startedAt: Date = Date(timeIntervalSince1970: 1),
     finishedAt: Date? = Date(timeIntervalSince1970: 2),
-    sourceURL: URL? = nil
+    sourceURL: URL? = nil,
+    scanOptions: ScanOptions? = nil
 ) -> ScanSnapshot {
     let file = makeTestFileNode(id: "\(rootPath)/shared.bin", name: "shared.bin", size: fileSize)
     let root = makeTestDirectoryNode(id: rootPath, name: URL(filePath: rootPath).lastPathComponent, children: [file])
@@ -2679,6 +2726,7 @@ private func makeComparisonSnapshot(
         scanWarnings: [],
         aggregateStats: store.aggregateStats,
         isComplete: true,
+        scanOptions: scanOptions,
         source: source
     )
 }

--- a/RadixCoreTests/AppModelDependencyTests.swift
+++ b/RadixCoreTests/AppModelDependencyTests.swift
@@ -2343,6 +2343,7 @@ final class AppModelDependencyTests: XCTestCase {
             systemActions: actions,
             scanArchiveService: archiveService
         ))
+        model.dismissOnboarding()
         model.scanState.restoreCompletedSnapshot(currentSnapshot)
 
         XCTAssertTrue(model.canCompareCurrentScanWithSnapshot)
@@ -2369,6 +2370,13 @@ final class AppModelDependencyTests: XCTestCase {
         XCTAssertEqual(model.scanComparison?.rows.first?.kind, .grew)
         XCTAssertEqual(model.scanComparison?.rows.first?.allocatedDelta, 20)
         XCTAssertEqual(model.scanState.snapshot?.id, currentSnapshot.id)
+        XCTAssertFalse(model.canUseWorkspaceCommands)
+        XCTAssertTrue(model.isQuickLookKeyboardShortcutBlocked)
+
+        model.closeScanComparison()
+
+        XCTAssertTrue(model.canUseWorkspaceCommands)
+        XCTAssertFalse(model.isQuickLookKeyboardShortcutBlocked)
     }
 
     @MainActor

--- a/RadixCoreTests/AppModelDependencyTests.swift
+++ b/RadixCoreTests/AppModelDependencyTests.swift
@@ -2241,6 +2241,213 @@ final class AppModelDependencyTests: XCTestCase {
         XCTAssertEqual(model.scanState.selectedTarget, liveTarget)
         XCTAssertNotEqual(model.scanState.snapshot?.id, importedSnapshot.id)
     }
+
+    @MainActor
+    func testCompareScanSnapshotsOpensSetupBeforeFileSelection() async throws {
+        let oldURL = URL(filePath: "/tmp/old.radixscan", directoryHint: .isDirectory)
+        let newURL = URL(filePath: "/tmp/new.radixscan", directoryHint: .isDirectory)
+        let oldSnapshot = makeComparisonSnapshot(
+            rootPath: "/old-root",
+            fileSize: 10,
+            startedAt: Date(timeIntervalSince1970: 10),
+            finishedAt: Date(timeIntervalSince1970: 20),
+            sourceURL: oldURL
+        )
+        let newSnapshot = makeComparisonSnapshot(
+            rootPath: "/new-root",
+            fileSize: 35,
+            startedAt: Date(timeIntervalSince1970: 30),
+            finishedAt: Date(timeIntervalSince1970: 40),
+            sourceURL: newURL
+        )
+        let archiveService = try SpyScanArchiveService(
+            previewResultsByURL: [
+                oldURL: makeArchivePreview(archiveURL: oldURL, snapshot: oldSnapshot),
+                newURL: makeArchivePreview(archiveURL: newURL, snapshot: newSnapshot),
+            ],
+            importResultsByURL: [
+                oldURL: makeArchiveImportResult(archiveURL: oldURL, snapshot: oldSnapshot),
+                newURL: makeArchiveImportResult(archiveURL: newURL, snapshot: newSnapshot),
+            ]
+        )
+        var selectedSnapshotURLs = [oldURL, newURL]
+        var actions = AppSystemActions.inert
+        actions.presentComparisonSnapshotPanel = {
+            selectedSnapshotURLs.removeFirst()
+        }
+        let model = AppModel(dependencies: makeDependencies(
+            systemActions: actions,
+            scanArchiveService: archiveService
+        ))
+
+        model.compareScanSnapshots()
+        XCTAssertNotNil(model.pendingComparisonSetup)
+        XCTAssertNil(model.pendingComparisonSetup?.before)
+        XCTAssertNil(model.pendingComparisonSetup?.after)
+
+        model.chooseComparisonSnapshot(for: .before)
+
+        try await waitForAppModelCondition("comparison setup built") {
+            model.pendingComparisonSetup?.before?.displayName == oldSnapshot.target.displayName
+        }
+
+        model.chooseComparisonSnapshot(for: .after)
+
+        try await waitForAppModelCondition("comparison setup completed") {
+            model.pendingComparisonSetup?.after?.displayName == newSnapshot.target.displayName
+        }
+
+        let previewedURLs = await archiveService.previewedURLsSnapshot()
+        XCTAssertEqual(previewedURLs, [oldURL, newURL])
+        let importedURLsBeforeConfirm = await archiveService.importedURLsSnapshot()
+        XCTAssertTrue(importedURLsBeforeConfirm.isEmpty)
+
+        model.confirmComparisonSetup()
+
+        try await waitForAppModelCondition("comparison built") {
+            model.scanComparison?.summary.changedCount == 1
+        }
+
+        let importedURLs = await archiveService.importedURLsSnapshot()
+        XCTAssertEqual(importedURLs, [oldURL, newURL])
+        XCTAssertEqual(model.scanComparison?.before.id, oldSnapshot.id)
+        XCTAssertEqual(model.scanComparison?.after.id, newSnapshot.id)
+        XCTAssertEqual(model.scanComparison?.rows.first?.kind, .grew)
+        XCTAssertEqual(model.scanComparison?.rows.first?.allocatedDelta, 25)
+        XCTAssertNil(model.scanState.snapshot)
+    }
+
+    @MainActor
+    func testCompareCurrentScanWithSnapshotUsesCurrentScanAsAfter() async throws {
+        let archiveURL = URL(filePath: "/tmp/current-compare.radixscan", directoryHint: .isDirectory)
+        let archivedSnapshot = makeComparisonSnapshot(
+            rootPath: "/archived-root",
+            fileSize: 10,
+            sourceURL: archiveURL
+        )
+        let currentSnapshot = makeComparisonSnapshot(
+            rootPath: "/current-root",
+            fileSize: 30
+        )
+        let archiveService = try SpyScanArchiveService(
+            previewResultsByURL: [
+                archiveURL: makeArchivePreview(archiveURL: archiveURL, snapshot: archivedSnapshot),
+            ],
+            importResultsByURL: [
+                archiveURL: makeArchiveImportResult(archiveURL: archiveURL, snapshot: archivedSnapshot),
+            ]
+        )
+        var actions = AppSystemActions.inert
+        actions.presentComparisonSnapshotPanel = { archiveURL }
+        let model = AppModel(dependencies: makeDependencies(
+            systemActions: actions,
+            scanArchiveService: archiveService
+        ))
+        model.scanState.restoreCompletedSnapshot(currentSnapshot)
+
+        XCTAssertTrue(model.canCompareCurrentScanWithSnapshot)
+
+        model.compareCurrentScanWithSnapshot()
+
+        XCTAssertNil(model.pendingComparisonSetup?.before)
+        XCTAssertEqual(model.pendingComparisonSetup?.after?.id, currentSnapshot.id)
+
+        model.chooseComparisonSnapshot(for: .before)
+
+        try await waitForAppModelCondition("current comparison setup built") {
+            model.pendingComparisonSetup?.before?.displayName == archivedSnapshot.target.displayName
+        }
+
+        model.confirmComparisonSetup()
+
+        try await waitForAppModelCondition("current comparison built") {
+            model.scanComparison?.summary.changedCount == 1
+        }
+
+        XCTAssertEqual(model.scanComparison?.before.id, archivedSnapshot.id)
+        XCTAssertEqual(model.scanComparison?.after.id, currentSnapshot.id)
+        XCTAssertEqual(model.scanComparison?.rows.first?.kind, .grew)
+        XCTAssertEqual(model.scanComparison?.rows.first?.allocatedDelta, 20)
+        XCTAssertEqual(model.scanState.snapshot?.id, currentSnapshot.id)
+    }
+
+    @MainActor
+    func testComparisonSetupSwapReversesFinalDiffDirection() async throws {
+        let oldURL = URL(filePath: "/tmp/swap-old.radixscan", directoryHint: .isDirectory)
+        let newURL = URL(filePath: "/tmp/swap-new.radixscan", directoryHint: .isDirectory)
+        let oldSnapshot = makeComparisonSnapshot(
+            rootPath: "/swap-old",
+            fileSize: 10,
+            startedAt: Date(timeIntervalSince1970: 10),
+            finishedAt: Date(timeIntervalSince1970: 20),
+            sourceURL: oldURL
+        )
+        let newSnapshot = makeComparisonSnapshot(
+            rootPath: "/swap-new",
+            fileSize: 35,
+            startedAt: Date(timeIntervalSince1970: 30),
+            finishedAt: Date(timeIntervalSince1970: 40),
+            sourceURL: newURL
+        )
+        let archiveService = try SpyScanArchiveService(
+            previewResultsByURL: [
+                oldURL: makeArchivePreview(archiveURL: oldURL, snapshot: oldSnapshot),
+                newURL: makeArchivePreview(archiveURL: newURL, snapshot: newSnapshot),
+            ],
+            importResultsByURL: [
+                oldURL: makeArchiveImportResult(archiveURL: oldURL, snapshot: oldSnapshot),
+                newURL: makeArchiveImportResult(archiveURL: newURL, snapshot: newSnapshot),
+            ]
+        )
+        var selectedSnapshotURLs = [oldURL, newURL]
+        var actions = AppSystemActions.inert
+        actions.presentComparisonSnapshotPanel = {
+            selectedSnapshotURLs.removeFirst()
+        }
+        let model = AppModel(dependencies: makeDependencies(
+            systemActions: actions,
+            scanArchiveService: archiveService
+        ))
+
+        model.compareScanSnapshots()
+        model.chooseComparisonSnapshot(for: .before)
+        try await waitForAppModelCondition("comparison setup built") {
+            model.pendingComparisonSetup?.before?.displayName == oldSnapshot.target.displayName
+        }
+        model.chooseComparisonSnapshot(for: .after)
+        try await waitForAppModelCondition("comparison setup completed") {
+            model.pendingComparisonSetup?.after?.displayName == newSnapshot.target.displayName
+        }
+
+        model.swapPendingComparisonSetup()
+        XCTAssertEqual(model.pendingComparisonSetup?.before?.displayName, newSnapshot.target.displayName)
+
+        model.confirmComparisonSetup()
+
+        try await waitForAppModelCondition("swapped comparison built") {
+            model.scanComparison?.summary.changedCount == 1
+        }
+
+        XCTAssertEqual(model.scanComparison?.before.id, newSnapshot.id)
+        XCTAssertEqual(model.scanComparison?.after.id, oldSnapshot.id)
+        XCTAssertEqual(model.scanComparison?.rows.first?.kind, .shrank)
+        XCTAssertEqual(model.scanComparison?.rows.first?.allocatedDelta, -25)
+    }
+
+    @MainActor
+    func testImportedSnapshotCannotBeComparedAsCurrentScan() {
+        let archiveURL = URL(filePath: "/tmp/imported-current.radixscan", directoryHint: .isDirectory)
+        let importedSnapshot = makeComparisonSnapshot(
+            rootPath: "/imported-current",
+            fileSize: 10,
+            sourceURL: archiveURL
+        )
+        let model = AppModel(dependencies: makeDependencies())
+
+        model.scanState.restoreCompletedSnapshot(importedSnapshot)
+
+        XCTAssertFalse(model.canCompareCurrentScanWithSnapshot)
+    }
 }
 
 @MainActor
@@ -2435,6 +2642,88 @@ private func installSelection(
     return file
 }
 
+private func makeComparisonSnapshot(
+    rootPath: String,
+    fileSize: Int64,
+    startedAt: Date = Date(timeIntervalSince1970: 1),
+    finishedAt: Date? = Date(timeIntervalSince1970: 2),
+    sourceURL: URL? = nil
+) -> ScanSnapshot {
+    let file = makeTestFileNode(id: "\(rootPath)/shared.bin", name: "shared.bin", size: fileSize)
+    let root = makeTestDirectoryNode(id: rootPath, name: URL(filePath: rootPath).lastPathComponent, children: [file])
+    let store = FileTreeStore(root: root, childrenByID: [root.id: [file]])
+    let source: ScanSnapshotSource
+    if let sourceURL {
+        source = .imported(ImportedSnapshotContext(
+            sourceURL: sourceURL,
+            pathMode: .absolute,
+            liveActionCapability: .pathValidation
+        ))
+    } else {
+        source = .live
+    }
+
+    return ScanSnapshot(
+        target: ScanTarget(id: root.id, url: root.url, displayName: root.name, kind: .folder),
+        treeStore: store,
+        startedAt: startedAt,
+        finishedAt: finishedAt,
+        scanWarnings: [],
+        aggregateStats: store.aggregateStats,
+        isComplete: true,
+        source: source
+    )
+}
+
+private func makeArchiveImportResult(
+    archiveURL: URL,
+    snapshot: ScanSnapshot
+) throws -> ScanArchiveImportResult {
+    let manifest = try ScanArchiveDocument(
+        exportedAt: Date(timeIntervalSince1970: 3),
+        appVersion: "Tests",
+        snapshot: snapshot,
+        pathMode: .absolute,
+        sections: ScanArchiveSections(
+            nodes: "nodes.jsonl",
+            topology: "topology.json",
+            warnings: "warnings.json",
+            stats: "stats.json"
+        ),
+        nodeChecksum: "checksum"
+    )
+    return ScanArchiveImportResult(
+        archiveURL: archiveURL,
+        snapshot: snapshot,
+        manifest: manifest
+    )
+}
+
+private func makeArchivePreview(
+    archiveURL: URL,
+    snapshot: ScanSnapshot
+) throws -> ScanArchivePreview {
+    let manifest = try ScanArchiveDocument(
+        exportedAt: Date(timeIntervalSince1970: 3),
+        appVersion: "Tests",
+        snapshot: snapshot,
+        pathMode: .absolute,
+        sections: ScanArchiveSections(
+            nodes: "nodes.jsonl",
+            topology: "topology.json",
+            warnings: "warnings.json",
+            stats: "stats.json"
+        ),
+        nodeChecksum: "checksum"
+    )
+    return ScanArchivePreview(
+        archiveURL: archiveURL,
+        archiveSize: 1,
+        manifest: manifest,
+        stats: ScanArchiveStatsV1(snapshot.aggregateStats)
+    )
+}
+
 private final class SpyAppPreferencesStore: AppPreferencesPersisting {
     var preferences: AppPreferences
     var savedScanPreferences: [AppScanPreferences] = []
@@ -2600,7 +2889,9 @@ private actor SpyScanArchiveService: ScanArchiveServicing {
     private(set) var previewedURLs: [URL] = []
     private(set) var importedURLs: [URL] = []
     private let previewResult: ScanArchivePreview?
+    private let previewResultsByURL: [URL: ScanArchivePreview]
     private let importResult: ScanArchiveImportResult?
+    private let importResultsByURL: [URL: ScanArchiveImportResult]
     private let exportWaitProbe: AsyncValueProbe<Void>?
     private let previewWaitProbe: AsyncValueProbe<Void>?
     private let importWaitProbe: AsyncValueProbe<Void>?
@@ -2610,13 +2901,17 @@ private actor SpyScanArchiveService: ScanArchiveServicing {
 
     init(
         previewResult: ScanArchivePreview? = nil,
+        previewResultsByURL: [URL: ScanArchivePreview] = [:],
         importResult: ScanArchiveImportResult? = nil,
+        importResultsByURL: [URL: ScanArchiveImportResult] = [:],
         exportWaitProbe: AsyncValueProbe<Void>? = nil,
         previewWaitProbe: AsyncValueProbe<Void>? = nil,
         importWaitProbe: AsyncValueProbe<Void>? = nil
     ) {
         self.previewResult = previewResult
+        self.previewResultsByURL = previewResultsByURL
         self.importResult = importResult
+        self.importResultsByURL = importResultsByURL
         self.exportWaitProbe = exportWaitProbe
         self.previewWaitProbe = previewWaitProbe
         self.importWaitProbe = importWaitProbe
@@ -2645,6 +2940,9 @@ private actor SpyScanArchiveService: ScanArchiveServicing {
             await previewWaitProbe.wait()
         }
         previewCancellationStates.append(Task.isCancelled)
+        if let result = previewResultsByURL[sourceURL] {
+            return result
+        }
         guard let previewResult else {
             throw ScanArchiveError.invalidArchivePackage("missing spy preview result")
         }
@@ -2660,6 +2958,9 @@ private actor SpyScanArchiveService: ScanArchiveServicing {
             await importWaitProbe.wait()
         }
         importCancellationStates.append(Task.isCancelled)
+        if let result = importResultsByURL[sourceURL] {
+            return result
+        }
         guard let importResult else {
             throw ScanArchiveError.invalidArchivePackage("missing spy import result")
         }

--- a/RadixCoreTests/AppModelDependencyTests.swift
+++ b/RadixCoreTests/AppModelDependencyTests.swift
@@ -243,6 +243,64 @@ final class AppModelDependencyTests: XCTestCase {
     }
 
     @MainActor
+    func testCompareWithPreviousScanUsesCompatibleRescanBaseline() async throws {
+        let scanService = ControlledAppModelScanService()
+        let model = AppModel(dependencies: makeDependencies(scanService: scanService))
+        let target = makeTestTarget("/comparison-baseline")
+
+        model.startScan(target)
+        try await waitUntil("first comparison scan started") {
+            scanService.requests.count == 1
+        }
+        let firstOptions = try XCTUnwrap(scanService.options.first)
+        let firstSnapshot = makeComparisonSnapshot(
+            rootPath: "/comparison-baseline",
+            fileSize: 10,
+            startedAt: Date(timeIntervalSince1970: 10),
+            finishedAt: Date(timeIntervalSince1970: 20),
+            scanOptions: firstOptions
+        )
+        scanService.yield(.finished(firstSnapshot), scanIndex: 0)
+        scanService.finish(scanIndex: 0)
+        try await waitUntil("first comparison scan completed") {
+            model.scanState.snapshot?.id == firstSnapshot.id
+        }
+
+        model.rescan()
+        try await waitUntil("second comparison scan started") {
+            scanService.requests.count == 2
+        }
+        let secondOptions = try XCTUnwrap(scanService.options.last)
+        XCTAssertEqual(secondOptions, firstOptions)
+        let secondSnapshot = makeComparisonSnapshot(
+            rootPath: "/comparison-baseline",
+            fileSize: 35,
+            startedAt: Date(timeIntervalSince1970: 30),
+            finishedAt: Date(timeIntervalSince1970: 40),
+            scanOptions: secondOptions
+        )
+        scanService.yield(.finished(secondSnapshot), scanIndex: 1)
+        scanService.finish(scanIndex: 1)
+        try await waitUntil("second comparison scan completed") {
+            model.scanState.snapshot?.id == secondSnapshot.id
+        }
+
+        XCTAssertTrue(model.canCompareCurrentScanWithPreviousScan)
+        model.compareCurrentScanWithPreviousScan()
+
+        try await waitForAppModelCondition("previous scan comparison built") {
+            model.scanComparison?.after.id == secondSnapshot.id
+        }
+
+        XCTAssertEqual(model.scanComparison?.before.id, firstSnapshot.id)
+        XCTAssertEqual(model.scanComparison?.rows.first?.kind, .grew)
+        XCTAssertEqual(model.scanComparison?.rows.first?.allocatedDelta, 25)
+        let location = try XCTUnwrap(model.scanComparison?.topLevelChanges.first)
+        XCTAssertEqual(location.relativePath, "shared.bin")
+        XCTAssertTrue(model.canShowComparisonLocationInBrowser(location))
+    }
+
+    @MainActor
     func testFullDiskAccessFromOnboardingShowsWelcomeAfterRelaunch() {
         let preferences = SpyAppPreferencesStore(
             preferences: AppPreferences(
@@ -2247,14 +2305,14 @@ final class AppModelDependencyTests: XCTestCase {
         let oldURL = URL(filePath: "/tmp/old.radixscan", directoryHint: .isDirectory)
         let newURL = URL(filePath: "/tmp/new.radixscan", directoryHint: .isDirectory)
         let oldSnapshot = makeComparisonSnapshot(
-            rootPath: "/old-root",
+            rootPath: "/comparison-root",
             fileSize: 10,
             startedAt: Date(timeIntervalSince1970: 10),
             finishedAt: Date(timeIntervalSince1970: 20),
             sourceURL: oldURL
         )
         let newSnapshot = makeComparisonSnapshot(
-            rootPath: "/new-root",
+            rootPath: "/comparison-root",
             fileSize: 35,
             startedAt: Date(timeIntervalSince1970: 30),
             finishedAt: Date(timeIntervalSince1970: 40),
@@ -2321,7 +2379,7 @@ final class AppModelDependencyTests: XCTestCase {
     func testCompareCurrentScanWithSnapshotUsesCurrentScanAsAfter() async throws {
         let archiveURL = URL(filePath: "/tmp/current-compare.radixscan", directoryHint: .isDirectory)
         let archivedSnapshot = makeComparisonSnapshot(
-            rootPath: "/archived-root",
+            rootPath: "/current-root",
             fileSize: 10,
             sourceURL: archiveURL
         )
@@ -2380,18 +2438,18 @@ final class AppModelDependencyTests: XCTestCase {
     }
 
     @MainActor
-    func testComparisonSetupSwapReversesFinalDiffDirection() async throws {
+    func testComparisonSetupRejectsReverseChronologicalOrder() async throws {
         let oldURL = URL(filePath: "/tmp/swap-old.radixscan", directoryHint: .isDirectory)
         let newURL = URL(filePath: "/tmp/swap-new.radixscan", directoryHint: .isDirectory)
         let oldSnapshot = makeComparisonSnapshot(
-            rootPath: "/swap-old",
+            rootPath: "/swap-root",
             fileSize: 10,
             startedAt: Date(timeIntervalSince1970: 10),
             finishedAt: Date(timeIntervalSince1970: 20),
             sourceURL: oldURL
         )
         let newSnapshot = makeComparisonSnapshot(
-            rootPath: "/swap-new",
+            rootPath: "/swap-root",
             fileSize: 35,
             startedAt: Date(timeIntervalSince1970: 30),
             finishedAt: Date(timeIntervalSince1970: 40),
@@ -2429,17 +2487,11 @@ final class AppModelDependencyTests: XCTestCase {
 
         model.swapPendingComparisonSetup()
         XCTAssertEqual(model.pendingComparisonSetup?.before?.displayName, newSnapshot.target.displayName)
-
-        model.confirmComparisonSetup()
-
-        try await waitForAppModelCondition("swapped comparison built") {
-            model.scanComparison?.summary.changedCount == 1
-        }
-
-        XCTAssertEqual(model.scanComparison?.before.id, newSnapshot.id)
-        XCTAssertEqual(model.scanComparison?.after.id, oldSnapshot.id)
-        XCTAssertEqual(model.scanComparison?.rows.first?.kind, .shrank)
-        XCTAssertEqual(model.scanComparison?.rows.first?.allocatedDelta, -25)
+        XCTAssertFalse(model.pendingComparisonSetup?.canCompare ?? true)
+        XCTAssertEqual(
+            model.pendingComparisonSetup?.validationMessage,
+            "The earlier scan must precede the later scan."
+        )
     }
 
     @MainActor
@@ -2457,7 +2509,7 @@ final class AppModelDependencyTests: XCTestCase {
         XCTAssertFalse(model.canCompareCurrentScanWithSnapshot)
     }
 
-    func testComparisonSetupWarnsAboutUnrelatedRootsAndDifferentScanOptions() {
+    func testComparisonSetupBlocksDifferentScanSettings() {
         var beforeOptions = ScanOptions()
         beforeOptions.includeHiddenFiles = true
         var afterOptions = beforeOptions
@@ -2470,20 +2522,20 @@ final class AppModelDependencyTests: XCTestCase {
                 scanOptions: beforeOptions
             )),
             after: ScanComparisonCandidate(snapshot: makeComparisonSnapshot(
-                rootPath: "/Volumes/Backup/Documents",
+                rootPath: "/Users/example/Documents",
                 fileSize: 20,
                 scanOptions: afterOptions
             ))
         )
 
-        XCTAssertTrue(setup.canCompare)
+        XCTAssertFalse(setup.canCompare)
         XCTAssertEqual(
-            setup.compatibilityWarnings,
-            [.unrelatedRoots, .differentScanOptions]
+            setup.validationMessage,
+            "Choose scans made with the same scan settings."
         )
     }
 
-    func testComparisonSetupDoesNotWarnForRelatedRootsWithMatchingScanOptions() {
+    func testComparisonSetupBlocksDifferentRootsWithMatchingScanOptions() {
         var options = ScanOptions()
         options.exclusionPatterns = ["*.tmp"]
 
@@ -2500,7 +2552,43 @@ final class AppModelDependencyTests: XCTestCase {
             ))
         )
 
-        XCTAssertTrue(setup.compatibilityWarnings.isEmpty)
+        XCTAssertFalse(setup.canCompare)
+        XCTAssertEqual(setup.validationMessage, "Choose scans of the same location.")
+    }
+
+    func testComparisonSetupBlocksDifferentTargetKinds() {
+        let options = ScanOptions()
+        let setup = ScanComparisonSetup(
+            before: ScanComparisonCandidate(snapshot: makeComparisonSnapshot(
+                rootPath: "/Users/example",
+                fileSize: 10,
+                scanOptions: options,
+                targetKind: .folder
+            )),
+            after: ScanComparisonCandidate(snapshot: makeComparisonSnapshot(
+                rootPath: "/Users/example",
+                fileSize: 20,
+                scanOptions: options,
+                targetKind: .volume
+            ))
+        )
+
+        XCTAssertFalse(setup.canCompare)
+        XCTAssertEqual(setup.validationMessage, "Choose scans of the same location.")
+    }
+
+    func testComparisonSetupDoesNotOfferCurrentScanInBothSlots() {
+        let currentSnapshot = makeComparisonSnapshot(
+            rootPath: "/Users/example",
+            fileSize: 20,
+            scanOptions: ScanOptions()
+        )
+        let setup = ScanComparisonSetup(
+            after: ScanComparisonCandidate(snapshot: currentSnapshot)
+        )
+
+        XCTAssertFalse(setup.canAssignCurrentScan(to: .before))
+        XCTAssertTrue(setup.canAssignCurrentScan(to: .after))
     }
 }
 
@@ -2571,6 +2659,7 @@ private final class ControlledAppModelScanService: ScanEventStreaming, @unchecke
     private let lock = NSLock()
     private var continuations: [Continuation] = []
     private var storedRequests: [ScanTarget] = []
+    private var storedOptions: [ScanOptions] = []
 
     var requests: [ScanTarget] {
         lock.lock()
@@ -2578,11 +2667,18 @@ private final class ControlledAppModelScanService: ScanEventStreaming, @unchecke
         return storedRequests
     }
 
+    var options: [ScanOptions] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedOptions
+    }
+
     func scan(target: ScanTarget, options: ScanOptions) -> AsyncThrowingStream<ScanProgressEvent, Error> {
         AsyncThrowingStream { continuation in
             lock.lock()
             continuations.append(continuation)
             storedRequests.append(target)
+            storedOptions.append(options)
             lock.unlock()
         }
     }
@@ -2702,7 +2798,8 @@ private func makeComparisonSnapshot(
     startedAt: Date = Date(timeIntervalSince1970: 1),
     finishedAt: Date? = Date(timeIntervalSince1970: 2),
     sourceURL: URL? = nil,
-    scanOptions: ScanOptions? = nil
+    scanOptions: ScanOptions? = nil,
+    targetKind: ScanTargetKind = .folder
 ) -> ScanSnapshot {
     let file = makeTestFileNode(id: "\(rootPath)/shared.bin", name: "shared.bin", size: fileSize)
     let root = makeTestDirectoryNode(id: rootPath, name: URL(filePath: rootPath).lastPathComponent, children: [file])
@@ -2719,7 +2816,7 @@ private func makeComparisonSnapshot(
     }
 
     return ScanSnapshot(
-        target: ScanTarget(id: root.id, url: root.url, displayName: root.name, kind: .folder),
+        target: ScanTarget(id: root.id, url: root.url, displayName: root.name, kind: targetKind),
         treeStore: store,
         startedAt: startedAt,
         finishedAt: finishedAt,

--- a/RadixCoreTests/AppModelDependencyTests.swift
+++ b/RadixCoreTests/AppModelDependencyTests.swift
@@ -2553,6 +2553,12 @@ final class AppModelDependencyTests: XCTestCase {
             model.pendingComparisonSetup?.validationMessage,
             "The earlier scan must precede the later scan."
         )
+
+        model.swapPendingComparisonSetup()
+        XCTAssertEqual(model.pendingComparisonSetup?.before?.displayName, oldSnapshot.target.displayName)
+        XCTAssertTrue(model.pendingComparisonSetup?.canCompare ?? false)
+        XCTAssertNil(model.pendingComparisonSetup?.validationMessage)
+        XCTAssertNil(model.pendingComparisonSetup?.errorMessage)
     }
 
     @MainActor

--- a/RadixCoreTests/AppModelDependencyTests.swift
+++ b/RadixCoreTests/AppModelDependencyTests.swift
@@ -288,6 +288,12 @@ final class AppModelDependencyTests: XCTestCase {
         XCTAssertTrue(model.canCompareCurrentScanWithPreviousScan)
         model.compareCurrentScanWithPreviousScan()
 
+        XCTAssertEqual(model.pendingComparisonSetup?.before?.id, firstSnapshot.id)
+        XCTAssertEqual(model.pendingComparisonSetup?.after?.id, secondSnapshot.id)
+        XCTAssertTrue(model.pendingComparisonSetup?.canCompare == true)
+
+        model.confirmComparisonSetup()
+
         try await waitForAppModelCondition("previous scan comparison built") {
             model.scanComparison?.after.id == secondSnapshot.id
         }

--- a/RadixCoreTests/ScanArchiveServiceTests.swift
+++ b/RadixCoreTests/ScanArchiveServiceTests.swift
@@ -145,6 +145,7 @@ final class ScanArchiveServiceTests: XCTestCase {
         XCTAssertEqual(preview.totalLogicalSize, snapshot.aggregateStats.totalLogicalSize)
         XCTAssertEqual(preview.fileCount, snapshot.aggregateStats.fileCount)
         XCTAssertEqual(preview.directoryCount, snapshot.aggregateStats.directoryCount)
+        XCTAssertEqual(preview.scanOptions, snapshot.scanOptions)
     }
 
     func testExportWritesOrdinalTopology() async throws {

--- a/RadixCoreTests/ScanBenchmarkTests.swift
+++ b/RadixCoreTests/ScanBenchmarkTests.swift
@@ -247,6 +247,100 @@ final class ScanBenchmarkTests: XCTestCase {
         }
     }
 
+    func testPackageSummaryBenchmark() async throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard environment["RADIX_BENCH_PACKAGE_SUMMARY"] == "1" else {
+            throw XCTSkip("Set RADIX_BENCH_PACKAGE_SUMMARY=1 to run the package summary benchmark.")
+        }
+
+        let directoryCounts = Self.integerList(
+            from: environment["RADIX_BENCH_PACKAGE_DIR_COUNTS"],
+            defaultValues: [16]
+        )
+        let filesPerDirectoryCounts = Self.integerList(
+            from: environment["RADIX_BENCH_PACKAGE_FILES_PER_DIR"],
+            defaultValues: [2_500]
+        )
+        let symlinksPerDirectoryCounts = Self.integerList(
+            from: environment["RADIX_BENCH_PACKAGE_SYMLINKS_PER_DIR"],
+            defaultValues: [0]
+        )
+        let iterations = environment["RADIX_BENCH_PACKAGE_ITERATIONS"]
+            .flatMap(Int.init)
+            .map { max(1, $0) } ?? 3
+        let summaryWorkers = environment["RADIX_BENCH_PACKAGE_SUMMARY_WORKERS"]
+            .flatMap(Int.init)
+            .map { max(1, $0) } ?? 8
+
+        let configurations = [
+            PackageSummaryBenchmarkConfiguration(name: "default-policy", atomicSummaryWorkerLimit: nil),
+            PackageSummaryBenchmarkConfiguration(name: "serial-summary", atomicSummaryWorkerLimit: 1),
+            PackageSummaryBenchmarkConfiguration(name: "parallel-summary", atomicSummaryWorkerLimit: summaryWorkers)
+        ]
+
+        for directoryCount in directoryCounts {
+            for filesPerDirectory in filesPerDirectoryCounts {
+                for symlinksPerDirectory in symlinksPerDirectoryCounts {
+                    let rootURL = try makePackageSummaryBenchmarkDirectory(
+                        directoryCount: directoryCount,
+                        filesPerDirectory: filesPerDirectory,
+                        symlinksPerDirectory: symlinksPerDirectory
+                    )
+                    defer { try? FileManager.default.removeItem(at: rootURL) }
+                    let fileCount = directoryCount * filesPerDirectory + (symlinksPerDirectory > 0 ? directoryCount : 0)
+                    let symlinkCount = directoryCount * symlinksPerDirectory
+
+                    for configuration in configurations {
+                        _ = try await runPackageSummaryBenchmark(
+                            rootURL: rootURL,
+                            fileCount: fileCount,
+                            symlinkCount: symlinkCount,
+                            configuration: configuration,
+                            iteration: 0,
+                            isWarmup: true
+                        )
+                    }
+
+                    var elapsedByConfiguration: [String: [Double]] = [:]
+                    for iteration in 1...iterations {
+                        for configuration in configurations {
+                            let elapsedSeconds = try await runPackageSummaryBenchmark(
+                                rootURL: rootURL,
+                                fileCount: fileCount,
+                                symlinkCount: symlinkCount,
+                                configuration: configuration,
+                                iteration: iteration,
+                                isWarmup: false
+                            )
+                            elapsedByConfiguration[configuration.name, default: []].append(elapsedSeconds)
+                        }
+                    }
+
+                    for configuration in configurations {
+                        let elapsed = elapsedByConfiguration[configuration.name, default: []]
+                        guard !elapsed.isEmpty else { continue }
+                        let average = elapsed.reduce(0, +) / Double(elapsed.count)
+                        print(
+                            """
+                            RADIX_BENCH_PACKAGE_SUMMARY dirs=\(directoryCount)
+                            files_per_dir=\(filesPerDirectory)
+                            symlinks_per_dir=\(symlinksPerDirectory)
+                            files=\(fileCount)
+                            symlinks=\(symlinkCount)
+                            config=\(configuration.name)
+                            summary_workers=\(configuration.workerDescription)
+                            iterations=\(elapsed.count)
+                            avg_elapsed=\(String(format: "%.3f", average))s
+                            min_elapsed=\(String(format: "%.3f", elapsed.min() ?? average))s
+                            max_elapsed=\(String(format: "%.3f", elapsed.max() ?? average))s
+                            """
+                        )
+                    }
+                }
+            }
+        }
+    }
+
     private struct WideDirectoryBenchmarkConfiguration {
         let name: String
         let traversalWorkerLimit: Int?
@@ -258,6 +352,15 @@ final class ScanBenchmarkTests: XCTestCase {
 
         var classificationWorkerDescription: String {
             classificationWorkerLimit.map(String.init) ?? "default"
+        }
+    }
+
+    private struct PackageSummaryBenchmarkConfiguration {
+        let name: String
+        let atomicSummaryWorkerLimit: Int?
+
+        var workerDescription: String {
+            atomicSummaryWorkerLimit.map(String.init) ?? "default"
         }
     }
 
@@ -306,6 +409,41 @@ final class ScanBenchmarkTests: XCTestCase {
         return rootURL
     }
 
+    private func makePackageSummaryBenchmarkDirectory(
+        directoryCount: Int,
+        filesPerDirectory: Int,
+        symlinksPerDirectory: Int
+    ) throws -> URL {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appending(path: "radix-package-summary-\(UUID().uuidString)", directoryHint: .isDirectory)
+        let packageURL = rootURL.appending(path: "Payload.app", directoryHint: .isDirectory)
+        let resourcesURL = packageURL
+            .appending(path: "Contents", directoryHint: .isDirectory)
+            .appending(path: "Resources", directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: resourcesURL, withIntermediateDirectories: true)
+
+        let payload = Data([0x41])
+        for directoryIndex in 0..<directoryCount {
+            let directoryURL = resourcesURL.appending(path: String(format: "bucket-%03d", directoryIndex), directoryHint: .isDirectory)
+            try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+
+            let targetURL = directoryURL.appending(path: "symlink-target.dat")
+            if symlinksPerDirectory > 0 {
+                try payload.write(to: targetURL, options: .atomic)
+            }
+            for fileIndex in 0..<filesPerDirectory {
+                let fileURL = directoryURL.appending(path: String(format: "asset-%08d.dat", fileIndex))
+                try payload.write(to: fileURL, options: .atomic)
+            }
+            for symlinkIndex in 0..<symlinksPerDirectory {
+                let symlinkURL = directoryURL.appending(path: String(format: "alias-%08d.dat", symlinkIndex))
+                try FileManager.default.createSymbolicLink(at: symlinkURL, withDestinationURL: targetURL)
+            }
+        }
+
+        return rootURL
+    }
+
     private func runWideDirectoryBenchmark(
         rootURL: URL,
         fileCount: Int,
@@ -343,6 +481,52 @@ final class ScanBenchmarkTests: XCTestCase {
             iteration=\(iteration)
             traversal_workers=\(configuration.traversalWorkerDescription)
             requested_classification_workers=\(configuration.classificationWorkerDescription)
+            elapsed=\(String(format: "%.3f", elapsedSeconds))s
+            """
+        )
+
+        return elapsedSeconds
+    }
+
+    private func runPackageSummaryBenchmark(
+        rootURL: URL,
+        fileCount: Int,
+        symlinkCount: Int,
+        configuration: PackageSummaryBenchmarkConfiguration,
+        iteration: Int,
+        isWarmup: Bool
+    ) async throws -> Double {
+        var options = ScanOptions()
+        options.atomicSummaryWorkerLimit = configuration.atomicSummaryWorkerLimit
+
+        let engine = ScanEngine()
+        let startedAt = ContinuousClock.now
+        var finalSnapshot: ScanSnapshot?
+
+        for try await event in engine.scan(target: ScanTarget(url: rootURL), options: options) {
+            if case .finished(let snapshot) = event {
+                finalSnapshot = snapshot
+            }
+        }
+
+        let elapsed = startedAt.duration(to: .now)
+        let elapsedSeconds = Double(elapsed.components.seconds) +
+            (Double(elapsed.components.attoseconds) / 1_000_000_000_000_000_000)
+        let snapshot = try XCTUnwrap(finalSnapshot)
+        let packageNode = try XCTUnwrap(snapshot.treeStore.children(of: snapshot.root.id).first { $0.name == "Payload.app" })
+        XCTAssertEqual(snapshot.aggregateStats.fileCount, fileCount)
+        XCTAssertEqual(packageNode.descendantFileCount, fileCount)
+        XCTAssertFalse(snapshot.treeStore.childIDsByID.keys.contains(packageNode.id))
+
+        let phase = isWarmup ? "warmup" : "measure"
+        print(
+            """
+            RADIX_BENCH_PACKAGE_RESULT phase=\(phase)
+            files=\(fileCount)
+            symlinks=\(symlinkCount)
+            config=\(configuration.name)
+            iteration=\(iteration)
+            summary_workers=\(configuration.workerDescription)
             elapsed=\(String(format: "%.3f", elapsedSeconds))s
             """
         )

--- a/RadixCoreTests/ScanComparisonServiceTests.swift
+++ b/RadixCoreTests/ScanComparisonServiceTests.swift
@@ -66,7 +66,7 @@ final class ScanComparisonServiceTests: XCTestCase {
         XCTAssertEqual(comparison.summary.addedCount, 1)
         XCTAssertEqual(comparison.summary.removedCount, 1)
         XCTAssertEqual(comparison.summary.grewCount, 1)
-        XCTAssertEqual(comparison.summary.changedCount, 3)
+        XCTAssertEqual(comparison.summary.changedCount, 1)
     }
 
     func testNestedFileGrowthDoesNotEmitAncestorDirectoryRows() async throws {
@@ -99,6 +99,7 @@ final class ScanComparisonServiceTests: XCTestCase {
         XCTAssertEqual(comparison.rows[0].kind, .grew)
         XCTAssertEqual(comparison.rows[0].allocatedDelta, 90)
         XCTAssertFalse(comparison.rows.contains { $0.isDirectory })
+        XCTAssertEqual(comparison.summary.fileCountDelta, 0)
         XCTAssertEqual(comparison.summary.grewCount, 1)
         XCTAssertEqual(comparison.summary.changedCount, 1)
         // The aggregate delta still reflects the full change even though no directory row is emitted.
@@ -430,7 +431,7 @@ final class ScanComparisonServiceTests: XCTestCase {
         XCTAssertEqual(comparison.topLevelChanges[1].removedCount, 1)
         XCTAssertEqual(comparison.topLevelChanges[2].grewCount, 1)
         XCTAssertEqual(comparison.topLevelChanges.reduce(0) { $0 + $1.allocatedDelta }, 40)
-        XCTAssertEqual(comparison.topLevelChanges.reduce(0) { $0 + $1.changedCount }, comparison.summary.changedCount)
+        XCTAssertEqual(comparison.topLevelChanges.reduce(0) { $0 + $1.affectedCount }, 3)
         XCTAssertEqual(comparison.summary.grossIncreasedAllocatedSize, 60)
         XCTAssertEqual(comparison.summary.grossReclaimedAllocatedSize, 20)
         XCTAssertEqual(comparison.summary.attributedAllocatedDelta, 40)

--- a/RadixCoreTests/ScanComparisonServiceTests.swift
+++ b/RadixCoreTests/ScanComparisonServiceTests.swift
@@ -293,9 +293,11 @@ final class ScanComparisonServiceTests: XCTestCase {
         XCTAssertEqual(location.representativeRelativePath, "Documents/new-name.bin")
         XCTAssertEqual(location.afterNode?.id, "/scan/Documents")
 
-        let movedProjection = comparison.changeTree.significantProjection(impactFilter: .moved)
+        let movedProjection = comparison.changeTree.significantProjection(changeKinds: [.moved])
         XCTAssertEqual(movedProjection.roots.map(\.relativePath), ["Documents"])
-        let allActivityProjection = comparison.changeTree.significantProjection(impactFilter: .allActivity)
+        let allActivityProjection = comparison.changeTree.significantProjection(
+            changeKinds: Set(ScanComparisonChangeKind.allCases)
+        )
         XCTAssertEqual(allActivityProjection.roots.map(\.relativePath), ["Documents"])
     }
 
@@ -570,7 +572,6 @@ final class ScanComparisonServiceTests: XCTestCase {
             ),
         ]
         let query = ScanComparisonRowQuery(
-            changeKind: nil,
             searchText: "",
             sortOrder: [ScanComparisonRowComparator(field: .allocatedDelta, order: .reverse)]
         )
@@ -602,7 +603,7 @@ final class ScanComparisonServiceTests: XCTestCase {
             ),
         ]
         let query = ScanComparisonRowQuery(
-            changeKind: .added,
+            changeKinds: [.added],
             searchText: "application support",
             sortOrder: []
         )
@@ -638,7 +639,6 @@ final class ScanComparisonServiceTests: XCTestCase {
             ),
         ]
         let query = ScanComparisonRowQuery(
-            changeKind: nil,
             searchText: "",
             sortOrder: [],
             pathPrefix: "Library"
@@ -824,7 +824,7 @@ final class ScanComparisonServiceTests: XCTestCase {
         )
 
         let projection = comparison.changeTree.significantProjection(
-            impactFilter: .allActivity,
+            changeKinds: Set(ScanComparisonChangeKind.allCases),
             coverageTarget: 0.95
         )
 
@@ -835,7 +835,34 @@ final class ScanComparisonServiceTests: XCTestCase {
         XCTAssertTrue(projection.roots.contains(where: \.isRemainder))
     }
 
-    func testImpactQueryUsesSignedBytesAndMovementIndependently() {
+    func testSignificantProjectionHonorsExactChangeKindSelection() async throws {
+        let grewBefore = makeTestFileNode(id: "/scan/grew.bin", name: "grew.bin", size: 10)
+        let beforeRoot = makeTestDirectoryNode(id: "/scan", name: "scan", children: [grewBefore])
+        let beforeStore = FileTreeStore(root: beforeRoot, childrenByID: [beforeRoot.id: [grewBefore]])
+
+        let grewAfter = makeTestFileNode(id: "/scan/grew.bin", name: "grew.bin", size: 20)
+        let added = makeTestFileNode(id: "/scan/added.bin", name: "added.bin", size: 50)
+        let afterRoot = makeTestDirectoryNode(id: "/scan", name: "scan", children: [grewAfter, added])
+        let afterStore = FileTreeStore(root: afterRoot, childrenByID: [
+            afterRoot.id: [grewAfter, added],
+        ])
+        let comparison = try await ScanComparisonService().compare(
+            before: makeTestSnapshot(root: beforeRoot, store: beforeStore),
+            after: makeTestSnapshot(root: afterRoot, store: afterStore)
+        )
+
+        let addedProjection = comparison.changeTree.significantProjection(changeKinds: [.added])
+        let grewProjection = comparison.changeTree.significantProjection(changeKinds: [.grew])
+        let combinedProjection = comparison.changeTree.significantProjection(changeKinds: [.added, .grew])
+
+        XCTAssertEqual(addedProjection.roots.map(\.relativePath), ["added.bin"])
+        XCTAssertEqual(addedProjection.roots.first?.increasedAllocatedSize, 50)
+        XCTAssertEqual(grewProjection.roots.map(\.relativePath), ["grew.bin"])
+        XCTAssertEqual(grewProjection.roots.first?.increasedAllocatedSize, 10)
+        XCTAssertEqual(Set(combinedProjection.roots.map(\.relativePath)), ["added.bin", "grew.bin"])
+    }
+
+    func testRowQueryCombinesSelectedChangeKinds() {
         let movedBefore = makeTestFileNode(id: "/before/old.bin", name: "old.bin", size: 100)
         let movedAfter = makeTestFileNode(id: "/after/new.bin", name: "new.bin", size: 150)
         let movedAndGrew = ScanComparisonRow(
@@ -853,27 +880,24 @@ final class ScanComparisonServiceTests: XCTestCase {
         )
         let rows = [movedAndGrew, removed]
 
-        let taking = ScanComparisonRowQuery(
-            changeKind: nil,
-            impactFilter: .takingSpace,
+        let movedAndRemoved = ScanComparisonRowQuery(
+            changeKinds: [.moved, .removed],
             searchText: "",
             sortOrder: []
         ).applying(to: rows)
-        let freeing = ScanComparisonRowQuery(
-            changeKind: nil,
-            impactFilter: .freeingSpace,
+        let removedOnly = ScanComparisonRowQuery(
+            changeKinds: [.removed],
             searchText: "",
             sortOrder: []
         ).applying(to: rows)
-        let moved = ScanComparisonRowQuery(
-            changeKind: nil,
-            impactFilter: .moved,
+        let movedOnly = ScanComparisonRowQuery(
+            changeKinds: [.moved],
             searchText: "",
             sortOrder: []
         ).applying(to: rows)
 
-        XCTAssertEqual(taking.map(\.relativePath), ["new.bin"])
-        XCTAssertEqual(freeing.map(\.relativePath), ["removed.bin"])
-        XCTAssertEqual(moved.map(\.relativePath), ["new.bin"])
+        XCTAssertEqual(movedAndRemoved.map(\.relativePath), ["new.bin", "removed.bin"])
+        XCTAssertEqual(removedOnly.map(\.relativePath), ["removed.bin"])
+        XCTAssertEqual(movedOnly.map(\.relativePath), ["new.bin"])
     }
 }

--- a/RadixCoreTests/ScanComparisonServiceTests.swift
+++ b/RadixCoreTests/ScanComparisonServiceTests.swift
@@ -128,6 +128,105 @@ final class ScanComparisonServiceTests: XCTestCase {
         XCTAssertEqual(comparison.summary.grewCount, 1)
     }
 
+    func testExpandedVersionOfSummarizedDirectorySuppressesMaterializedDescendants() async throws {
+        let beforeCache = makeTestSummarizedDirectoryNode(id: "/before/cache", name: "cache", size: 100)
+        let beforeRoot = makeTestDirectoryNode(id: "/before", name: "before", children: [beforeCache])
+        let beforeStore = FileTreeStore(root: beforeRoot, childrenByID: [beforeRoot.id: [beforeCache]])
+        let beforeSnapshot = makeTestSnapshot(root: beforeRoot, store: beforeStore)
+
+        let afterLeaf = makeTestFileNode(id: "/after/cache/file.bin", name: "file.bin", size: 100)
+        let afterCache = makeTestDirectoryNode(id: "/after/cache", name: "cache", children: [afterLeaf])
+        let afterRoot = makeTestDirectoryNode(id: "/after", name: "after", children: [afterCache])
+        let afterStore = FileTreeStore(root: afterRoot, childrenByID: [
+            afterRoot.id: [afterCache],
+            afterCache.id: [afterLeaf],
+        ])
+        let afterSnapshot = makeTestSnapshot(root: afterRoot, store: afterStore)
+
+        let comparison = try await ScanComparisonService().compare(before: beforeSnapshot, after: afterSnapshot)
+
+        XCTAssertTrue(comparison.rows.isEmpty)
+        XCTAssertEqual(comparison.summary.allocatedDelta, 0)
+        XCTAssertEqual(comparison.summary.changedCount, 0)
+    }
+
+    func testExpandedVersionOfSummarizedDirectoryReportsOnlyBoundaryDelta() async throws {
+        let beforeCache = makeTestSummarizedDirectoryNode(id: "/before/cache", name: "cache", size: 100)
+        let beforeRoot = makeTestDirectoryNode(id: "/before", name: "before", children: [beforeCache])
+        let beforeStore = FileTreeStore(root: beforeRoot, childrenByID: [beforeRoot.id: [beforeCache]])
+        let beforeSnapshot = makeTestSnapshot(root: beforeRoot, store: beforeStore)
+
+        let afterLeaf = makeTestFileNode(id: "/after/cache/file.bin", name: "file.bin", size: 150)
+        let afterCache = makeTestDirectoryNode(id: "/after/cache", name: "cache", children: [afterLeaf])
+        let afterRoot = makeTestDirectoryNode(id: "/after", name: "after", children: [afterCache])
+        let afterStore = FileTreeStore(root: afterRoot, childrenByID: [
+            afterRoot.id: [afterCache],
+            afterCache.id: [afterLeaf],
+        ])
+        let afterSnapshot = makeTestSnapshot(root: afterRoot, store: afterStore)
+
+        let comparison = try await ScanComparisonService().compare(before: beforeSnapshot, after: afterSnapshot)
+
+        XCTAssertEqual(comparison.rows.count, 1)
+        XCTAssertEqual(comparison.rows[0].relativePath, "cache")
+        XCTAssertEqual(comparison.rows[0].kind, .grew)
+        XCTAssertEqual(comparison.rows[0].allocatedDelta, 50)
+        XCTAssertEqual(comparison.summary.allocatedDelta, 50)
+    }
+
+    func testNewHardLinkDoesNotMoveAllocatedSizeFromSharedPath() async throws {
+        let identity = FileIdentity(device: 1, inode: 42)
+        let beforeShared = makeTestFileNode(
+            id: "/before/z.bin",
+            name: "z.bin",
+            size: 100,
+            unduplicatedAllocatedSize: 100,
+            fileIdentity: identity,
+            linkCount: 1
+        )
+        let beforeRoot = makeTestDirectoryNode(id: "/before", name: "before", children: [beforeShared])
+        let beforeStore = FileTreeStore(root: beforeRoot, childrenByID: [beforeRoot.id: [beforeShared]])
+        let beforeSnapshot = makeTestSnapshot(root: beforeRoot, store: beforeStore)
+
+        let afterNewLink = makeTestFileNode(
+            id: "/after/a/new.bin",
+            name: "new.bin",
+            size: 100,
+            unduplicatedAllocatedSize: 100,
+            fileIdentity: identity,
+            linkCount: 2
+        )
+        let afterFolder = makeTestDirectoryNode(id: "/after/a", name: "a", children: [afterNewLink])
+        let afterShared = makeTestFileNode(
+            id: "/after/z.bin",
+            name: "z.bin",
+            size: 0,
+            unduplicatedAllocatedSize: 100,
+            fileIdentity: identity,
+            linkCount: 2
+        )
+        let afterRoot = makeTestDirectoryNode(
+            id: "/after",
+            name: "after",
+            children: [afterFolder, afterShared]
+        )
+        let afterStore = FileTreeStore(root: afterRoot, childrenByID: [
+            afterRoot.id: [afterFolder, afterShared],
+            afterFolder.id: [afterNewLink],
+        ])
+        let afterSnapshot = makeTestSnapshot(root: afterRoot, store: afterStore)
+
+        let comparison = try await ScanComparisonService().compare(before: beforeSnapshot, after: afterSnapshot)
+
+        XCTAssertEqual(comparison.rows.count, 1)
+        XCTAssertEqual(comparison.rows[0].relativePath, "a")
+        XCTAssertEqual(comparison.rows[0].kind, .added)
+        XCTAssertEqual(comparison.rows[0].afterAllocatedSize, 0)
+        XCTAssertEqual(comparison.rows[0].allocatedDelta, 0)
+        XCTAssertFalse(comparison.rows.contains { $0.relativePath == "z.bin" })
+        XCTAssertEqual(comparison.summary.allocatedDelta, 0)
+    }
+
     func testUnchangedAndRootRowsAreExcluded() async throws {
         let unchangedBefore = makeTestFileNode(id: "/before/unchanged.bin", name: "unchanged.bin", size: 20)
         let beforeRoot = makeTestDirectoryNode(id: "/before", name: "before", children: [unchangedBefore])

--- a/RadixCoreTests/ScanComparisonServiceTests.swift
+++ b/RadixCoreTests/ScanComparisonServiceTests.swift
@@ -227,6 +227,323 @@ final class ScanComparisonServiceTests: XCTestCase {
         XCTAssertEqual(comparison.summary.allocatedDelta, 0)
     }
 
+    func testUnambiguousFileIdentityMoveIsReportedAtDestination() async throws {
+        let identity = FileIdentity(device: 1, inode: 900)
+        let beforeFile = makeTestFileNode(
+            id: "/scan/Documents/old-name.bin",
+            name: "old-name.bin",
+            size: 64,
+            fileIdentity: identity
+        )
+        let beforeDocuments = makeTestDirectoryNode(
+            id: "/scan/Documents",
+            name: "Documents",
+            children: [beforeFile]
+        )
+        let beforeRoot = makeTestDirectoryNode(
+            id: "/scan",
+            name: "scan",
+            children: [beforeDocuments]
+        )
+        let beforeStore = FileTreeStore(root: beforeRoot, childrenByID: [
+            beforeRoot.id: [beforeDocuments],
+            beforeDocuments.id: [beforeFile],
+        ])
+        let beforeSnapshot = makeTestSnapshot(root: beforeRoot, store: beforeStore)
+
+        let afterFile = makeTestFileNode(
+            id: "/scan/Documents/new-name.bin",
+            name: "new-name.bin",
+            size: 64,
+            fileIdentity: identity
+        )
+        let afterDocuments = makeTestDirectoryNode(
+            id: "/scan/Documents",
+            name: "Documents",
+            children: [afterFile]
+        )
+        let afterRoot = makeTestDirectoryNode(
+            id: "/scan",
+            name: "scan",
+            children: [afterDocuments]
+        )
+        let afterStore = FileTreeStore(root: afterRoot, childrenByID: [
+            afterRoot.id: [afterDocuments],
+            afterDocuments.id: [afterFile],
+        ])
+        let afterSnapshot = makeTestSnapshot(root: afterRoot, store: afterStore)
+
+        let comparison = try await ScanComparisonService().compare(before: beforeSnapshot, after: afterSnapshot)
+
+        XCTAssertEqual(comparison.rows.count, 1)
+        let row = try XCTUnwrap(comparison.rows.first)
+        XCTAssertEqual(row.kind, .moved)
+        XCTAssertEqual(row.relativePath, "Documents/new-name.bin")
+        XCTAssertEqual(row.movedFromRelativePath, "Documents/old-name.bin")
+        XCTAssertEqual(row.allocatedDelta, 0)
+        XCTAssertEqual(comparison.summary.addedCount, 0)
+        XCTAssertEqual(comparison.summary.removedCount, 0)
+        XCTAssertEqual(comparison.summary.movedCount, 1)
+
+        XCTAssertEqual(comparison.topLevelChanges.count, 1)
+        let location = try XCTUnwrap(comparison.topLevelChanges.first)
+        XCTAssertEqual(location.relativePath, "Documents")
+        XCTAssertEqual(location.movedCount, 1)
+        XCTAssertEqual(location.representativeRelativePath, "Documents/new-name.bin")
+        XCTAssertEqual(location.afterNode?.id, "/scan/Documents")
+    }
+
+    func testAmbiguousFileIdentityDoesNotInferMove() async throws {
+        let identity = FileIdentity(device: 1, inode: 901)
+        let beforeFirst = makeTestFileNode(
+            id: "/scan/Documents/first.bin",
+            name: "first.bin",
+            size: 10,
+            fileIdentity: identity
+        )
+        let beforeSecond = makeTestFileNode(
+            id: "/scan/Documents/second.bin",
+            name: "second.bin",
+            size: 10,
+            fileIdentity: identity
+        )
+        let beforeDocuments = makeTestDirectoryNode(
+            id: "/scan/Documents",
+            name: "Documents",
+            children: [beforeFirst, beforeSecond]
+        )
+        let beforeRoot = makeTestDirectoryNode(
+            id: "/scan",
+            name: "scan",
+            children: [beforeDocuments]
+        )
+        let beforeStore = FileTreeStore(root: beforeRoot, childrenByID: [
+            beforeRoot.id: [beforeDocuments],
+            beforeDocuments.id: [beforeFirst, beforeSecond],
+        ])
+        let beforeSnapshot = makeTestSnapshot(root: beforeRoot, store: beforeStore)
+
+        let afterFile = makeTestFileNode(
+            id: "/scan/Documents/renamed.bin",
+            name: "renamed.bin",
+            size: 10,
+            fileIdentity: identity
+        )
+        let afterDocuments = makeTestDirectoryNode(
+            id: "/scan/Documents",
+            name: "Documents",
+            children: [afterFile]
+        )
+        let afterRoot = makeTestDirectoryNode(
+            id: "/scan",
+            name: "scan",
+            children: [afterDocuments]
+        )
+        let afterStore = FileTreeStore(root: afterRoot, childrenByID: [
+            afterRoot.id: [afterDocuments],
+            afterDocuments.id: [afterFile],
+        ])
+        let afterSnapshot = makeTestSnapshot(root: afterRoot, store: afterStore)
+
+        let comparison = try await ScanComparisonService().compare(before: beforeSnapshot, after: afterSnapshot)
+
+        XCTAssertFalse(comparison.rows.contains { $0.kind == .moved })
+        XCTAssertEqual(comparison.summary.addedCount, 1)
+        XCTAssertEqual(comparison.summary.removedCount, 2)
+        XCTAssertEqual(comparison.summary.movedCount, 0)
+    }
+
+    func testTopLevelChangesPartitionFinalRowsAndReportGrossSpaceChanges() async throws {
+        let beforeLibraryFile = makeTestFileNode(
+            id: "/scan/Library/cache.bin",
+            name: "cache.bin",
+            size: 10
+        )
+        let beforeDownloadsFile = makeTestFileNode(
+            id: "/scan/Downloads/old.bin",
+            name: "old.bin",
+            size: 20
+        )
+        let beforeLibrary = makeTestDirectoryNode(
+            id: "/scan/Library",
+            name: "Library",
+            children: [beforeLibraryFile]
+        )
+        let beforeDownloads = makeTestDirectoryNode(
+            id: "/scan/Downloads",
+            name: "Downloads",
+            children: [beforeDownloadsFile]
+        )
+        let beforeWork = makeTestDirectoryNode(id: "/scan/Work", name: "Work", children: [])
+        let beforeRoot = makeTestDirectoryNode(
+            id: "/scan",
+            name: "scan",
+            children: [beforeLibrary, beforeDownloads, beforeWork]
+        )
+        let beforeStore = FileTreeStore(root: beforeRoot, childrenByID: [
+            beforeRoot.id: [beforeLibrary, beforeDownloads, beforeWork],
+            beforeLibrary.id: [beforeLibraryFile],
+            beforeDownloads.id: [beforeDownloadsFile],
+            beforeWork.id: [],
+        ])
+        let beforeSnapshot = makeTestSnapshot(root: beforeRoot, store: beforeStore)
+
+        let afterLibraryFile = makeTestFileNode(
+            id: "/scan/Library/cache.bin",
+            name: "cache.bin",
+            size: 30
+        )
+        let afterWorkFile = makeTestFileNode(
+            id: "/scan/Work/new.bin",
+            name: "new.bin",
+            size: 40
+        )
+        let afterLibrary = makeTestDirectoryNode(
+            id: "/scan/Library",
+            name: "Library",
+            children: [afterLibraryFile]
+        )
+        let afterDownloads = makeTestDirectoryNode(id: "/scan/Downloads", name: "Downloads", children: [])
+        let afterWork = makeTestDirectoryNode(
+            id: "/scan/Work",
+            name: "Work",
+            children: [afterWorkFile]
+        )
+        let afterRoot = makeTestDirectoryNode(
+            id: "/scan",
+            name: "scan",
+            children: [afterLibrary, afterDownloads, afterWork]
+        )
+        let afterStore = FileTreeStore(root: afterRoot, childrenByID: [
+            afterRoot.id: [afterLibrary, afterDownloads, afterWork],
+            afterLibrary.id: [afterLibraryFile],
+            afterDownloads.id: [],
+            afterWork.id: [afterWorkFile],
+        ])
+        let afterSnapshot = makeTestSnapshot(root: afterRoot, store: afterStore)
+
+        let comparison = try await ScanComparisonService().compare(before: beforeSnapshot, after: afterSnapshot)
+
+        XCTAssertEqual(comparison.topLevelChanges.map(\.relativePath), ["Work", "Downloads", "Library"])
+        XCTAssertEqual(comparison.topLevelChanges.map(\.allocatedDelta), [40, -20, 20])
+        XCTAssertEqual(comparison.topLevelChanges[0].addedCount, 1)
+        XCTAssertEqual(comparison.topLevelChanges[1].removedCount, 1)
+        XCTAssertEqual(comparison.topLevelChanges[2].grewCount, 1)
+        XCTAssertEqual(comparison.topLevelChanges.reduce(0) { $0 + $1.allocatedDelta }, 40)
+        XCTAssertEqual(comparison.topLevelChanges.reduce(0) { $0 + $1.changedCount }, comparison.summary.changedCount)
+        XCTAssertEqual(comparison.summary.grossIncreasedAllocatedSize, 60)
+        XCTAssertEqual(comparison.summary.grossReclaimedAllocatedSize, 20)
+        XCTAssertEqual(comparison.summary.attributedAllocatedDelta, 40)
+        XCTAssertEqual(comparison.summary.allocatedDelta, 40)
+    }
+
+    func testWarningsSuppressUncertainAddedAndRemovedRows() async throws {
+        let beforePrivateFile = makeTestFileNode(
+            id: "/scan/Private/old.bin",
+            name: "old.bin",
+            size: 100
+        )
+        let beforePrivate = makeTestDirectoryNode(
+            id: "/scan/Private",
+            name: "Private",
+            children: [beforePrivateFile]
+        )
+        let beforeRoot = makeTestDirectoryNode(
+            id: "/scan",
+            name: "scan",
+            children: [beforePrivate]
+        )
+        let beforeStore = FileTreeStore(root: beforeRoot, childrenByID: [
+            beforeRoot.id: [beforePrivate],
+            beforePrivate.id: [beforePrivateFile],
+        ])
+        let beforeSnapshot = makeTestSnapshot(root: beforeRoot, store: beforeStore)
+
+        let afterEmptyRoot = makeTestDirectoryNode(id: "/scan", name: "scan", children: [])
+        let afterEmptyStore = FileTreeStore(root: afterEmptyRoot, childrenByID: [afterEmptyRoot.id: []])
+        let afterWarning = ScanWarning(
+            path: "/scan/Private",
+            message: "Permission denied",
+            category: .permissionDenied
+        )
+        let afterWithWarning = makeTestSnapshot(
+            root: afterEmptyRoot,
+            store: afterEmptyStore,
+            warnings: [afterWarning]
+        )
+
+        let removalComparison = try await ScanComparisonService().compare(
+            before: beforeSnapshot,
+            after: afterWithWarning
+        )
+
+        XCTAssertTrue(removalComparison.rows.isEmpty)
+        XCTAssertEqual(removalComparison.summary.removedCount, 0)
+        XCTAssertEqual(removalComparison.summary.grossReclaimedAllocatedSize, 0)
+        XCTAssertEqual(removalComparison.summary.allocatedDelta, -100)
+        XCTAssertEqual(removalComparison.summary.attributedAllocatedDelta, 0)
+        XCTAssertTrue(removalComparison.coverage.issues.contains(.afterWarnings(1)))
+
+        let beforeWarning = ScanWarning(
+            path: "/scan/Private",
+            message: "Permission denied",
+            category: .permissionDenied
+        )
+        let beforeEmptyRoot = makeTestDirectoryNode(id: "/scan", name: "scan", children: [])
+        let beforeEmptyStore = FileTreeStore(root: beforeEmptyRoot, childrenByID: [beforeEmptyRoot.id: []])
+        let beforeWithWarning = makeTestSnapshot(
+            root: beforeEmptyRoot,
+            store: beforeEmptyStore,
+            warnings: [beforeWarning]
+        )
+
+        let additionComparison = try await ScanComparisonService().compare(
+            before: beforeWithWarning,
+            after: beforeSnapshot
+        )
+
+        XCTAssertTrue(additionComparison.rows.isEmpty)
+        XCTAssertEqual(additionComparison.summary.addedCount, 0)
+        XCTAssertEqual(additionComparison.summary.grossIncreasedAllocatedSize, 0)
+        XCTAssertEqual(additionComparison.summary.allocatedDelta, 100)
+        XCTAssertEqual(additionComparison.summary.attributedAllocatedDelta, 0)
+        XCTAssertTrue(additionComparison.coverage.issues.contains(.beforeWarnings(1)))
+    }
+
+    func testCoverageIsHighForCompleteEquivalentSnapshotsWithKnownOptions() async throws {
+        let root = makeTestDirectoryNode(id: "/scan", name: "scan", children: [])
+        let store = FileTreeStore(root: root, childrenByID: [root.id: []])
+        let target = makeTestTarget("/scan")
+        let options = ScanOptions()
+        let before = ScanSnapshot(
+            target: target,
+            treeStore: store,
+            startedAt: Date(),
+            finishedAt: Date(),
+            scanWarnings: [],
+            aggregateStats: store.aggregateStats,
+            isComplete: true,
+            scanOptions: options
+        )
+        let after = ScanSnapshot(
+            target: target,
+            treeStore: store,
+            startedAt: Date(),
+            finishedAt: Date(),
+            scanWarnings: [],
+            aggregateStats: store.aggregateStats,
+            isComplete: true,
+            scanOptions: options
+        )
+
+        let comparison = try await ScanComparisonService().compare(before: before, after: after)
+
+        XCTAssertEqual(comparison.coverage.confidence, .high)
+        XCTAssertTrue(comparison.coverage.issues.isEmpty)
+        XCTAssertTrue(comparison.coverage.targetsMatch)
+        XCTAssertEqual(comparison.coverage.scanOptionsMatch, true)
+    }
+
     func testRowQuerySortsDeltaByDisplayedSignedValue() {
         let grewBefore = makeTestFileNode(id: "/before/grew.bin", name: "grew.bin", size: 10)
         let grewAfter = makeTestFileNode(id: "/after/grew.bin", name: "grew.bin", size: 20)
@@ -287,6 +604,41 @@ final class ScanComparisonServiceTests: XCTestCase {
         let result = query.applying(to: rows)
 
         XCTAssertEqual(result.map(\.relativePath), ["Library/Application Support/cache.bin"])
+    }
+
+    func testRowQueryFiltersExactLocationPrefix() {
+        let libraryNode = makeTestFileNode(
+            id: "/after/Library/cache.bin",
+            name: "cache.bin",
+            size: 10
+        )
+        let librarySupportNode = makeTestFileNode(
+            id: "/after/Library Support/cache.bin",
+            name: "cache.bin",
+            size: 20
+        )
+        let rows = [
+            ScanComparisonRow(
+                relativePath: "Library/cache.bin",
+                kind: .added,
+                beforeNode: nil,
+                afterNode: libraryNode
+            ),
+            ScanComparisonRow(
+                relativePath: "Library Support/cache.bin",
+                kind: .added,
+                beforeNode: nil,
+                afterNode: librarySupportNode
+            ),
+        ]
+        let query = ScanComparisonRowQuery(
+            changeKind: nil,
+            searchText: "",
+            sortOrder: [],
+            pathPrefix: "Library"
+        )
+
+        XCTAssertEqual(query.applying(to: rows).map(\.relativePath), ["Library/cache.bin"])
     }
 
     func testUnchangedAndRootRowsAreExcluded() async throws {

--- a/RadixCoreTests/ScanComparisonServiceTests.swift
+++ b/RadixCoreTests/ScanComparisonServiceTests.swift
@@ -1,0 +1,148 @@
+import XCTest
+@testable import RadixCore
+
+final class ScanComparisonServiceTests: XCTestCase {
+    func testComparesSnapshotsByRelativePathAcrossDifferentRoots() async throws {
+        let beforeFile = makeTestFileNode(id: "/before/shared.bin", name: "shared.bin", size: 10)
+        let beforeRoot = makeTestDirectoryNode(id: "/before", name: "before", children: [beforeFile])
+        let beforeStore = FileTreeStore(root: beforeRoot, childrenByID: [beforeRoot.id: [beforeFile]])
+        let beforeSnapshot = makeTestSnapshot(root: beforeRoot, store: beforeStore)
+
+        let afterFile = makeTestFileNode(id: "/after/shared.bin", name: "shared.bin", size: 25)
+        let afterRoot = makeTestDirectoryNode(id: "/after", name: "after", children: [afterFile])
+        let afterStore = FileTreeStore(root: afterRoot, childrenByID: [afterRoot.id: [afterFile]])
+        let afterSnapshot = makeTestSnapshot(root: afterRoot, store: afterStore)
+
+        let comparison = try await ScanComparisonService().compare(before: beforeSnapshot, after: afterSnapshot)
+
+        XCTAssertEqual(comparison.rows.count, 1)
+        XCTAssertEqual(comparison.rows[0].relativePath, "shared.bin")
+        XCTAssertEqual(comparison.rows[0].kind, .grew)
+        XCTAssertEqual(comparison.rows[0].allocatedDelta, 15)
+        XCTAssertEqual(comparison.summary.allocatedDelta, 15)
+        XCTAssertEqual(comparison.summary.grewCount, 1)
+    }
+
+    func testAddedAndRemovedDirectoriesSuppressDescendantRows() async throws {
+        let removedChild = makeTestFileNode(id: "/before/removed/child.bin", name: "child.bin", size: 30)
+        let removedFolder = makeTestDirectoryNode(id: "/before/removed", name: "removed", children: [removedChild])
+        let sharedBefore = makeTestFileNode(id: "/before/shared.bin", name: "shared.bin", size: 10)
+        let beforeRoot = makeTestDirectoryNode(
+            id: "/before",
+            name: "before",
+            children: [removedFolder, sharedBefore]
+        )
+        let beforeStore = FileTreeStore(root: beforeRoot, childrenByID: [
+            beforeRoot.id: [removedFolder, sharedBefore],
+            removedFolder.id: [removedChild],
+        ])
+        let beforeSnapshot = makeTestSnapshot(root: beforeRoot, store: beforeStore)
+
+        let addedChild = makeTestFileNode(id: "/after/added/child.bin", name: "child.bin", size: 80)
+        let addedFolder = makeTestDirectoryNode(id: "/after/added", name: "added", children: [addedChild])
+        let sharedAfter = makeTestFileNode(id: "/after/shared.bin", name: "shared.bin", size: 45)
+        let afterRoot = makeTestDirectoryNode(
+            id: "/after",
+            name: "after",
+            children: [addedFolder, sharedAfter]
+        )
+        let afterStore = FileTreeStore(root: afterRoot, childrenByID: [
+            afterRoot.id: [addedFolder, sharedAfter],
+            addedFolder.id: [addedChild],
+        ])
+        let afterSnapshot = makeTestSnapshot(root: afterRoot, store: afterStore)
+
+        let comparison = try await ScanComparisonService().compare(before: beforeSnapshot, after: afterSnapshot)
+
+        XCTAssertEqual(
+            comparison.rows.map { "\($0.kind.rawValue):\($0.relativePath)" },
+            [
+                "added:added",
+                "grew:shared.bin",
+                "removed:removed",
+            ]
+        )
+        XCTAssertFalse(comparison.rows.contains { $0.relativePath.contains("child.bin") })
+        XCTAssertEqual(comparison.summary.addedCount, 1)
+        XCTAssertEqual(comparison.summary.removedCount, 1)
+        XCTAssertEqual(comparison.summary.grewCount, 1)
+        XCTAssertEqual(comparison.summary.changedCount, 3)
+    }
+
+    func testNestedFileGrowthDoesNotEmitAncestorDirectoryRows() async throws {
+        let beforeLeaf = makeTestFileNode(id: "/before/a/b/file.bin", name: "file.bin", size: 10)
+        let beforeInner = makeTestDirectoryNode(id: "/before/a/b", name: "b", children: [beforeLeaf])
+        let beforeOuter = makeTestDirectoryNode(id: "/before/a", name: "a", children: [beforeInner])
+        let beforeRoot = makeTestDirectoryNode(id: "/before", name: "before", children: [beforeOuter])
+        let beforeStore = FileTreeStore(root: beforeRoot, childrenByID: [
+            beforeRoot.id: [beforeOuter],
+            beforeOuter.id: [beforeInner],
+            beforeInner.id: [beforeLeaf],
+        ])
+        let beforeSnapshot = makeTestSnapshot(root: beforeRoot, store: beforeStore)
+
+        let afterLeaf = makeTestFileNode(id: "/after/a/b/file.bin", name: "file.bin", size: 100)
+        let afterInner = makeTestDirectoryNode(id: "/after/a/b", name: "b", children: [afterLeaf])
+        let afterOuter = makeTestDirectoryNode(id: "/after/a", name: "a", children: [afterInner])
+        let afterRoot = makeTestDirectoryNode(id: "/after", name: "after", children: [afterOuter])
+        let afterStore = FileTreeStore(root: afterRoot, childrenByID: [
+            afterRoot.id: [afterOuter],
+            afterOuter.id: [afterInner],
+            afterInner.id: [afterLeaf],
+        ])
+        let afterSnapshot = makeTestSnapshot(root: afterRoot, store: afterStore)
+
+        let comparison = try await ScanComparisonService().compare(before: beforeSnapshot, after: afterSnapshot)
+
+        XCTAssertEqual(comparison.rows.count, 1)
+        XCTAssertEqual(comparison.rows[0].relativePath, "a/b/file.bin")
+        XCTAssertEqual(comparison.rows[0].kind, .grew)
+        XCTAssertEqual(comparison.rows[0].allocatedDelta, 90)
+        XCTAssertFalse(comparison.rows.contains { $0.isDirectory })
+        XCTAssertEqual(comparison.summary.grewCount, 1)
+        XCTAssertEqual(comparison.summary.changedCount, 1)
+        // The aggregate delta still reflects the full change even though no directory row is emitted.
+        XCTAssertEqual(comparison.summary.allocatedDelta, 90)
+    }
+
+    func testSummarizedLeafDirectoryGrowthEmitsRow() async throws {
+        // An auto-summarized directory is a leaf node with no indexed children, so its size
+        // change has no descendant rows to represent it and must be reported directly.
+        let beforeCache = makeTestSummarizedDirectoryNode(id: "/before/cache", name: "cache", size: 100)
+        let beforeRoot = makeTestDirectoryNode(id: "/before", name: "before", children: [beforeCache])
+        let beforeStore = FileTreeStore(root: beforeRoot, childrenByID: [beforeRoot.id: [beforeCache]])
+        let beforeSnapshot = makeTestSnapshot(root: beforeRoot, store: beforeStore)
+
+        let afterCache = makeTestSummarizedDirectoryNode(id: "/after/cache", name: "cache", size: 500)
+        let afterRoot = makeTestDirectoryNode(id: "/after", name: "after", children: [afterCache])
+        let afterStore = FileTreeStore(root: afterRoot, childrenByID: [afterRoot.id: [afterCache]])
+        let afterSnapshot = makeTestSnapshot(root: afterRoot, store: afterStore)
+
+        let comparison = try await ScanComparisonService().compare(before: beforeSnapshot, after: afterSnapshot)
+
+        XCTAssertEqual(comparison.rows.count, 1)
+        XCTAssertEqual(comparison.rows[0].relativePath, "cache")
+        XCTAssertEqual(comparison.rows[0].kind, .grew)
+        XCTAssertTrue(comparison.rows[0].isDirectory)
+        XCTAssertEqual(comparison.rows[0].allocatedDelta, 400)
+        XCTAssertEqual(comparison.summary.grewCount, 1)
+    }
+
+    func testUnchangedAndRootRowsAreExcluded() async throws {
+        let unchangedBefore = makeTestFileNode(id: "/before/unchanged.bin", name: "unchanged.bin", size: 20)
+        let beforeRoot = makeTestDirectoryNode(id: "/before", name: "before", children: [unchangedBefore])
+        let beforeStore = FileTreeStore(root: beforeRoot, childrenByID: [beforeRoot.id: [unchangedBefore]])
+        let beforeSnapshot = makeTestSnapshot(root: beforeRoot, store: beforeStore)
+
+        let unchangedAfter = makeTestFileNode(id: "/after/unchanged.bin", name: "unchanged.bin", size: 20)
+        let afterRoot = makeTestDirectoryNode(id: "/after", name: "after", children: [unchangedAfter])
+        let afterStore = FileTreeStore(root: afterRoot, childrenByID: [afterRoot.id: [unchangedAfter]])
+        let afterSnapshot = makeTestSnapshot(root: afterRoot, store: afterStore)
+
+        let comparison = try await ScanComparisonService().compare(before: beforeSnapshot, after: afterSnapshot)
+
+        XCTAssertTrue(comparison.rows.isEmpty)
+        XCTAssertEqual(comparison.summary.changedCount, 0)
+        XCTAssertEqual(comparison.summary.allocatedDelta, 0)
+    }
+}

--- a/RadixCoreTests/ScanComparisonServiceTests.swift
+++ b/RadixCoreTests/ScanComparisonServiceTests.swift
@@ -292,6 +292,11 @@ final class ScanComparisonServiceTests: XCTestCase {
         XCTAssertEqual(location.movedCount, 1)
         XCTAssertEqual(location.representativeRelativePath, "Documents/new-name.bin")
         XCTAssertEqual(location.afterNode?.id, "/scan/Documents")
+
+        let movedProjection = comparison.changeTree.significantProjection(impactFilter: .moved)
+        XCTAssertEqual(movedProjection.roots.map(\.relativePath), ["Documents"])
+        let allActivityProjection = comparison.changeTree.significantProjection(impactFilter: .allActivity)
+        XCTAssertEqual(allActivityProjection.roots.map(\.relativePath), ["Documents"])
     }
 
     func testAmbiguousFileIdentityDoesNotInferMove() async throws {
@@ -658,5 +663,217 @@ final class ScanComparisonServiceTests: XCTestCase {
         XCTAssertTrue(comparison.rows.isEmpty)
         XCTAssertEqual(comparison.summary.changedCount, 0)
         XCTAssertEqual(comparison.summary.allocatedDelta, 0)
+    }
+
+    func testChangeTreeRollsEvidenceIntoEveryAncestorWithoutHidingChurn() async throws {
+        let beforeCache = makeTestFileNode(
+            id: "/scan/Users/colin/Library/cache.bin",
+            name: "cache.bin",
+            size: 10
+        )
+        let beforeOld = makeTestFileNode(
+            id: "/scan/Users/colin/Downloads/old.bin",
+            name: "old.bin",
+            size: 60
+        )
+        let beforeApp = makeTestFileNode(
+            id: "/scan/Applications/app.bin",
+            name: "app.bin",
+            size: 10
+        )
+        let beforeLibrary = makeTestDirectoryNode(
+            id: "/scan/Users/colin/Library",
+            name: "Library",
+            children: [beforeCache]
+        )
+        let beforeDownloads = makeTestDirectoryNode(
+            id: "/scan/Users/colin/Downloads",
+            name: "Downloads",
+            children: [beforeOld]
+        )
+        let beforeColin = makeTestDirectoryNode(
+            id: "/scan/Users/colin",
+            name: "colin",
+            children: [beforeLibrary, beforeDownloads]
+        )
+        let beforeUsers = makeTestDirectoryNode(
+            id: "/scan/Users",
+            name: "Users",
+            children: [beforeColin]
+        )
+        let beforeApplications = makeTestDirectoryNode(
+            id: "/scan/Applications",
+            name: "Applications",
+            children: [beforeApp]
+        )
+        let beforeRoot = makeTestDirectoryNode(
+            id: "/scan",
+            name: "scan",
+            children: [beforeUsers, beforeApplications]
+        )
+        let beforeStore = FileTreeStore(root: beforeRoot, childrenByID: [
+            beforeRoot.id: [beforeUsers, beforeApplications],
+            beforeUsers.id: [beforeColin],
+            beforeColin.id: [beforeLibrary, beforeDownloads],
+            beforeLibrary.id: [beforeCache],
+            beforeDownloads.id: [beforeOld],
+            beforeApplications.id: [beforeApp],
+        ])
+
+        let afterCache = makeTestFileNode(
+            id: "/scan/Users/colin/Library/cache.bin",
+            name: "cache.bin",
+            size: 110
+        )
+        let afterApp = makeTestFileNode(
+            id: "/scan/Applications/app.bin",
+            name: "app.bin",
+            size: 50
+        )
+        let afterLibrary = makeTestDirectoryNode(
+            id: "/scan/Users/colin/Library",
+            name: "Library",
+            children: [afterCache]
+        )
+        let afterDownloads = makeTestDirectoryNode(
+            id: "/scan/Users/colin/Downloads",
+            name: "Downloads",
+            children: []
+        )
+        let afterColin = makeTestDirectoryNode(
+            id: "/scan/Users/colin",
+            name: "colin",
+            children: [afterLibrary, afterDownloads]
+        )
+        let afterUsers = makeTestDirectoryNode(
+            id: "/scan/Users",
+            name: "Users",
+            children: [afterColin]
+        )
+        let afterApplications = makeTestDirectoryNode(
+            id: "/scan/Applications",
+            name: "Applications",
+            children: [afterApp]
+        )
+        let afterRoot = makeTestDirectoryNode(
+            id: "/scan",
+            name: "scan",
+            children: [afterUsers, afterApplications]
+        )
+        let afterStore = FileTreeStore(root: afterRoot, childrenByID: [
+            afterRoot.id: [afterUsers, afterApplications],
+            afterUsers.id: [afterColin],
+            afterColin.id: [afterLibrary, afterDownloads],
+            afterLibrary.id: [afterCache],
+            afterDownloads.id: [],
+            afterApplications.id: [afterApp],
+        ])
+
+        let comparison = try await ScanComparisonService().compare(
+            before: makeTestSnapshot(root: beforeRoot, store: beforeStore),
+            after: makeTestSnapshot(root: afterRoot, store: afterStore)
+        )
+
+        let users = try XCTUnwrap(comparison.changeTree.node(at: "Users"))
+        XCTAssertEqual(users.increasedAllocatedSize, 100)
+        XCTAssertEqual(users.reclaimedAllocatedSize, 60)
+        XCTAssertEqual(users.allocatedDelta, 40)
+        XCTAssertEqual(users.affectedCount, 2)
+        XCTAssertEqual(users.childPaths, ["Users/colin"])
+
+        let colin = try XCTUnwrap(comparison.changeTree.node(at: "Users/colin"))
+        XCTAssertEqual(colin.increasedAllocatedSize, 100)
+        XCTAssertEqual(colin.reclaimedAllocatedSize, 60)
+        XCTAssertEqual(colin.childPaths, ["Users/colin/Library", "Users/colin/Downloads"])
+        XCTAssertEqual(comparison.changeTree.rootPaths, ["Users", "Applications"])
+        XCTAssertEqual(comparison.topLevelChanges.map(\.relativePath), ["Users", "Applications"])
+        XCTAssertEqual(comparison.topLevelChanges.first?.increasedAllocatedSize, 100)
+        XCTAssertEqual(comparison.topLevelChanges.first?.reclaimedAllocatedSize, 60)
+        XCTAssertEqual(
+            comparison.changeTree.rootPaths.compactMap(comparison.changeTree.node).reduce(0) {
+                $0 + $1.increasedAllocatedSize
+            },
+            comparison.summary.grossIncreasedAllocatedSize
+        )
+        XCTAssertEqual(
+            comparison.changeTree.rootPaths.compactMap(comparison.changeTree.node).reduce(0) {
+                $0 + $1.reclaimedAllocatedSize
+            },
+            comparison.summary.grossReclaimedAllocatedSize
+        )
+    }
+
+    func testSignificantProjectionCoversGrowthAndReclamationIndependently() async throws {
+        let beforeNodes = [
+            makeTestFileNode(id: "/scan/growth.bin", name: "growth.bin", size: 0),
+            makeTestFileNode(id: "/scan/reclaimed.bin", name: "reclaimed.bin", size: 5),
+            makeTestFileNode(id: "/scan/tail.bin", name: "tail.bin", size: 0),
+        ]
+        let beforeRoot = makeTestDirectoryNode(id: "/scan", name: "scan", children: beforeNodes)
+        let beforeStore = FileTreeStore(root: beforeRoot, childrenByID: [beforeRoot.id: beforeNodes])
+        let afterNodes = [
+            makeTestFileNode(id: "/scan/growth.bin", name: "growth.bin", size: 95),
+            makeTestFileNode(id: "/scan/reclaimed.bin", name: "reclaimed.bin", size: 0),
+            makeTestFileNode(id: "/scan/tail.bin", name: "tail.bin", size: 5),
+        ]
+        let afterRoot = makeTestDirectoryNode(id: "/scan", name: "scan", children: afterNodes)
+        let afterStore = FileTreeStore(root: afterRoot, childrenByID: [afterRoot.id: afterNodes])
+        let comparison = try await ScanComparisonService().compare(
+            before: makeTestSnapshot(root: beforeRoot, store: beforeStore),
+            after: makeTestSnapshot(root: afterRoot, store: afterStore)
+        )
+
+        let projection = comparison.changeTree.significantProjection(
+            impactFilter: .allActivity,
+            coverageTarget: 0.95
+        )
+
+        XCTAssertEqual(projection.namedRootCount, 2)
+        XCTAssertEqual(projection.hiddenRootCount, 1)
+        XCTAssertTrue(projection.roots.contains { $0.relativePath == "growth.bin" })
+        XCTAssertTrue(projection.roots.contains { $0.relativePath == "reclaimed.bin" })
+        XCTAssertTrue(projection.roots.contains(where: \.isRemainder))
+    }
+
+    func testImpactQueryUsesSignedBytesAndMovementIndependently() {
+        let movedBefore = makeTestFileNode(id: "/before/old.bin", name: "old.bin", size: 100)
+        let movedAfter = makeTestFileNode(id: "/after/new.bin", name: "new.bin", size: 150)
+        let movedAndGrew = ScanComparisonRow(
+            relativePath: "new.bin",
+            kind: .moved,
+            beforeNode: movedBefore,
+            afterNode: movedAfter,
+            movedFromRelativePath: "old.bin"
+        )
+        let removed = ScanComparisonRow(
+            relativePath: "removed.bin",
+            kind: .removed,
+            beforeNode: makeTestFileNode(id: "/before/removed.bin", name: "removed.bin", size: 40),
+            afterNode: nil
+        )
+        let rows = [movedAndGrew, removed]
+
+        let taking = ScanComparisonRowQuery(
+            changeKind: nil,
+            impactFilter: .takingSpace,
+            searchText: "",
+            sortOrder: []
+        ).applying(to: rows)
+        let freeing = ScanComparisonRowQuery(
+            changeKind: nil,
+            impactFilter: .freeingSpace,
+            searchText: "",
+            sortOrder: []
+        ).applying(to: rows)
+        let moved = ScanComparisonRowQuery(
+            changeKind: nil,
+            impactFilter: .moved,
+            searchText: "",
+            sortOrder: []
+        ).applying(to: rows)
+
+        XCTAssertEqual(taking.map(\.relativePath), ["new.bin"])
+        XCTAssertEqual(freeing.map(\.relativePath), ["removed.bin"])
+        XCTAssertEqual(moved.map(\.relativePath), ["new.bin"])
     }
 }

--- a/RadixCoreTests/ScanComparisonServiceTests.swift
+++ b/RadixCoreTests/ScanComparisonServiceTests.swift
@@ -227,6 +227,68 @@ final class ScanComparisonServiceTests: XCTestCase {
         XCTAssertEqual(comparison.summary.allocatedDelta, 0)
     }
 
+    func testRowQuerySortsDeltaByDisplayedSignedValue() {
+        let grewBefore = makeTestFileNode(id: "/before/grew.bin", name: "grew.bin", size: 10)
+        let grewAfter = makeTestFileNode(id: "/after/grew.bin", name: "grew.bin", size: 20)
+        let shrankBefore = makeTestFileNode(id: "/before/shrank.bin", name: "shrank.bin", size: 100)
+        let shrankAfter = makeTestFileNode(id: "/after/shrank.bin", name: "shrank.bin", size: 20)
+        let rows = [
+            ScanComparisonRow(
+                relativePath: "shrank.bin",
+                kind: .shrank,
+                beforeNode: shrankBefore,
+                afterNode: shrankAfter
+            ),
+            ScanComparisonRow(
+                relativePath: "grew.bin",
+                kind: .grew,
+                beforeNode: grewBefore,
+                afterNode: grewAfter
+            ),
+        ]
+        let query = ScanComparisonRowQuery(
+            changeKind: nil,
+            searchText: "",
+            sortOrder: [ScanComparisonRowComparator(field: .allocatedDelta, order: .reverse)]
+        )
+
+        let result = query.applying(to: rows)
+
+        XCTAssertEqual(result.map(\.relativePath), ["grew.bin", "shrank.bin"])
+    }
+
+    func testRowQueryFiltersKindAndNormalizedPath() {
+        let addedNode = makeTestFileNode(
+            id: "/after/Library/Application Support/cache.bin",
+            name: "cache.bin",
+            size: 10
+        )
+        let removedNode = makeTestFileNode(id: "/before/other.bin", name: "other.bin", size: 20)
+        let rows = [
+            ScanComparisonRow(
+                relativePath: "Library/Application Support/cache.bin",
+                kind: .added,
+                beforeNode: nil,
+                afterNode: addedNode
+            ),
+            ScanComparisonRow(
+                relativePath: "other.bin",
+                kind: .removed,
+                beforeNode: removedNode,
+                afterNode: nil
+            ),
+        ]
+        let query = ScanComparisonRowQuery(
+            changeKind: .added,
+            searchText: "application support",
+            sortOrder: []
+        )
+
+        let result = query.applying(to: rows)
+
+        XCTAssertEqual(result.map(\.relativePath), ["Library/Application Support/cache.bin"])
+    }
+
     func testUnchangedAndRootRowsAreExcluded() async throws {
         let unchangedBefore = makeTestFileNode(id: "/before/unchanged.bin", name: "unchanged.bin", size: 20)
         let beforeRoot = makeTestDirectoryNode(id: "/before", name: "before", children: [unchangedBefore])

--- a/RadixCoreTests/ScanEngineTests.swift
+++ b/RadixCoreTests/ScanEngineTests.swift
@@ -1388,6 +1388,8 @@ final class ScanEngineTests: XCTestCase {
         XCTAssertEqual(rootChildren(in: parallelSnapshot).map(\.name), rootChildren(in: serialSnapshot).map(\.name))
         XCTAssertFalse(rootChildren(in: parallelSnapshot).contains(where: { $0.name == "excluded.log" }))
         XCTAssertEqual(parallelSnapshot.root.descendantFileCount, serialSnapshot.root.descendantFileCount)
+        XCTAssertEqual(parallelSnapshot.root.isAccessible, serialSnapshot.root.isAccessible)
+        XCTAssertEqual(parallelSnapshot.root.isSelfAccessible, serialSnapshot.root.isSelfAccessible)
         XCTAssertEqual(parallelSnapshot.root.logicalSize, serialSnapshot.root.logicalSize)
         XCTAssertEqual(parallelSnapshot.root.allocatedSize, serialSnapshot.root.allocatedSize)
         XCTAssertEqual(parallelSnapshot.aggregateStats.fileCount, serialSnapshot.aggregateStats.fileCount)
@@ -1442,6 +1444,8 @@ final class ScanEngineTests: XCTestCase {
         for serialChild in rootChildren(in: serialSnapshot) {
             let parallelChild = try XCTUnwrap(rootChildren(in: parallelSnapshot).first { $0.id == serialChild.id })
             XCTAssertEqual(children(of: parallelChild, in: parallelSnapshot).map(\.name), children(of: serialChild, in: serialSnapshot).map(\.name))
+            XCTAssertEqual(parallelChild.isAccessible, serialChild.isAccessible)
+            XCTAssertEqual(parallelChild.isSelfAccessible, serialChild.isSelfAccessible)
         }
     }
 

--- a/RadixCoreTests/ScanMetadataLoaderTests.swift
+++ b/RadixCoreTests/ScanMetadataLoaderTests.swift
@@ -186,6 +186,63 @@ final class ScanMetadataLoaderTests: XCTestCase {
         XCTAssertEqual(counters.lstatCount, 1)
     }
 
+    func testVisibleSymlinkMetadataUsesLstatIdentity() throws {
+        let rootURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        let targetURL = rootURL.appending(path: "target.bin")
+        let symlinkURL = rootURL.appending(path: "target-link")
+        try Data(repeating: 0xA5, count: 128).write(to: targetURL)
+        try FileManager.default.createSymbolicLink(at: symlinkURL, withDestinationURL: targetURL)
+
+        let counters = LinkCountProbeCounters()
+        let loader = ScanMetadataLoader(
+            diagnostics: nil,
+            fileSystemInfoProvider: { _, _ in
+                counters.recordLstat()
+                return (FileIdentity(device: 1, inode: 42), 1)
+            }
+        )
+
+        let metadata = loader.metadata(
+            for: symlinkURL,
+            prefetchedResourceValues: try resourceValuesWithoutIdentity(for: symlinkURL)
+        )
+
+        XCTAssertTrue(metadata.isSymbolicLink)
+        XCTAssertEqual(metadata.fileIdentity, FileIdentity(device: 1, inode: 42))
+        XCTAssertEqual(counters.lstatCount, 1)
+    }
+
+    func testAtomicSummarySymlinkMetadataSkipsLstatIdentity() throws {
+        let rootURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        let targetURL = rootURL.appending(path: "target.bin")
+        let symlinkURL = rootURL.appending(path: "target-link")
+        try Data(repeating: 0xA5, count: 128).write(to: targetURL)
+        try FileManager.default.createSymbolicLink(at: symlinkURL, withDestinationURL: targetURL)
+
+        let counters = LinkCountProbeCounters()
+        let loader = ScanMetadataLoader(
+            diagnostics: nil,
+            fileSystemInfoProvider: { _, _ in
+                counters.recordLstat()
+                return (FileIdentity(device: 1, inode: 42), 1)
+            }
+        )
+
+        let metadata = loader.atomicSummaryMetadata(
+            for: symlinkURL,
+            prefetchedResourceValues: try resourceValuesWithoutIdentity(for: symlinkURL)
+        )
+
+        XCTAssertTrue(metadata.isSymbolicLink)
+        XCTAssertNil(metadata.fileIdentity)
+        XCTAssertEqual(metadata.linkCount, 1)
+        XCTAssertEqual(counters.lstatCount, 0)
+    }
+
     private func resourceValuesWithoutIdentity(for url: URL) throws -> URLResourceValues {
         try url.resourceValues(forKeys: [
             .isDirectoryKey,

--- a/RadixCoreTests/TestFixtures.swift
+++ b/RadixCoreTests/TestFixtures.swift
@@ -57,6 +57,36 @@ func makeTestDirectoryNode(
     )
 }
 
+/// A directory the scan engine collapsed into a single leaf node (an auto-summarized
+/// subtree). Its children are never indexed, so it must be placed in a store without a
+/// `childrenByID` entry for its own id.
+func makeTestSummarizedDirectoryNode(
+    id: String,
+    name: String,
+    size: Int64,
+    descendantFileCount: Int = 100
+) -> FileNodeRecord {
+    FileNodeRecord(
+        id: id,
+        url: URL(filePath: id, directoryHint: .isDirectory),
+        name: name,
+        isDirectory: true,
+        isSymbolicLink: false,
+        allocatedSize: size,
+        unduplicatedAllocatedSize: nil,
+        logicalSize: size,
+        descendantFileCount: descendantFileCount,
+        lastModified: nil,
+        fileIdentity: nil,
+        linkCount: 1,
+        isPackage: false,
+        isAccessible: true,
+        isSelfAccessible: true,
+        isSynthetic: false,
+        isAutoSummarized: true
+    )
+}
+
 func makeTestSnapshot(
     target: ScanTarget? = nil,
     root: FileNodeRecord,

--- a/RadixCoreTests/WorkspaceNavigationModelTests.swift
+++ b/RadixCoreTests/WorkspaceNavigationModelTests.swift
@@ -239,6 +239,30 @@ final class WorkspaceNavigationModelTests: XCTestCase {
     }
 
     @MainActor
+    func testRevealFileFocusesContainingFolderAndSelectsNode() throws {
+        let fixture = makeNavigationFixture()
+        let model = makeConfiguredNavigationModel(fixture: fixture)
+        var publishedStates: [WorkspaceNavigationState] = []
+        var cancellables = Set<AnyCancellable>()
+
+        model.$state
+            .dropFirst()
+            .sink { publishedStates.append($0) }
+            .store(in: &cancellables)
+
+        model.reveal(nodeID: fixture.docFile.id)
+
+        XCTAssertEqual(publishedStates.count, 1)
+        let state = try XCTUnwrap(publishedStates.first)
+        // Unlike selectAndFocus, reveal focuses the parent folder (docs) rather than the
+        // file itself, so the file list shows the file among its siblings.
+        XCTAssertEqual(state.focusedNodeID, fixture.docs.id)
+        XCTAssertEqual(state.selectedNodeID, fixture.docFile.id)
+        XCTAssertEqual(state.tableNodes.map(\.id), [fixture.docFile.id])
+        XCTAssertEqual(state.focusBackStack, [fixture.root.id])
+    }
+
+    @MainActor
     func testSelectionPublishesAncestorsWithoutReplacingTableState() throws {
         let fixture = makeNavigationFixture()
         let model = makeConfiguredNavigationModel(fixture: fixture)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scan comparison workflows for saved snapshots and comparing the current scan with a previous compatible scan.
  * Added a comparison setup sheet and a “Storage Changes” view with filtering, search, sorting, and change-type controls.
  * Added “Compare Scans…” commands and updated toolbar/menu actions, plus improved navigation with “Reveal” focusing the containing folder.
* **Bug Fixes**
  * Tightened workspace-dependent command availability to prevent inaccessible actions.
  * Fixed inspector/sidebar presentation behavior during comparison setup and completion.
  * Improved scan preview metadata and symbolic-link handling for atomic summary scans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->