### PR TITLE
fix: harden scan state and derived data

### DIFF
--- a/Radix/Models/ScanSnapshot.swift
+++ b/Radix/Models/ScanSnapshot.swift
@@ -178,13 +178,22 @@ nonisolated struct ScanSnapshot: Identifiable, Sendable {
             cancellationCheck: cancellationCheck
         ) else { return nil }
 
+        var retainedWarnings: [ScanWarning] = []
+        retainedWarnings.reserveCapacity(scanWarnings.count)
+        for warning in scanWarnings {
+            try cancellationCheck()
+            if !Self.path(warning.path, isContainedIn: targetID) {
+                retainedWarnings.append(warning)
+            }
+        }
+
         let updatedSnapshot = ScanSnapshot(
             id: id,
             target: target,
             treeStore: updatedStore,
             startedAt: startedAt,
             finishedAt: finishedAt,
-            scanWarnings: scanWarnings,
+            scanWarnings: retainedWarnings,
             aggregateStats: updatedStore.aggregateStats,
             isComplete: isComplete,
             scanOptions: scanOptions,

--- a/Radix/Models/ScanSnapshot.swift
+++ b/Radix/Models/ScanSnapshot.swift
@@ -257,6 +257,7 @@ nonisolated struct ScanSnapshot: Identifiable, Sendable {
         }
 
         return ScanSnapshot(
+            id: id,
             target: target,
             treeStore: updatedStore,
             startedAt: startedAt,

--- a/Radix/Models/ScanSnapshot.swift
+++ b/Radix/Models/ScanSnapshot.swift
@@ -268,25 +268,10 @@ nonisolated struct ScanSnapshot: Identifiable, Sendable {
         additionalWarnings: [ScanWarning] = [],
         cancellationCheck: () throws -> Void
     ) throws -> ScanSnapshot? {
-        try cancellationCheck()
-        guard let updatedStore = try treeStore.replacingSubtree(
-            id: targetID,
-            with: replacement,
+        try replacingSubtrees(
+            [targetID: replacement],
+            additionalWarnings: additionalWarnings,
             cancellationCheck: cancellationCheck
-        ) else { return nil }
-
-        return ScanSnapshot(
-            target: target,
-            treeStore: updatedStore,
-            startedAt: startedAt,
-            finishedAt: finishedAt,
-            scanWarnings: Self.mergedWarnings(existing: scanWarnings, additional: additionalWarnings),
-            aggregateStats: updatedStore.aggregateStats,
-            isComplete: isComplete,
-            scanOptions: scanOptions,
-            volumeCapacity: volumeCapacity,
-            source: source,
-            incrementalCheckpoint: incrementalCheckpoint
         )
     }
 

--- a/Radix/Services/ScanArchiveModels.swift
+++ b/Radix/Services/ScanArchiveModels.swift
@@ -553,4 +553,16 @@ nonisolated struct ScanArchiveStatsV1: Codable, Sendable {
             accessibleItemCount == stats.accessibleItemCount &&
             inaccessibleItemCount == stats.inaccessibleItemCount
     }
+
+    func validate() throws {
+        guard totalAllocatedSize >= 0, totalLogicalSize >= 0 else {
+            throw ScanArchiveError.stats(localized: "snapshot totals cannot be negative")
+        }
+        guard fileCount >= 0,
+              directoryCount >= 0,
+              accessibleItemCount >= 0,
+              inaccessibleItemCount >= 0 else {
+            throw ScanArchiveError.stats(localized: "snapshot item counts cannot be negative")
+        }
+    }
 }

--- a/Radix/Services/ScanArchiveNodeIO.swift
+++ b/Radix/Services/ScanArchiveNodeIO.swift
@@ -9,6 +9,7 @@ import Foundation
 private nonisolated enum ScanArchiveNodeIOConstants {
     static let readChunkSize = 1024 * 1024
     static let maxNodeLineByteCount = 1024 * 1024
+    static let maximumInitialRecordCapacity = 65_536
     static let newlineData = Data([0x0A])
 }
 
@@ -271,7 +272,10 @@ extension ScanArchiveService {
 
         let decoder = Self.makeJSONDecoder()
         var records: [Record] = []
-        records.reserveCapacity(expectedNodeCount)
+        records.reserveCapacity(min(
+            expectedNodeCount,
+            ScanArchiveNodeIOConstants.maximumInitialRecordCapacity
+        ))
         var buffer = Data()
         var hasher = SHA256()
         var decodedNodeCount = 0

--- a/Radix/Services/ScanArchiveService.swift
+++ b/Radix/Services/ScanArchiveService.swift
@@ -327,6 +327,7 @@ nonisolated struct ScanArchiveService: ScanArchiveServicing {
         let stats: ScanArchiveStatsV1 = try readJSON(ScanArchiveStatsV1.self, from: statsURL) { detail in
             ScanArchiveError.stats(detail)
         }
+        try stats.validate()
         let archiveSize = try archiveLogicalSize(at: sourceURL)
         return ScanArchivePreview(
             archiveURL: sourceURL,
@@ -406,6 +407,7 @@ nonisolated struct ScanArchiveService: ScanArchiveServicing {
         let archivedStats: ScanArchiveStatsV1 = try readJSON(ScanArchiveStatsV1.self, from: statsURL) { detail in
             ScanArchiveError.stats(detail)
         }
+        try archivedStats.validate()
 
         try Task.checkCancellation()
         progressReporter?.report(ScanArchiveProgress(

--- a/Radix/Services/ScanArchiveService.swift
+++ b/Radix/Services/ScanArchiveService.swift
@@ -368,6 +368,13 @@ nonisolated struct ScanArchiveService: ScanArchiveServicing {
             in: sourceURL,
             sectionDescription: "stats"
         )
+        let archivedStats: ScanArchiveStatsV1 = try readJSON(
+            ScanArchiveStatsV1.self,
+            from: statsURL
+        ) { detail in
+            ScanArchiveError.stats(detail)
+        }
+        try archivedStats.validate()
 
         let encodedNodePayload = try await readNodes(
             from: nodesURL,
@@ -404,11 +411,6 @@ nonisolated struct ScanArchiveService: ScanArchiveServicing {
         let warnings: [ScanArchiveWarningV1] = try readJSON([ScanArchiveWarningV1].self, from: warningsURL) { detail in
             ScanArchiveError.manifest(localized: "warnings section failed: \(detail)")
         }
-        let archivedStats: ScanArchiveStatsV1 = try readJSON(ScanArchiveStatsV1.self, from: statsURL) { detail in
-            ScanArchiveError.stats(detail)
-        }
-        try archivedStats.validate()
-
         try Task.checkCancellation()
         progressReporter?.report(ScanArchiveProgress(
             phase: .rebuildingSnapshot,

--- a/Radix/Services/ScanComparisonProjection.swift
+++ b/Radix/Services/ScanComparisonProjection.swift
@@ -156,11 +156,20 @@ nonisolated struct ScanComparisonChangeTree: Equatable, Sendable {
             } else {
                 hidden.append(entry.node.relativePath)
             }
-            totalImpact += entry.impact
-            totalChangeCount += entry.changeCount
+            totalImpact = ScanComparisonIntegerMath.addingClamped(totalImpact, entry.impact)
+            totalChangeCount = ScanComparisonIntegerMath.addingClamped(
+                totalChangeCount,
+                entry.changeCount
+            )
             if isSelected {
-                representedImpact += entry.impact
-                representedChangeCount += entry.changeCount
+                representedImpact = ScanComparisonIntegerMath.addingClamped(
+                    representedImpact,
+                    entry.impact
+                )
+                representedChangeCount = ScanComparisonIntegerMath.addingClamped(
+                    representedChangeCount,
+                    entry.changeCount
+                )
             }
         }
         if totalImpact == 0 {
@@ -293,10 +302,16 @@ nonisolated struct ScanComparisonChangeTreeNode: Identifiable, Equatable, Sendab
             relativePath: parentPath ?? "",
             name: "Other smaller changes",
             increasedAllocatedSize: hiddenNodes.reduce(0) {
-                $0 + $1.increasedAllocatedSize(for: changeKinds)
+                ScanComparisonIntegerMath.addingClamped(
+                    $0,
+                    $1.increasedAllocatedSize(for: changeKinds)
+                )
             },
             reclaimedAllocatedSize: hiddenNodes.reduce(0) {
-                $0 + $1.reclaimedAllocatedSize(for: changeKinds)
+                ScanComparisonIntegerMath.addingClamped(
+                    $0,
+                    $1.reclaimedAllocatedSize(for: changeKinds)
+                )
             },
             affectedCount: affectedCount,
             movedCount: changeKinds.contains(.moved)
@@ -340,4 +355,3 @@ nonisolated struct ScanComparisonChangeTreeProjection: Equatable, Sendable {
         return nil
     }
 }
-

--- a/Radix/Services/ScanComparisonService.swift
+++ b/Radix/Services/ScanComparisonService.swift
@@ -9,7 +9,7 @@ nonisolated enum ScanComparisonIntegerMath {
     static func addingClamped(_ lhs: Int64, _ rhs: Int64) -> Int64 {
         let (sum, overflow) = lhs.addingReportingOverflow(rhs)
         guard overflow else { return sum }
-        return rhs >= 0 ? .max : .min
+        return rhs >= 0 ? .max : -.max
     }
 }
 
@@ -993,7 +993,10 @@ nonisolated struct ScanComparisonService: Sendable {
             var reclaimedAllocatedSize: Int64 = 0
             for row in locationRows {
                 counts[row.kind, default: 0] += 1
-                allocatedDelta += row.allocatedDelta
+                allocatedDelta = ScanComparisonIntegerMath.addingClamped(
+                    allocatedDelta,
+                    row.allocatedDelta
+                )
                 if row.allocatedDelta > 0 {
                     increasedAllocatedSize = ScanComparisonIntegerMath.addingClamped(
                         increasedAllocatedSize,

--- a/Radix/Services/ScanComparisonService.swift
+++ b/Radix/Services/ScanComparisonService.swift
@@ -5,6 +5,14 @@
 
 import Foundation
 
+nonisolated enum ScanComparisonIntegerMath {
+    static func addingClamped(_ lhs: Int64, _ rhs: Int64) -> Int64 {
+        let (sum, overflow) = lhs.addingReportingOverflow(rhs)
+        guard overflow else { return sum }
+        return rhs >= 0 ? .max : .min
+    }
+}
+
 nonisolated struct ComparedSnapshotSummary: Equatable, Sendable {
     let id: UUID
     let displayName: String
@@ -110,9 +118,15 @@ nonisolated struct ScanComparisonSummary: Equatable, Sendable {
         for row in rows {
             counts[row.kind, default: 0] += 1
             if row.allocatedDelta > 0 {
-                grossIncreasedAllocatedSize += row.allocatedDelta
+                grossIncreasedAllocatedSize = ScanComparisonIntegerMath.addingClamped(
+                    grossIncreasedAllocatedSize,
+                    row.allocatedDelta
+                )
             } else if row.allocatedDelta < 0 {
-                grossReclaimedAllocatedSize += -row.allocatedDelta
+                grossReclaimedAllocatedSize = ScanComparisonIntegerMath.addingClamped(
+                    grossReclaimedAllocatedSize,
+                    -row.allocatedDelta
+                )
             }
         }
         self.addedCount = counts[.added, default: 0]
@@ -265,7 +279,7 @@ nonisolated struct ScanComparisonLocationChange: Identifiable, Equatable, Sendab
     }
 
     var grossChangedAllocatedSize: Int64 {
-        increasedAllocatedSize + reclaimedAllocatedSize
+        ScanComparisonIntegerMath.addingClamped(increasedAllocatedSize, reclaimedAllocatedSize)
     }
 
     /// Prefer the current node so an overview can navigate to the location in the active scan.
@@ -303,7 +317,7 @@ nonisolated struct ScanComparisonAggregateChange: Identifiable, Equatable, Senda
     }
 
     var grossChangedAllocatedSize: Int64 {
-        increasedAllocatedSize + reclaimedAllocatedSize
+        ScanComparisonIntegerMath.addingClamped(increasedAllocatedSize, reclaimedAllocatedSize)
     }
 
     var affectedCount: Int {
@@ -337,25 +351,39 @@ nonisolated struct ScanComparisonAggregateChange: Identifiable, Equatable, Senda
     }
 
     func increasedAllocatedSize(for changeKinds: Set<ScanComparisonChangeKind>) -> Int64 {
-        changeKinds.reduce(0) { $0 + increasedAllocatedSizeByKind[$1, default: 0] }
+        changeKinds.reduce(0) {
+            ScanComparisonIntegerMath.addingClamped(
+                $0,
+                increasedAllocatedSizeByKind[$1, default: 0]
+            )
+        }
     }
 
     func reclaimedAllocatedSize(for changeKinds: Set<ScanComparisonChangeKind>) -> Int64 {
-        changeKinds.reduce(0) { $0 + reclaimedAllocatedSizeByKind[$1, default: 0] }
+        changeKinds.reduce(0) {
+            ScanComparisonIntegerMath.addingClamped(
+                $0,
+                reclaimedAllocatedSizeByKind[$1, default: 0]
+            )
+        }
     }
 
     func impact(for kind: ScanComparisonChangeKind) -> Int64 {
         if kind == .moved {
             return Int64(movedCount)
         }
-        return increasedAllocatedSizeByKind[kind, default: 0]
-            + reclaimedAllocatedSizeByKind[kind, default: 0]
+        return ScanComparisonIntegerMath.addingClamped(
+            increasedAllocatedSizeByKind[kind, default: 0],
+            reclaimedAllocatedSizeByKind[kind, default: 0]
+        )
     }
 
     func impact(for changeKinds: Set<ScanComparisonChangeKind>) -> Int64 {
         let storageKinds = changeKinds.subtracting([.moved])
         if !storageKinds.isEmpty {
-            return storageKinds.reduce(0) { $0 + impact(for: $1) }
+            return storageKinds.reduce(0) {
+                ScanComparisonIntegerMath.addingClamped($0, impact(for: $1))
+            }
         }
         return changeKinds.contains(.moved) ? Int64(movedCount) : 0
     }
@@ -814,11 +842,25 @@ nonisolated struct ScanComparisonService: Sendable {
                 directRowID = row.id
             }
             if row.allocatedDelta > 0 {
-                increasedAllocatedSize += row.allocatedDelta
-                increasedAllocatedSizeByKind[row.kind, default: 0] += row.allocatedDelta
+                increasedAllocatedSize = ScanComparisonIntegerMath.addingClamped(
+                    increasedAllocatedSize,
+                    row.allocatedDelta
+                )
+                increasedAllocatedSizeByKind[row.kind, default: 0] =
+                    ScanComparisonIntegerMath.addingClamped(
+                        increasedAllocatedSizeByKind[row.kind, default: 0],
+                        row.allocatedDelta
+                    )
             } else if row.allocatedDelta < 0 {
-                reclaimedAllocatedSize += -row.allocatedDelta
-                reclaimedAllocatedSizeByKind[row.kind, default: 0] += -row.allocatedDelta
+                reclaimedAllocatedSize = ScanComparisonIntegerMath.addingClamped(
+                    reclaimedAllocatedSize,
+                    -row.allocatedDelta
+                )
+                reclaimedAllocatedSizeByKind[row.kind, default: 0] =
+                    ScanComparisonIntegerMath.addingClamped(
+                        reclaimedAllocatedSizeByKind[row.kind, default: 0],
+                        -row.allocatedDelta
+                    )
             }
             switch row.kind {
             case .added:
@@ -877,8 +919,14 @@ nonisolated struct ScanComparisonService: Sendable {
             guard let lhs = accumulators[lhsPath], let rhs = accumulators[rhsPath] else {
                 return lhsPath.localizedStandardCompare(rhsPath) == .orderedAscending
             }
-            let lhsGross = lhs.increasedAllocatedSize + lhs.reclaimedAllocatedSize
-            let rhsGross = rhs.increasedAllocatedSize + rhs.reclaimedAllocatedSize
+            let lhsGross = ScanComparisonIntegerMath.addingClamped(
+                lhs.increasedAllocatedSize,
+                lhs.reclaimedAllocatedSize
+            )
+            let rhsGross = ScanComparisonIntegerMath.addingClamped(
+                rhs.increasedAllocatedSize,
+                rhs.reclaimedAllocatedSize
+            )
             if lhsGross != rhsGross { return lhsGross > rhsGross }
             return lhsPath.localizedStandardCompare(rhsPath) == .orderedAscending
         }
@@ -947,9 +995,15 @@ nonisolated struct ScanComparisonService: Sendable {
                 counts[row.kind, default: 0] += 1
                 allocatedDelta += row.allocatedDelta
                 if row.allocatedDelta > 0 {
-                    increasedAllocatedSize += row.allocatedDelta
+                    increasedAllocatedSize = ScanComparisonIntegerMath.addingClamped(
+                        increasedAllocatedSize,
+                        row.allocatedDelta
+                    )
                 } else if row.allocatedDelta < 0 {
-                    reclaimedAllocatedSize += -row.allocatedDelta
+                    reclaimedAllocatedSize = ScanComparisonIntegerMath.addingClamped(
+                        reclaimedAllocatedSize,
+                        -row.allocatedDelta
+                    )
                 }
             }
 

--- a/Radix/Services/SunburstGeometry.swift
+++ b/Radix/Services/SunburstGeometry.swift
@@ -56,7 +56,7 @@ nonisolated enum SunburstLayout {
         let visibleChildren = rootChildren.isEmpty ? [root] : rootChildren
         let ringStart = centerRadius
         let ringWidth = (0.98 - ringStart) / CGFloat(max(depthLimit, 1))
-        let denominator = max(root.allocatedSize, Int64(visibleChildren.count))
+        let denominator = max(Double(root.allocatedSize), Double(visibleChildren.count))
         let colorBranchContext = ColorBranchContext(rootChildIDs: rootColorBranchIDs(in: treeStore))
 
         var result: [SunburstSegment] = []
@@ -82,7 +82,7 @@ nonisolated enum SunburstLayout {
     private nonisolated static func appendSegments(
         in treeStore: FileTreeStore,
         children: [FileNodeRecord],
-        parentDenominator: Int64,
+        parentDenominator: Double,
         startAngle: Double,
         endAngle: Double,
         depth: Int,
@@ -98,8 +98,8 @@ nonisolated enum SunburstLayout {
         guard depth < depthLimit else { return }
 
         try cancellationCheck()
-        let effectiveChildTotal = children.reduce(Int64(0)) { total, child in
-            total + max(child.allocatedSize, 1)
+        let effectiveChildTotal = children.reduce(0.0) { total, child in
+            total + Double(max(child.allocatedSize, 1))
         }
         let safeDenominator = max(parentDenominator, effectiveChildTotal)
         let totalAngle = endAngle - startAngle
@@ -116,7 +116,7 @@ nonisolated enum SunburstLayout {
         var cursor = startAngle
         for entry in grouped {
             try cancellationCheck()
-            let proportion = Double(entry.totalSize) / Double(safeDenominator)
+            let proportion = Double(entry.totalSize) / safeDenominator
             let segmentEnd = cursor + (totalAngle * proportion)
             let siblingIndex = siblingIndexes[entry.id] ?? 0
             let branch = branchContext ?? colorBranch(
@@ -164,7 +164,7 @@ nonisolated enum SunburstLayout {
                 try appendSegments(
                     in: treeStore,
                     children: childNodes,
-                    parentDenominator: node.allocatedSize,
+                    parentDenominator: Double(node.allocatedSize),
                     startAngle: cursor,
                     endAngle: segmentEnd,
                     depth: depth + 1,
@@ -185,7 +185,7 @@ nonisolated enum SunburstLayout {
 
     private nonisolated static func groupedChildren(
         _ children: [FileNodeRecord],
-        denominator: Int64,
+        denominator: Double,
         totalAngle: Double,
         minimumAngle: Double,
         cancellationCheck: CancellationCheck
@@ -211,10 +211,10 @@ nonisolated enum SunburstLayout {
         for child in children {
             try cancellationCheck()
             let size = max(child.allocatedSize, 1)
-            let angle = totalAngle * (Double(size) / Double(max(denominator, 1)))
+            let angle = totalAngle * (Double(size) / max(denominator, 1))
             if angle < minimumAngle {
                 groupedNodes.append(child)
-                groupedSize += size
+                groupedSize = addingClamped(groupedSize, size)
             } else {
                 visible.append(
                     GroupEntry(
@@ -257,6 +257,11 @@ nonisolated enum SunburstLayout {
         }
 
         return visible
+    }
+
+    private nonisolated static func addingClamped(_ lhs: Int64, _ rhs: Int64) -> Int64 {
+        let (sum, overflow) = lhs.addingReportingOverflow(rhs)
+        return overflow ? .max : sum
     }
 
     private nonisolated static func colorRole(for entry: GroupEntry) -> SunburstColorRole {

--- a/Radix/ViewModels/AppModel.swift
+++ b/Radix/ViewModels/AppModel.swift
@@ -249,7 +249,9 @@ final class AppModel: ObservableObject {
     private var deferredNavigationContextSnapshotID: UUID?
     private var postTrashRemovalTask: Task<Void, Never>?
     private var exportPanelTask: Task<Void, Never>?
+    private var exportPanelRequestID: UUID?
     private var comparisonPanelTask: Task<Void, Never>?
+    private var comparisonPanelRequestID: UUID?
     private var readyDeferredArchiveImportURL: URL?
     private var exportConfirmationDismissTask: Task<Void, Never>?
     private var postTrashRemovalRequests: [PostTrashRemovalRequest] = []
@@ -344,8 +346,10 @@ final class AppModel: ObservableObject {
         cancelDiskFreeSpaceCapacityRefresh(clearCache: true)
         exportPanelTask?.cancel()
         exportPanelTask = nil
+        exportPanelRequestID = nil
         comparisonPanelTask?.cancel()
         comparisonPanelTask = nil
+        comparisonPanelRequestID = nil
         isExportPanelPresented = false
         readyDeferredArchiveImportURL = nil
         cancelArchiveOperation()
@@ -708,16 +712,22 @@ final class AppModel: ObservableObject {
         let snapshotID = snapshot.id
 
         exportPanelTask?.cancel()
+        let requestID = UUID()
+        exportPanelRequestID = requestID
         isExportPanelPresented = true
         exportPanelTask = Task { @MainActor [weak self] in
             guard let self else { return }
             defer {
-                self.isExportPanelPresented = false
-                self.exportPanelTask = nil
+                if self.exportPanelRequestID == requestID {
+                    self.isExportPanelPresented = false
+                    self.exportPanelTask = nil
+                    self.exportPanelRequestID = nil
+                }
             }
 
             guard let destinationURL = await self.dependencies.systemActions.presentExportScanPanel(defaultFileName),
                   !Task.isCancelled,
+                  self.exportPanelRequestID == requestID,
                   self.scanCoordinator.snapshot?.id == snapshotID,
                   self.canExportCurrentScanIgnoringPresentedPanel else {
                 return
@@ -1093,10 +1103,19 @@ final class AppModel: ObservableObject {
         let setupID = pendingComparisonSetup?.id
 
         comparisonPanelTask?.cancel()
+        let requestID = UUID()
+        comparisonPanelRequestID = requestID
         comparisonPanelTask = Task { @MainActor [weak self] in
-            defer { self?.comparisonPanelTask = nil }
-            guard let self,
-                  let sourceURL = await self.dependencies.systemActions.presentComparisonSnapshotPanel(),
+            guard let self else { return }
+            defer {
+                if self.comparisonPanelRequestID == requestID {
+                    self.comparisonPanelTask = nil
+                    self.comparisonPanelRequestID = nil
+                }
+            }
+            guard let sourceURL = await self.dependencies.systemActions.presentComparisonSnapshotPanel(),
+                  !Task.isCancelled,
+                  self.comparisonPanelRequestID == requestID,
                   self.pendingComparisonSetup?.id == setupID,
                   self.pendingComparisonSetup?.loadingSlot == nil else {
                 return

--- a/Radix/ViewModels/ScanComparisonBrowserModel.swift
+++ b/Radix/ViewModels/ScanComparisonBrowserModel.swift
@@ -118,6 +118,9 @@ final class ScanComparisonBrowserModel: ObservableObject {
         refreshTask?.cancel()
         refreshTask = nil
         generation &+= 1
+        latestComparisonID = nil
+        latestQuery = nil
+        latestChangeKinds = nil
         isRefreshing = false
     }
 

--- a/RadixCoreTests/AppModelDependencyTests.swift
+++ b/RadixCoreTests/AppModelDependencyTests.swift
@@ -2122,6 +2122,59 @@ final class AppModelDependencyTests: XCTestCase {
     }
 
     @MainActor
+    func testSupersededExportPanelCannotClearOrOutliveRestartedRequest() async throws {
+        let staleURL = URL(filePath: "/tmp/stale-export.radixscan", directoryHint: .isDirectory)
+        let currentURL = URL(filePath: "/tmp/current-export.radixscan", directoryHint: .isDirectory)
+        let firstPanel = AsyncValueProbe<URL?>()
+        let secondPanel = AsyncValueProbe<URL?>()
+        let archiveService = SpyScanArchiveService()
+        var panelRequestCount = 0
+        var actions = AppSystemActions.inert
+        actions.presentExportScanPanel = { _ in
+            panelRequestCount += 1
+            return await (panelRequestCount == 1 ? firstPanel : secondPanel).wait()
+        }
+        let model = AppModel(dependencies: makeDependencies(
+            systemActions: actions,
+            scanArchiveService: archiveService
+        ))
+        let file = makeTestFileNode(id: "/export-race/file.txt", name: "file.txt")
+        let root = makeTestDirectoryNode(id: "/export-race", name: "Export Race", children: [file])
+        let store = FileTreeStore(root: root, childrenByID: [root.id: [file]])
+        model.scanState.restoreCompletedSnapshot(ScanSnapshot(
+            target: ScanTarget(id: root.id, url: root.url, displayName: "Export Race", kind: .folder),
+            treeStore: store,
+            startedAt: Date(timeIntervalSince1970: 1),
+            finishedAt: Date(timeIntervalSince1970: 2),
+            scanWarnings: [],
+            aggregateStats: store.aggregateStats,
+            isComplete: true
+        ))
+
+        model.exportCurrentScan()
+        try await waitForAsyncCondition("first export panel") {
+            await firstPanel.isWaiting
+        }
+        model.cleanup()
+        model.exportCurrentScan()
+        try await waitForAsyncCondition("second export panel") {
+            await secondPanel.isWaiting
+        }
+
+        await firstPanel.resume(returning: staleURL)
+        try await Task.sleep(for: .milliseconds(20))
+        XCTAssertTrue(model.isExportPanelPresented)
+
+        model.cleanup()
+        await secondPanel.resume(returning: currentURL)
+        try await Task.sleep(for: .milliseconds(20))
+
+        XCTAssertFalse(model.isExportPanelPresented)
+        let exportRequests = await archiveService.exportRequestsSnapshot()
+        XCTAssertTrue(exportRequests.isEmpty)
+    }
+
+    @MainActor
     func testExportFailureUsesExportSpecificAlertTitle() async throws {
         let archiveURL = URL(filePath: "/tmp/export.invalid", directoryHint: .isDirectory)
         var actions = AppSystemActions.inert

--- a/RadixCoreTests/AppModelDependencyTests.swift
+++ b/RadixCoreTests/AppModelDependencyTests.swift
@@ -2529,6 +2529,63 @@ final class AppModelDependencyTests: XCTestCase {
     }
 
     @MainActor
+    func testSupersededComparisonPanelCannotApplyLateSelection() async throws {
+        let oldURL = URL(filePath: "/tmp/superseded.radixscan", directoryHint: .isDirectory)
+        let newURL = URL(filePath: "/tmp/current.radixscan", directoryHint: .isDirectory)
+        let oldSnapshot = makeComparisonSnapshot(
+            rootPath: "/comparison-root",
+            fileSize: 10,
+            startedAt: Date(timeIntervalSince1970: 10),
+            finishedAt: Date(timeIntervalSince1970: 20),
+            sourceURL: oldURL
+        )
+        let newSnapshot = makeComparisonSnapshot(
+            rootPath: "/comparison-root",
+            fileSize: 20,
+            startedAt: Date(timeIntervalSince1970: 30),
+            finishedAt: Date(timeIntervalSince1970: 40),
+            sourceURL: newURL
+        )
+        let archiveService = SpyScanArchiveService(previewResultsByURL: [
+            oldURL: try makeArchivePreview(archiveURL: oldURL, snapshot: oldSnapshot),
+            newURL: try makeArchivePreview(archiveURL: newURL, snapshot: newSnapshot),
+        ])
+        let firstPanel = AsyncValueProbe<URL?>()
+        let secondPanel = AsyncValueProbe<URL?>()
+        var panelRequestCount = 0
+        var actions = AppSystemActions.inert
+        actions.presentComparisonSnapshotPanel = {
+            panelRequestCount += 1
+            return await (panelRequestCount == 1 ? firstPanel : secondPanel).wait()
+        }
+        let model = AppModel(dependencies: makeDependencies(
+            systemActions: actions,
+            scanArchiveService: archiveService
+        ))
+
+        model.compareScanSnapshots()
+        model.chooseComparisonSnapshot(for: .before)
+        try await waitForAsyncCondition("first comparison panel") {
+            await firstPanel.isWaiting
+        }
+        model.chooseComparisonSnapshot(for: .before)
+        try await waitForAsyncCondition("second comparison panel") {
+            await secondPanel.isWaiting
+        }
+
+        await secondPanel.resume(returning: newURL)
+        try await waitForAppModelCondition("current comparison selection") {
+            model.pendingComparisonSetup?.before?.displayName == newSnapshot.target.displayName
+        }
+        await firstPanel.resume(returning: oldURL)
+        try await Task.sleep(for: .milliseconds(20))
+
+        XCTAssertEqual(model.pendingComparisonSetup?.before?.displayName, newSnapshot.target.displayName)
+        let previewedURLs = await archiveService.previewedURLsSnapshot()
+        XCTAssertEqual(previewedURLs, [newURL])
+    }
+
+    @MainActor
     func testCompareCurrentScanWithSnapshotUsesCurrentScanAsAfter() async throws {
         let archiveURL = URL(filePath: "/tmp/current-compare.radixscan", directoryHint: .isDirectory)
         let archivedSnapshot = makeComparisonSnapshot(

--- a/RadixCoreTests/ScanArchiveServiceTests.swift
+++ b/RadixCoreTests/ScanArchiveServiceTests.swift
@@ -199,29 +199,40 @@ final class ScanArchiveServiceTests: XCTestCase {
 
     func testPreviewAndImportRejectNegativeStats() async throws {
         let service = ScanArchiveService()
-        let archiveURL = try makeTemporaryArchiveURL()
-        _ = try await service.export(
-            snapshot: makeArchiveSnapshot(),
-            to: archiveURL,
-            options: ScanArchiveExportOptions()
-        )
-        let statsURL = archiveURL.appending(path: "stats.json", directoryHint: .notDirectory)
-        try rewriteJSONObject(at: statsURL) { object in
-            object["totalAllocatedSize"] = -1
-        }
+        let fields = [
+            "totalAllocatedSize",
+            "totalLogicalSize",
+            "fileCount",
+            "directoryCount",
+            "accessibleItemCount",
+            "inaccessibleItemCount",
+        ]
 
-        do {
-            _ = try await service.previewSnapshot(from: archiveURL)
-            XCTFail("Preview should reject negative archive stats.")
-        } catch ScanArchiveError.stats(let detail) {
-            XCTAssertTrue(detail.contains("negative"))
-        }
+        for field in fields {
+            let archiveURL = try makeTemporaryArchiveURL()
+            _ = try await service.export(
+                snapshot: makeArchiveSnapshot(),
+                to: archiveURL,
+                options: ScanArchiveExportOptions()
+            )
+            let statsURL = archiveURL.appending(path: "stats.json", directoryHint: .notDirectory)
+            try rewriteJSONObject(at: statsURL) { object in
+                object[field] = -1
+            }
 
-        do {
-            _ = try await service.importSnapshot(from: archiveURL)
-            XCTFail("Import should reject negative archive stats.")
-        } catch ScanArchiveError.stats(let detail) {
-            XCTAssertTrue(detail.contains("negative"))
+            do {
+                _ = try await service.previewSnapshot(from: archiveURL)
+                XCTFail("Preview should reject negative \(field).")
+            } catch ScanArchiveError.stats(let detail) {
+                XCTAssertTrue(detail.contains("negative"), "Unexpected detail for \(field): \(detail)")
+            }
+
+            do {
+                _ = try await service.importSnapshot(from: archiveURL)
+                XCTFail("Import should reject negative \(field).")
+            } catch ScanArchiveError.stats(let detail) {
+                XCTAssertTrue(detail.contains("negative"), "Unexpected detail for \(field): \(detail)")
+            }
         }
     }
 

--- a/RadixCoreTests/ScanArchiveServiceTests.swift
+++ b/RadixCoreTests/ScanArchiveServiceTests.swift
@@ -197,6 +197,57 @@ final class ScanArchiveServiceTests: XCTestCase {
         XCTAssertEqual(preview.scanOptions, snapshot.scanOptions)
     }
 
+    func testPreviewAndImportRejectNegativeStats() async throws {
+        let service = ScanArchiveService()
+        let archiveURL = try makeTemporaryArchiveURL()
+        _ = try await service.export(
+            snapshot: makeArchiveSnapshot(),
+            to: archiveURL,
+            options: ScanArchiveExportOptions()
+        )
+        let statsURL = archiveURL.appending(path: "stats.json", directoryHint: .notDirectory)
+        try rewriteJSONObject(at: statsURL) { object in
+            object["totalAllocatedSize"] = -1
+        }
+
+        do {
+            _ = try await service.previewSnapshot(from: archiveURL)
+            XCTFail("Preview should reject negative archive stats.")
+        } catch ScanArchiveError.stats(let detail) {
+            XCTAssertTrue(detail.contains("negative"))
+        }
+
+        do {
+            _ = try await service.importSnapshot(from: archiveURL)
+            XCTFail("Import should reject negative archive stats.")
+        } catch ScanArchiveError.stats(let detail) {
+            XCTAssertTrue(detail.contains("negative"))
+        }
+    }
+
+    func testImportHandlesUntrustedHugeManifestNodeCountWithoutPreallocatingIt() async throws {
+        let service = ScanArchiveService()
+        let archiveURL = try makeTemporaryArchiveURL()
+        _ = try await service.export(
+            snapshot: makeArchiveSnapshot(),
+            to: archiveURL,
+            options: ScanArchiveExportOptions()
+        )
+        let manifestURL = archiveURL.appending(path: "manifest.json", directoryHint: .notDirectory)
+        try rewriteJSONObject(at: manifestURL) { object in
+            var snapshot = object["snapshot"] as? [String: Any] ?? [:]
+            snapshot["nodeCount"] = Int.max
+            object["snapshot"] = snapshot
+        }
+
+        do {
+            _ = try await service.importSnapshot(from: archiveURL)
+            XCTFail("Import should reject a manifest node count that does not match its payload.")
+        } catch ScanArchiveError.nodes(let detail) {
+            XCTAssertTrue(detail.contains("manifest expected"))
+        }
+    }
+
     func testExportWritesOrdinalTopology() async throws {
         let service = ScanArchiveService()
         let snapshot = makeArchiveSnapshot()

--- a/RadixCoreTests/ScanComparisonBrowserModelTests.swift
+++ b/RadixCoreTests/ScanComparisonBrowserModelTests.swift
@@ -84,6 +84,43 @@ final class ScanComparisonBrowserModelTests: XCTestCase {
         XCTAssertFalse(model.isRefreshing)
     }
 
+    func testCancelledRefreshCanRestartSameRequest() async throws {
+        let gate = ComparisonProcessorGate()
+        let model = ScanComparisonBrowserModel(
+            searchDebounceNanoseconds: 0,
+            processor: { input in
+                await gate.process(input)
+            }
+        )
+        let rows = [makeRow("first.txt")]
+        let comparisonID = UUID()
+        let query = query("first")
+
+        model.refresh(
+            comparisonID: comparisonID,
+            rows: rows,
+            changeTree: .empty,
+            query: query,
+            changeKinds: allKinds
+        )
+        try await waitUntil { await gate.requestCount == 1 }
+        model.cancel()
+
+        model.refresh(
+            comparisonID: comparisonID,
+            rows: rows,
+            changeTree: .empty,
+            query: query,
+            changeKinds: allKinds
+        )
+        try await waitUntil { await gate.requestCount == 2 }
+        await gate.resumeRequest(at: 1)
+        try await waitUntil { model.displayedRows.map(\.name) == ["first.txt"] }
+        await gate.resumeRequest(at: 0)
+
+        XCTAssertFalse(model.isRefreshing)
+    }
+
     func testDefaultProcessorFiltersRowsAndBuildsProjection() async throws {
         let model = ScanComparisonBrowserModel(searchDebounceNanoseconds: 0)
         let rows = [makeRow("first.txt"), makeRow("second.txt")]

--- a/RadixCoreTests/ScanComparisonServiceTests.swift
+++ b/RadixCoreTests/ScanComparisonServiceTests.swift
@@ -956,6 +956,65 @@ final class ScanComparisonServiceTests: XCTestCase {
         XCTAssertEqual(projection.representedImpact, Int64.max)
     }
 
+    func testTopLevelChangesClampLargeReclamationUnderOnePath() async throws {
+        let first = makeTestFileNode(id: "/scan/folder/first.bin", name: "first.bin", size: .max)
+        let second = makeTestFileNode(id: "/scan/folder/second.bin", name: "second.bin", size: .max)
+        let beforeFolder = FileNodeRecord(
+            id: "/scan/folder",
+            url: URL(filePath: "/scan/folder", directoryHint: .isDirectory),
+            name: "folder",
+            isDirectory: true,
+            isSymbolicLink: false,
+            allocatedSize: .max,
+            logicalSize: .max,
+            descendantFileCount: 2,
+            lastModified: nil,
+            isPackage: false,
+            isAccessible: true,
+            isSelfAccessible: true,
+            isSynthetic: false,
+            isAutoSummarized: false
+        )
+        let beforeRoot = FileNodeRecord(
+            id: "/scan",
+            url: URL(filePath: "/scan", directoryHint: .isDirectory),
+            name: "scan",
+            isDirectory: true,
+            isSymbolicLink: false,
+            allocatedSize: .max,
+            logicalSize: .max,
+            descendantFileCount: 2,
+            lastModified: nil,
+            isPackage: false,
+            isAccessible: true,
+            isSelfAccessible: true,
+            isSynthetic: false,
+            isAutoSummarized: false
+        )
+        let beforeStore = FileTreeStore(root: beforeRoot, childrenByID: [
+            beforeRoot.id: [beforeFolder],
+            beforeFolder.id: [first, second],
+        ])
+        let afterFolder = makeTestDirectoryNode(id: "/scan/folder", name: "folder", children: [])
+        let afterRoot = makeTestDirectoryNode(id: "/scan", name: "scan", children: [afterFolder])
+        let afterStore = FileTreeStore(
+            root: afterRoot,
+            childrenByID: [afterRoot.id: [afterFolder]]
+        )
+
+        let comparison = try await ScanComparisonService().compare(
+            before: makeTestSnapshot(root: beforeRoot, store: beforeStore),
+            after: makeTestSnapshot(root: afterRoot, store: afterStore)
+        )
+        let location = try XCTUnwrap(comparison.topLevelChanges.first)
+
+        XCTAssertEqual(comparison.rows.count, 2)
+        XCTAssertEqual(location.relativePath, "folder")
+        XCTAssertEqual(location.allocatedDelta, -Int64.max)
+        XCTAssertEqual(location.absoluteAllocatedDelta, Int64.max)
+        XCTAssertEqual(location.reclaimedAllocatedSize, Int64.max)
+    }
+
     func testRowQueryCombinesSelectedChangeKinds() {
         let movedBefore = makeTestFileNode(id: "/before/old.bin", name: "old.bin", size: 100)
         let movedAfter = makeTestFileNode(id: "/after/new.bin", name: "new.bin", size: 150)

--- a/RadixCoreTests/ScanComparisonServiceTests.swift
+++ b/RadixCoreTests/ScanComparisonServiceTests.swift
@@ -910,6 +910,52 @@ final class ScanComparisonServiceTests: XCTestCase {
         XCTAssertEqual(Set(combinedProjection.roots.map(\.relativePath)), ["added.bin", "grew.bin"])
     }
 
+    func testComparisonClampsAggregateStorageOverflow() async throws {
+        let beforeRoot = makeTestDirectoryNode(id: "/scan", name: "scan", children: [])
+        let beforeStore = FileTreeStore(root: beforeRoot)
+        let first = makeTestFileNode(
+            id: "/scan/first.bin",
+            name: "first.bin",
+            size: .max
+        )
+        let second = makeTestFileNode(
+            id: "/scan/second.bin",
+            name: "second.bin",
+            size: .max
+        )
+        let afterRoot = FileNodeRecord(
+            id: "/scan",
+            url: URL(filePath: "/scan", directoryHint: .isDirectory),
+            name: "scan",
+            isDirectory: true,
+            isSymbolicLink: false,
+            allocatedSize: .max,
+            logicalSize: .max,
+            descendantFileCount: 2,
+            lastModified: nil,
+            isPackage: false,
+            isAccessible: true,
+            isSelfAccessible: true,
+            isSynthetic: false,
+            isAutoSummarized: false
+        )
+        let afterStore = FileTreeStore(
+            root: afterRoot,
+            childrenByID: [afterRoot.id: [first, second]]
+        )
+
+        let comparison = try await ScanComparisonService().compare(
+            before: makeTestSnapshot(root: beforeRoot, store: beforeStore),
+            after: makeTestSnapshot(root: afterRoot, store: afterStore)
+        )
+        let projection = comparison.changeTree.significantProjection(changeKinds: [.added])
+
+        XCTAssertEqual(comparison.rows.count, 2)
+        XCTAssertEqual(comparison.summary.grossIncreasedAllocatedSize, Int64.max)
+        XCTAssertEqual(projection.totalImpact, Int64.max)
+        XCTAssertEqual(projection.representedImpact, Int64.max)
+    }
+
     func testRowQueryCombinesSelectedChangeKinds() {
         let movedBefore = makeTestFileNode(id: "/before/old.bin", name: "old.bin", size: 100)
         let movedAfter = makeTestFileNode(id: "/after/new.bin", name: "new.bin", size: 150)

--- a/RadixCoreTests/ScanCoordinatorTests.swift
+++ b/RadixCoreTests/ScanCoordinatorTests.swift
@@ -287,7 +287,7 @@ final class ScanCoordinatorTests: XCTestCase {
         XCTAssertEqual(replacementRootID, summarizedNode.id)
         XCTAssertFalse(updatedNode.isAutoSummarized)
         XCTAssertEqual(updatedSnapshot.treeStore.children(of: summarizedNode.id).map(\.id), [expandedFile.id])
-        XCTAssertEqual(updatedSnapshot.scanWarnings.map(\.path), [existingWarning.path, expansionWarning.path])
+        XCTAssertEqual(updatedSnapshot.scanWarnings.map(\.path), [expansionWarning.path])
         XCTAssertEqual(coordinator.fileTreeStore?.root.id, root.id)
         XCTAssertNil(coordinator.expandingNodeID)
     }

--- a/RadixCoreTests/ScanModelTests.swift
+++ b/RadixCoreTests/ScanModelTests.swift
@@ -550,10 +550,11 @@ final class ScanModelTests: XCTestCase {
             snapshot.replacingNode(
                 id: child.id,
                 with: FileTreeStore(root: replacement),
-                additionalWarnings: [duplicateWarning, distinctWarning]
+                additionalWarnings: [duplicateWarning, duplicateWarning, distinctWarning]
             )
         )
 
+        XCTAssertEqual(updatedSnapshot.id, snapshot.id)
         XCTAssertEqual(updatedSnapshot.scanWarnings.count, 2)
         XCTAssertEqual(updatedSnapshot.scanWarnings.map(\.path), [
             duplicateWarning.path,

--- a/RadixCoreTests/ScanModelTests.swift
+++ b/RadixCoreTests/ScanModelTests.swift
@@ -381,8 +381,13 @@ final class ScanModelTests: XCTestCase {
             root.id: [folder, sibling],
             folder.id: [removedLeaf, keptLeaf],
         ])
-        let warning = ScanWarning(path: removedLeaf.id, message: "kept", category: .fileSystem)
-        let snapshot = makeSnapshot(root: root, treeStore: treeStore, warnings: [warning])
+        let removedWarning = ScanWarning(path: removedLeaf.id, message: "removed", category: .fileSystem)
+        let retainedWarning = ScanWarning(path: keptLeaf.id, message: "kept", category: .fileSystem)
+        let snapshot = makeSnapshot(
+            root: root,
+            treeStore: treeStore,
+            warnings: [removedWarning, retainedWarning]
+        )
 
         let updatedSnapshot = try XCTUnwrap(snapshot.removingNode(id: removedLeaf.id))
 
@@ -399,7 +404,7 @@ final class ScanModelTests: XCTestCase {
         XCTAssertEqual(updatedSnapshot.aggregateStats.totalAllocatedSize, 25)
         XCTAssertEqual(updatedSnapshot.aggregateStats.fileCount, 2)
         XCTAssertEqual(updatedSnapshot.aggregateStats.directoryCount, 2)
-        XCTAssertEqual(updatedSnapshot.scanWarnings.map(\.path), [warning.path])
+        XCTAssertEqual(updatedSnapshot.scanWarnings.map(\.path), [retainedWarning.path])
     }
 
     func testSnapshotRemovingMissingOrRootNodeReturnsNil() {

--- a/RadixCoreTests/ScanModelTests.swift
+++ b/RadixCoreTests/ScanModelTests.swift
@@ -247,7 +247,7 @@ final class ScanModelTests: XCTestCase {
         XCTAssertFalse(directory.isAutoSummarized)
     }
 
-    func testSnapshotReplacingNodeRebuildsAncestorsAndPreservesWarnings() throws {
+    func testSnapshotReplacingNodeRebuildsAncestorsAndReplacesStaleWarnings() throws {
         let staleLeaf = makeNode(id: "/root/folder/stale.txt", isDirectory: false, isSynthetic: false, isAccessible: true, allocatedSize: 5)
         let summarizedFolder = makeNode(
             id: "/root/folder",
@@ -317,8 +317,7 @@ final class ScanModelTests: XCTestCase {
         XCTAssertFalse(updatedFolder.isAccessible)
         XCTAssertEqual(updatedSnapshot.aggregateStats.fileCount, 3)
         XCTAssertFalse(updatedSnapshot.root.isAccessible)
-        XCTAssertEqual(updatedSnapshot.scanWarnings.count, 2)
-        XCTAssertEqual(updatedSnapshot.scanWarnings.map(\.path), [originalWarning.path, expansionWarning.path])
+        XCTAssertEqual(updatedSnapshot.scanWarnings.map(\.path), [expansionWarning.path])
         XCTAssertNotEqual(staleLeaf.id, updatedChildren.first?.id)
     }
 
@@ -552,11 +551,11 @@ final class ScanModelTests: XCTestCase {
 
         XCTAssertEqual(updatedSnapshot.scanWarnings.count, 2)
         XCTAssertEqual(updatedSnapshot.scanWarnings.map(\.path), [
-            existingWarning.path,
+            duplicateWarning.path,
             distinctWarning.path
         ])
         XCTAssertEqual(updatedSnapshot.scanWarnings.map(\.message), [
-            existingWarning.message,
+            duplicateWarning.message,
             distinctWarning.message
         ])
     }

--- a/RadixCoreTests/SunburstGeometryTests.swift
+++ b/RadixCoreTests/SunburstGeometryTests.swift
@@ -45,6 +45,43 @@ final class SunburstGeometryTests: XCTestCase {
         XCTAssertLessThanOrEqual(lastSegment.endAngle.radians, .pi * 2 + 0.0001)
     }
 
+    func testSaturatedChildrenStayWithinParentArc() throws {
+        let children = [
+            makeFileNode(id: "/root/a", name: "a", size: .max),
+            makeFileNode(id: "/root/b", name: "b", size: .max),
+        ]
+        let root = FileNodeRecord(
+            id: "/root",
+            url: URL(filePath: "/root", directoryHint: .isDirectory),
+            name: "root",
+            isDirectory: true,
+            isSymbolicLink: false,
+            allocatedSize: .max,
+            logicalSize: .max,
+            descendantFileCount: children.count,
+            lastModified: nil,
+            isPackage: false,
+            isAccessible: true,
+            isSelfAccessible: true,
+            isSynthetic: false,
+            isAutoSummarized: false
+        )
+        let store = makeStore(root: root, children: children)
+
+        let segments = SunburstLayout.segments(in: store, rootID: root.id, depthLimit: 1)
+        let totalRadians = segments.reduce(0.0) {
+            $0 + ($1.endAngle.radians - $1.startAngle.radians)
+        }
+        let lastSegment = try XCTUnwrap(segments.last)
+
+        XCTAssertEqual(segments.count, 2)
+        XCTAssertEqual(totalRadians, .pi * 2, accuracy: 0.0001)
+        XCTAssertLessThanOrEqual(lastSegment.endAngle.radians, .pi * 2 + 0.0001)
+        XCTAssertTrue(segments.allSatisfy {
+            $0.startAngle.radians.isFinite && $0.endAngle.radians.isFinite
+        })
+    }
+
     func testSmallItemsCollapseIntoAggregateSegment() throws {
         let children = [
             makeFileNode(id: "/root/large", name: "large", size: 100),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed obsolete scan warnings when nodes or subtrees are removed or replaced, including during snapshot transformations.
  * Prevented stale export and comparison panel tasks from updating UI after newer requests.
  * Ensured cancelled comparison refreshes can restart the same request.
  * Improved overflow resilience in comparison totals and sunburst segment sizing (with clamped math and safer denominators).
* **Reliability**
  * Added validation for archive statistics and stricter handling of malformed archive metadata.
  * Reduced upfront decoding allocations for large manifests.
* **Tests**
  * Added new concurrency and overflow robustness test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->