### PR TITLE
fix: harden reliability audit edge cases

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -79,6 +79,7 @@ let package = Package(
                 "Services/ScanEngine.swift",
                 "Services/ScanExclusionMatcher.swift",
                 "Services/ScanIncrementalModels.swift",
+                "Services/ScanIntegerMath.swift",
                 "Services/ScanMetadataLoader.swift",
                 "Services/ScanSnapshotTransformService.swift",
                 "Services/ScanWarningFactory.swift",

--- a/Radix/Services/AtomicDirectoryParallelSummary.swift
+++ b/Radix/Services/AtomicDirectoryParallelSummary.swift
@@ -124,9 +124,12 @@ nonisolated final class AtomicSummaryAccumulator: @unchecked Sendable {
 
     func merge(_ partial: AtomicDirectorySummaryPartial) {
         lock.lock()
-        allocatedSize += partial.allocatedSize
-        logicalSize += partial.logicalSize
-        descendantFileCount += partial.descendantFileCount
+        allocatedSize = ScanIntegerMath.addingClamped(allocatedSize, partial.allocatedSize)
+        logicalSize = ScanIntegerMath.addingClamped(logicalSize, partial.logicalSize)
+        descendantFileCount = ScanIntegerMath.addingClamped(
+            descendantFileCount,
+            partial.descendantFileCount
+        )
         isAccessible = isAccessible && partial.isAccessible
         warnings.append(contentsOf: partial.warnings)
         hardLinkAccumulator.merge(partial.hardLinkAccumulator)

--- a/Radix/Services/AtomicDirectorySummaryModels.swift
+++ b/Radix/Services/AtomicDirectorySummaryModels.swift
@@ -63,10 +63,10 @@ nonisolated struct AtomicDirectorySummaryPartial: Sendable {
     }
 
     mutating func accumulateFile(_ metadata: NodeMetadata, url: URL, ownerNodeID: String) {
-        allocatedSize += metadata.allocatedSize
-        logicalSize += metadata.logicalSize
+        allocatedSize = ScanIntegerMath.addingClamped(allocatedSize, metadata.allocatedSize)
+        logicalSize = ScanIntegerMath.addingClamped(logicalSize, metadata.logicalSize)
         if !metadata.isSymbolicLink {
-            descendantFileCount += 1
+            descendantFileCount = ScanIntegerMath.addingClamped(descendantFileCount, 1)
         }
         if metadata.linkCount > 1,
            let claim = HardLinkDeduplicator.claim(for: metadata, ownerNodeID: ownerNodeID, path: url.path) {

--- a/Radix/Services/AtomicDirectorySummaryProbe.swift
+++ b/Radix/Services/AtomicDirectorySummaryProbe.swift
@@ -209,7 +209,10 @@ extension AtomicDirectorySummarizer {
                 }
                 guard !isSymbolicLink else { continue }
 
-                profile.totalSampledLogicalSize += Int64(values.totalFileSize ?? values.fileSize ?? 0)
+                profile.totalSampledLogicalSize = ScanIntegerMath.addingClamped(
+                    profile.totalSampledLogicalSize,
+                    Int64(values.totalFileSize ?? values.fileSize ?? 0)
+                )
                 profile.observedFileCount += 1
 
                 if profile.suggestsAtomicDirectory(
@@ -405,7 +408,10 @@ extension AtomicDirectorySummarizer {
             partial.accumulateFile(metadata, url: entry.url, ownerNodeID: frames[frameIndex].ownerNodeID)
             guard !metadata.isSymbolicLink else { continue }
 
-            profile.totalSampledLogicalSize += metadata.logicalSize
+            profile.totalSampledLogicalSize = ScanIntegerMath.addingClamped(
+                profile.totalSampledLogicalSize,
+                metadata.logicalSize
+            )
             profile.observedFileCount += 1
             if profile.suggestsAtomicDirectory(
                 minFileCount: minFileCount,

--- a/Radix/Services/AtomicDirectorySummaryWalker.swift
+++ b/Radix/Services/AtomicDirectorySummaryWalker.swift
@@ -191,9 +191,12 @@ extension AtomicDirectorySummarizer {
     }
 
     nonisolated private func merge(_ summary: AtomicDirectorySummary, into state: AtomicDirectorySummaryState) {
-        state.allocatedSize += summary.allocatedSize
-        state.logicalSize += summary.logicalSize
-        state.descendantFileCount += summary.descendantFileCount
+        state.allocatedSize = ScanIntegerMath.addingClamped(state.allocatedSize, summary.allocatedSize)
+        state.logicalSize = ScanIntegerMath.addingClamped(state.logicalSize, summary.logicalSize)
+        state.descendantFileCount = ScanIntegerMath.addingClamped(
+            state.descendantFileCount,
+            summary.descendantFileCount
+        )
         state.isAccessible = state.isAccessible && summary.isAccessible
         state.warnings.append(contentsOf: summary.warnings)
         state.hardLinkAccumulator.merge(summary.hardLinkAccumulator)
@@ -213,11 +216,11 @@ extension AtomicDirectorySummarizer {
     }
 
     nonisolated private func accumulateAtomicFile(_ metadata: NodeMetadata, url: URL, into state: AtomicDirectorySummaryState) {
-        state.allocatedSize += metadata.allocatedSize
-        state.logicalSize += metadata.logicalSize
+        state.allocatedSize = ScanIntegerMath.addingClamped(state.allocatedSize, metadata.allocatedSize)
+        state.logicalSize = ScanIntegerMath.addingClamped(state.logicalSize, metadata.logicalSize)
 
         if !metadata.isSymbolicLink {
-            state.descendantFileCount += 1
+            state.descendantFileCount = ScanIntegerMath.addingClamped(state.descendantFileCount, 1)
         }
 
         if metadata.linkCount > 1,

--- a/Radix/Services/FileBrowserSearch.swift
+++ b/Radix/Services/FileBrowserSearch.swift
@@ -63,7 +63,7 @@ actor FileSearchService: FileSearching {
             index = cachedIndex
         } else {
             index = try await makeIndex(treeStore: treeStore)
-            indexes = [indexKey: index]
+            indexes[indexKey] = index
         }
 
         var matchedNodes: [FileNodeRecord] = []

--- a/Radix/Services/FileBrowserSearch.swift
+++ b/Radix/Services/FileBrowserSearch.swift
@@ -43,7 +43,7 @@ actor CurrentContentsSearchService {
 }
 
 actor FileSearchService: FileSearching {
-    private var indexes: [UUID: FileSearchIndex] = [:]
+    private var indexes: [FileSearchIndexKey: FileSearchIndex] = [:]
 
     func search(
         snapshotID: UUID,
@@ -54,12 +54,16 @@ actor FileSearchService: FileSearching {
     ) async throws -> [FileNodeRecord] {
         guard !normalizedQuery.isEmpty else { return [] }
 
+        let indexKey = FileSearchIndexKey(
+            snapshotID: snapshotID,
+            treeContentID: treeStore.contentID
+        )
         var index: FileSearchIndex
-        if let cachedIndex = indexes[snapshotID] {
+        if let cachedIndex = indexes[indexKey] {
             index = cachedIndex
         } else {
             index = try await makeIndex(treeStore: treeStore)
-            indexes = [snapshotID: index]
+            indexes = [indexKey: index]
         }
 
         var matchedNodes: [FileNodeRecord] = []
@@ -95,7 +99,7 @@ actor FileSearchService: FileSearching {
         }
 
         if includesPath {
-            indexes[snapshotID] = index
+            indexes[indexKey] = index
         }
 
         try Task.checkCancellation()
@@ -117,7 +121,7 @@ actor FileSearchService: FileSearching {
             return
         }
 
-        indexes = indexes.filter { $0.key == snapshotID }
+        indexes = indexes.filter { $0.key.snapshotID == snapshotID }
     }
 
     private func makeIndex(treeStore: FileTreeStore) async throws -> FileSearchIndex {
@@ -177,6 +181,11 @@ enum SearchNormalizer {
 private struct FileSearchIndex {
     let entries: [FileSearchEntry]
     var normalizedPathsByID: [FileNodeRecord.ID: String]
+}
+
+private nonisolated struct FileSearchIndexKey: Hashable, Sendable {
+    let snapshotID: UUID
+    let treeContentID: UUID
 }
 
 private struct FileSearchEntry {

--- a/Radix/Services/IncrementalScanService.swift
+++ b/Radix/Services/IncrementalScanService.swift
@@ -145,29 +145,50 @@ nonisolated final class IncrementalScanService: ScanEventStreaming, @unchecked S
         for (index, nodeID) in nodeIDs.enumerated() {
             try Task.checkCancellation()
             guard let node = baseline.treeStore.node(id: nodeID) else {
-                throw FileSystemEventHistoryError.targetUnavailable(nodeID)
+                try await forwardFullScan(
+                    target: target,
+                    options: options,
+                    continuation: continuation
+                )
+                return
             }
             var replacementSnapshot: ScanSnapshot?
-            for try await event in engine.scan(
-                target: ScanTarget(url: node.url),
-                options: subtreeOptions
-            ) {
-                switch event {
-                case .progress(var metrics):
-                    let localFraction = min(max(metrics.progressFraction, 0), 1)
-                    metrics.progressFraction = min(
-                        (Double(index) + localFraction) / Double(max(nodeIDs.count, 1)) * 0.95,
-                        0.95
-                    )
-                    continuation.yield(.progress(metrics))
-                case .warning(let warning):
-                    continuation.yield(.warning(warning))
-                case .finished(let snapshot):
-                    replacementSnapshot = snapshot
+            do {
+                for try await event in engine.scan(
+                    target: ScanTarget(url: node.url),
+                    options: subtreeOptions
+                ) {
+                    switch event {
+                    case .progress(var metrics):
+                        let localFraction = min(max(metrics.progressFraction, 0), 1)
+                        metrics.progressFraction = min(
+                            (Double(index) + localFraction) / Double(max(nodeIDs.count, 1)) * 0.95,
+                            0.95
+                        )
+                        continuation.yield(.progress(metrics))
+                    case .warning(let warning):
+                        continuation.yield(.warning(warning))
+                    case .finished(let snapshot):
+                        replacementSnapshot = snapshot
+                    }
                 }
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                try await forwardFullScan(
+                    target: target,
+                    options: options,
+                    continuation: continuation
+                )
+                return
             }
             guard let replacement = replacementSnapshot else {
-                throw FileSystemEventHistoryError.targetUnavailable(nodeID)
+                try await forwardFullScan(
+                    target: target,
+                    options: options,
+                    continuation: continuation
+                )
+                return
             }
             replacements[nodeID] = replacement.treeStore
             replacementWarnings.append(contentsOf: replacement.scanWarnings)

--- a/Radix/Services/ScanArchiveService.swift
+++ b/Radix/Services/ScanArchiveService.swift
@@ -236,6 +236,12 @@ nonisolated struct ScanArchiveService: ScanArchiveServicing {
     private nonisolated static let warningsFileName = "warnings.json"
     private nonisolated static let statsFileName = "stats.json"
 
+    private nonisolated static let maximumManifestByteCount = 1 * 1_024 * 1_024
+    private nonisolated static let maximumStatsByteCount = 256 * 1_024
+    private nonisolated static let maximumTopologyByteCount = 512 * 1_024 * 1_024
+    private nonisolated static let maximumWarningsByteCount = 64 * 1_024 * 1_024
+    private nonisolated static let sectionReadChunkByteCount = 64 * 1_024
+
     init(fileManager: FileManager = .default) {
         _ = fileManager
     }
@@ -324,7 +330,11 @@ nonisolated struct ScanArchiveService: ScanArchiveServicing {
             in: sourceURL,
             sectionDescription: "stats"
         )
-        let stats: ScanArchiveStatsV1 = try readJSON(ScanArchiveStatsV1.self, from: statsURL) { detail in
+        let stats: ScanArchiveStatsV1 = try readJSON(
+            ScanArchiveStatsV1.self,
+            from: statsURL,
+            maximumByteCount: Self.maximumStatsByteCount
+        ) { detail in
             ScanArchiveError.stats(detail)
         }
         try stats.validate()
@@ -370,7 +380,8 @@ nonisolated struct ScanArchiveService: ScanArchiveServicing {
         )
         let archivedStats: ScanArchiveStatsV1 = try readJSON(
             ScanArchiveStatsV1.self,
-            from: statsURL
+            from: statsURL,
+            maximumByteCount: Self.maximumStatsByteCount
         ) { detail in
             ScanArchiveError.stats(detail)
         }
@@ -388,7 +399,11 @@ nonisolated struct ScanArchiveService: ScanArchiveServicing {
             phase: .readingTopology,
             message: String(localized: "Reading topology", comment: "Progress message while reading scan tree topology.")
         ))
-        let archivedTopology: ScanArchiveTopology = try readJSON(ScanArchiveTopology.self, from: topologyURL) { detail in
+        let archivedTopology: ScanArchiveTopology = try readJSON(
+            ScanArchiveTopology.self,
+            from: topologyURL,
+            maximumByteCount: Self.maximumTopologySize(for: manifest.snapshot.nodeCount)
+        ) { detail in
             ScanArchiveError.topology(detail)
         }
         let nodePayload: ScanArchiveNodePayload
@@ -408,7 +423,11 @@ nonisolated struct ScanArchiveService: ScanArchiveServicing {
             phase: .readingMetadata,
             message: String(localized: "Reading metadata", comment: "Progress message while reading scan metadata.")
         ))
-        let warnings: [ScanArchiveWarningV1] = try readJSON([ScanArchiveWarningV1].self, from: warningsURL) { detail in
+        let warnings: [ScanArchiveWarningV1] = try readJSON(
+            [ScanArchiveWarningV1].self,
+            from: warningsURL,
+            maximumByteCount: Self.maximumWarningsSize(for: manifest.snapshot.warningCount)
+        ) { detail in
             ScanArchiveError.manifest(localized: "warnings section failed: \(detail)")
         }
         try Task.checkCancellation()
@@ -461,7 +480,10 @@ nonisolated struct ScanArchiveService: ScanArchiveServicing {
         try validatePackage(at: sourceURL)
 
         let manifestURL = sourceURL.appending(path: Self.manifestFileName, directoryHint: .notDirectory)
-        let manifestData = try readData(from: manifestURL) { detail in
+        let manifestData = try readData(
+            from: manifestURL,
+            maximumByteCount: Self.maximumManifestByteCount
+        ) { detail in
             ScanArchiveError.manifest(detail)
         }
         let header: ScanArchiveHeader = try decodeJSON(ScanArchiveHeader.self, from: manifestData) { detail in
@@ -611,23 +633,82 @@ nonisolated struct ScanArchiveService: ScanArchiveServicing {
     private func readJSON<T: Decodable>(
         _ type: T.Type,
         from url: URL,
+        maximumByteCount: Int,
         mapError: (String) -> ScanArchiveError
     ) throws -> T {
-        let data = try readData(from: url, mapError: mapError)
+        let data = try readData(
+            from: url,
+            maximumByteCount: maximumByteCount,
+            mapError: mapError
+        )
         return try decodeJSON(type, from: data, mapError: mapError)
     }
 
     private func readData(
         from url: URL,
+        maximumByteCount: Int,
         mapError: (String) -> ScanArchiveError
     ) throws -> Data {
         do {
-            return try Data(contentsOf: url)
+            let handle = try FileHandle(forReadingFrom: url)
+            defer { try? handle.close() }
+
+            var data = Data()
+            data.reserveCapacity(min(maximumByteCount, Self.sectionReadChunkByteCount))
+            while true {
+                let remainingByteCount = maximumByteCount - data.count
+                let nextReadByteCount = min(
+                    Self.sectionReadChunkByteCount,
+                    remainingByteCount + 1
+                )
+                guard let chunk = try handle.read(upToCount: nextReadByteCount),
+                      !chunk.isEmpty else {
+                    return data
+                }
+                data.append(chunk)
+                guard data.count <= maximumByteCount else {
+                    throw mapError("section exceeds supported size")
+                }
+            }
         } catch let error as ScanArchiveError {
             throw error
         } catch {
             throw mapError(error.localizedDescription)
         }
+    }
+
+    private nonisolated static func maximumTopologySize(for nodeCount: Int) -> Int {
+        boundedSectionSize(
+            itemCount: nodeCount,
+            baseByteCount: 64 * 1_024,
+            byteCountPerItem: 96,
+            absoluteMaximum: maximumTopologyByteCount
+        )
+    }
+
+    private nonisolated static func maximumWarningsSize(for warningCount: Int) -> Int {
+        boundedSectionSize(
+            itemCount: warningCount,
+            baseByteCount: 64 * 1_024,
+            byteCountPerItem: 64 * 1_024,
+            absoluteMaximum: maximumWarningsByteCount
+        )
+    }
+
+    private nonisolated static func boundedSectionSize(
+        itemCount: Int,
+        baseByteCount: Int,
+        byteCountPerItem: Int,
+        absoluteMaximum: Int
+    ) -> Int {
+        guard itemCount > 0 else { return min(baseByteCount, absoluteMaximum) }
+        let (itemBytes, multiplicationOverflow) = itemCount.multipliedReportingOverflow(
+            by: byteCountPerItem
+        )
+        guard !multiplicationOverflow else { return absoluteMaximum }
+        let (totalBytes, additionOverflow) = baseByteCount.addingReportingOverflow(itemBytes)
+        guard !additionOverflow else { return absoluteMaximum }
+        return min(totalBytes, absoluteMaximum)
     }
 
     private func decodeJSON<T: Decodable>(

--- a/Radix/Services/ScanEngine.swift
+++ b/Radix/Services/ScanEngine.swift
@@ -1430,13 +1430,16 @@ actor ScanEngine {
                         try Task.checkCancellation()
                     }
                     guard let child = resolvedNodeByKey[childKey] else { continue }
-                    allocatedSize += child.allocatedSize
-                    logicalSize += child.logicalSize
+                    allocatedSize = ScanIntegerMath.addingClamped(allocatedSize, child.allocatedSize)
+                    logicalSize = ScanIntegerMath.addingClamped(logicalSize, child.logicalSize)
                     childrenAreAccessible = childrenAreAccessible && child.isAccessible
                     if child.isDirectory {
-                        descendantFileCount += child.descendantFileCount
+                        descendantFileCount = ScanIntegerMath.addingClamped(
+                            descendantFileCount,
+                            child.descendantFileCount
+                        )
                     } else if !child.isSymbolicLink && !child.isSynthetic {
-                        descendantFileCount += 1
+                        descendantFileCount = ScanIntegerMath.addingClamped(descendantFileCount, 1)
                     }
                     let childIndex = FileTreeNodeIndex(rawValue: UInt32(childKey))
                     sortedChildIndices.append(childIndex)

--- a/Radix/Services/ScanIntegerMath.swift
+++ b/Radix/Services/ScanIntegerMath.swift
@@ -1,0 +1,14 @@
+//
+//  ScanIntegerMath.swift
+//  Radix
+//
+
+nonisolated enum ScanIntegerMath {
+    nonisolated static func addingClamped<Value: FixedWidthInteger>(
+        _ lhs: Value,
+        _ rhs: Value
+    ) -> Value {
+        let (sum, overflow) = lhs.addingReportingOverflow(rhs)
+        return overflow ? Value.max : sum
+    }
+}

--- a/RadixCoreTests/AppModelDependencyTests.swift
+++ b/RadixCoreTests/AppModelDependencyTests.swift
@@ -994,7 +994,7 @@ final class AppModelDependencyTests: XCTestCase {
     }
 
     @MainActor
-    func testConfirmPendingTrashBatchRevalidatesAndMovesEachItemInOrder() {
+    func testConfirmPendingTrashBatchReconcilesMovedPrefixAfterLaterFailure() async throws {
         let recorder = AppModelActionRecorder()
         let first = makeTestFileNode(
             id: "/selection/first.txt",
@@ -1019,6 +1019,7 @@ final class AppModelDependencyTests: XCTestCase {
         let store = FileTreeStore(root: root, childrenByID: [root.id: [first, second]])
         let snapshot = makeTestSnapshot(root: root, store: store)
         model.scanState.replaceCurrentSnapshot(snapshot)
+        model.scanState.selectedTarget = snapshot.target
         model.navigation.reconcileAfterSnapshotApplied(snapshot)
 
         model.pendingTrashSelection = AppModel.PendingTrashSelection(nodes: [first, second])
@@ -1031,6 +1032,11 @@ final class AppModelDependencyTests: XCTestCase {
             model.lastErrorMessage,
             "The item at \(second.url.path) changed since this scan. Rescan before moving it to Trash."
         )
+        try await waitUntil("partially successful trash batch reconciled", timeout: 2) {
+            model.scanState.snapshot?.treeStore.node(id: first.id) == nil
+        }
+        XCTAssertNotNil(model.scanState.snapshot?.treeStore.node(id: second.id))
+        XCTAssertFalse(model.discardPileHiddenNodeIDs.contains(second.id))
     }
 
     @MainActor

--- a/RadixCoreTests/FileBrowserModelTests.swift
+++ b/RadixCoreTests/FileBrowserModelTests.swift
@@ -600,6 +600,55 @@ final class FileBrowserModelTests: XCTestCase {
         XCTAssertEqual(pathMatches.map(\.id), [cache.id])
     }
 
+    func testSearchServiceDoesNotReuseIndexForDifferentTreeWithSameSnapshotID() async throws {
+        let snapshotID = UUID()
+        let originalFile = makeTestFileNode(
+            id: "/root/file.txt",
+            name: "alpha.txt"
+        )
+        let originalRoot = makeTestDirectoryNode(
+            id: "/root",
+            name: "root",
+            children: [originalFile]
+        )
+        let originalStore = FileTreeStore(
+            root: originalRoot,
+            childrenByID: [originalRoot.id: [originalFile]]
+        )
+        let replacementFile = makeTestFileNode(
+            id: originalFile.id,
+            name: "beta.txt"
+        )
+        let replacementRoot = makeTestDirectoryNode(
+            id: originalRoot.id,
+            name: originalRoot.name,
+            children: [replacementFile]
+        )
+        let replacementStore = FileTreeStore(
+            root: replacementRoot,
+            childrenByID: [replacementRoot.id: [replacementFile]]
+        )
+        let service = await FileSearchService()
+
+        let originalMatches = try await service.search(
+            snapshotID: snapshotID,
+            treeStore: originalStore,
+            normalizedQuery: "alpha",
+            includesPath: false,
+            sortOrder: []
+        )
+        let replacementMatches = try await service.search(
+            snapshotID: snapshotID,
+            treeStore: replacementStore,
+            normalizedQuery: "beta",
+            includesPath: false,
+            sortOrder: []
+        )
+
+        XCTAssertEqual(originalMatches.map(\.name), ["alpha.txt"])
+        XCTAssertEqual(replacementMatches.map(\.name), ["beta.txt"])
+    }
+
     @MainActor
     func testModelRunsEntireScanSearchThroughService() async throws {
         let smallTarget = makeTestFileNode(id: "/root/target-small.txt", name: "target-small.txt", size: 5)

--- a/RadixCoreTests/IncrementalScanServiceTests.swift
+++ b/RadixCoreTests/IncrementalScanServiceTests.swift
@@ -71,6 +71,42 @@ final class IncrementalScanServiceTests: XCTestCase {
         XCTAssertNotEqual(rescanned.id, baseline.id)
     }
 
+    func testSubtreeDisappearingAfterHistoryPlanningFallsBackToFullScan() async throws {
+        let rootURL = try makeIncrementalTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+        let changedURL = rootURL.appending(path: "Changed", directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: changedURL, withIntermediateDirectories: true)
+        try Data([0x1]).write(to: changedURL.appending(path: "payload.dat"))
+
+        let provider = IncrementalHistoryStub(
+            checkpoints: [checkpoint(10), checkpoint(20), checkpoint(30)],
+            events: [
+                FileSystemEventRecord(
+                    path: changedURL.path,
+                    eventID: 15,
+                    flags: [.itemModified, .itemIsDirectory]
+                )
+            ],
+            beforeReturningHistory: {
+                try FileManager.default.removeItem(at: changedURL)
+            }
+        )
+        let service = IncrementalScanService(eventHistoryProvider: provider)
+        let target = ScanTarget(url: rootURL)
+        let options = ScanOptions()
+        let baseline = try await finishedIncrementalSnapshot(
+            from: service.scan(target: target, options: options)
+        )
+
+        let rescanned = try await finishedIncrementalSnapshot(
+            from: service.rescan(target: target, options: options, from: baseline)
+        )
+
+        XCTAssertNil(rescanned.treeStore.node(id: changedURL.path))
+        XCTAssertEqual(rescanned.incrementalCheckpoint?.eventID, 30)
+        XCTAssertEqual(provider.historyRequestCount, 1)
+    }
+
     private func checkpoint(_ eventID: UInt64) -> ScanIncrementalCheckpoint {
         ScanIncrementalCheckpoint(volumeUUID: "test-volume", eventID: eventID)
     }
@@ -80,11 +116,17 @@ private final class IncrementalHistoryStub: FileSystemEventHistoryProviding, @un
     private let lock = NSLock()
     private var checkpoints: [ScanIncrementalCheckpoint]
     private let events: [FileSystemEventRecord]
+    private let beforeReturningHistory: @Sendable () throws -> Void
     private var historyRequests = 0
 
-    init(checkpoints: [ScanIncrementalCheckpoint], events: [FileSystemEventRecord]) {
+    init(
+        checkpoints: [ScanIncrementalCheckpoint],
+        events: [FileSystemEventRecord],
+        beforeReturningHistory: @escaping @Sendable () throws -> Void = {}
+    ) {
         self.checkpoints = checkpoints
         self.events = events
+        self.beforeReturningHistory = beforeReturningHistory
     }
 
     var historyRequestCount: Int {
@@ -112,6 +154,7 @@ private final class IncrementalHistoryStub: FileSystemEventHistoryProviding, @un
         lock.withLock {
             historyRequests += 1
         }
+        try beforeReturningHistory()
         return FileSystemEventHistory(since: since, through: through, events: events)
     }
 }

--- a/RadixCoreTests/ScanArchiveServiceTests.swift
+++ b/RadixCoreTests/ScanArchiveServiceTests.swift
@@ -236,6 +236,92 @@ final class ScanArchiveServiceTests: XCTestCase {
         }
     }
 
+    func testPreviewAndImportRejectOversizedStatsBeforeDecoding() async throws {
+        let service = ScanArchiveService()
+        let archiveURL = try makeTemporaryArchiveURL()
+        _ = try await service.export(
+            snapshot: makeArchiveSnapshot(),
+            to: archiveURL,
+            options: ScanArchiveExportOptions()
+        )
+        let statsURL = archiveURL.appending(path: "stats.json", directoryHint: .notDirectory)
+        try Data(repeating: 0x20, count: (256 * 1_024) + 1).write(to: statsURL, options: [.atomic])
+
+        do {
+            _ = try await service.previewSnapshot(from: archiveURL)
+            XCTFail("Preview should reject an oversized stats section.")
+        } catch ScanArchiveError.stats(let detail) {
+            XCTAssertTrue(detail.contains("supported size"))
+        }
+
+        do {
+            _ = try await service.importSnapshot(from: archiveURL)
+            XCTFail("Import should reject an oversized stats section.")
+        } catch ScanArchiveError.stats(let detail) {
+            XCTAssertTrue(detail.contains("supported size"))
+        }
+    }
+
+    func testImportRejectsOversizedTopologyBeforeDecoding() async throws {
+        let service = ScanArchiveService()
+        let archiveURL = try makeTemporaryArchiveURL()
+        _ = try await service.export(
+            snapshot: makeArchiveSnapshot(),
+            to: archiveURL,
+            options: ScanArchiveExportOptions()
+        )
+        let topologyURL = archiveURL.appending(path: "topology.json", directoryHint: .notDirectory)
+        try Data(repeating: 0x20, count: 128 * 1_024).write(to: topologyURL, options: [.atomic])
+
+        do {
+            _ = try await service.importSnapshot(from: archiveURL)
+            XCTFail("Import should reject an oversized topology section.")
+        } catch ScanArchiveError.topology(let detail) {
+            XCTAssertTrue(detail.contains("supported size"))
+        }
+    }
+
+    func testImportRejectsOversizedWarningsBeforeDecoding() async throws {
+        let service = ScanArchiveService()
+        let archiveURL = try makeTemporaryArchiveURL()
+        _ = try await service.export(
+            snapshot: makeArchiveSnapshot(),
+            to: archiveURL,
+            options: ScanArchiveExportOptions()
+        )
+        let warningsURL = archiveURL.appending(path: "warnings.json", directoryHint: .notDirectory)
+        try Data(repeating: 0x20, count: 192 * 1_024).write(to: warningsURL, options: [.atomic])
+
+        do {
+            _ = try await service.importSnapshot(from: archiveURL)
+            XCTFail("Import should reject an oversized warnings section.")
+        } catch ScanArchiveError.manifest(let detail) {
+            XCTAssertTrue(detail.contains("supported size"))
+        }
+    }
+
+    func testPreviewRejectsOversizedManifestBeforeDecoding() async throws {
+        let service = ScanArchiveService()
+        let archiveURL = try makeTemporaryArchiveURL()
+        _ = try await service.export(
+            snapshot: makeArchiveSnapshot(),
+            to: archiveURL,
+            options: ScanArchiveExportOptions()
+        )
+        let manifestURL = archiveURL.appending(path: "manifest.json", directoryHint: .notDirectory)
+        try Data(repeating: 0x20, count: (1 * 1_024 * 1_024) + 1).write(
+            to: manifestURL,
+            options: [.atomic]
+        )
+
+        do {
+            _ = try await service.previewSnapshot(from: archiveURL)
+            XCTFail("Preview should reject an oversized manifest.")
+        } catch ScanArchiveError.manifest(let detail) {
+            XCTAssertTrue(detail.contains("supported size"))
+        }
+    }
+
     func testImportHandlesUntrustedHugeManifestNodeCountWithoutPreallocatingIt() async throws {
         let service = ScanArchiveService()
         let archiveURL = try makeTemporaryArchiveURL()

--- a/RadixCoreTests/ScanEngineTests.swift
+++ b/RadixCoreTests/ScanEngineTests.swift
@@ -3,6 +3,47 @@ import XCTest
 @testable import RadixCore
 
 final class ScanEngineTests: XCTestCase {
+    func testAtomicSummarySizeAccumulationClampsInsteadOfOverflowing() {
+        var partial = AtomicDirectorySummaryPartial(
+            allocatedSize: Int64.max,
+            logicalSize: Int64.max,
+            descendantFileCount: Int.max
+        )
+        let metadata = NodeMetadata(
+            isDirectory: false,
+            isPackage: false,
+            isSymbolicLink: false,
+            logicalSize: 1,
+            allocatedSize: 1,
+            lastModified: nil,
+            isReadable: true,
+            volumeCapacity: nil,
+            fileIdentity: nil,
+            linkCount: 1
+        )
+
+        partial.accumulateFile(
+            metadata,
+            url: URL(filePath: "/overflow.bin"),
+            ownerNodeID: "/"
+        )
+
+        XCTAssertEqual(partial.allocatedSize, Int64.max)
+        XCTAssertEqual(partial.logicalSize, Int64.max)
+        XCTAssertEqual(partial.descendantFileCount, Int.max)
+
+        let accumulator = AtomicSummaryAccumulator(seed: partial)
+        accumulator.merge(AtomicDirectorySummaryPartial(
+            allocatedSize: 1,
+            logicalSize: 1,
+            descendantFileCount: 1
+        ))
+        let summary = accumulator.makeSummary()
+        XCTAssertEqual(summary.allocatedSize, Int64.max)
+        XCTAssertEqual(summary.logicalSize, Int64.max)
+        XCTAssertEqual(summary.descendantFileCount, Int.max)
+    }
+
     func testLowDescriptorBudgetMatchesNormalScanAndStaysWithinPeak() async throws {
         let rootURL = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: rootURL) }

--- a/RadixCoreTests/TreemapGeometryTests.swift
+++ b/RadixCoreTests/TreemapGeometryTests.swift
@@ -169,6 +169,25 @@ final class TreemapGeometryTests: XCTestCase {
         XCTAssertNil(index.segment(at: CGPoint(x: 300, y: 150), in: size))
     }
 
+    func testHitTestingMatchesRenderedRectsAcrossFractionalChartSize() {
+        let segments = [
+            makeTreemapSegment(id: "left", rect: CGRect(x: 0, y: 0, width: 0.6, height: 1)),
+            makeTreemapSegment(id: "right", rect: CGRect(x: 0.6, y: 0, width: 0.4, height: 1)),
+        ]
+        let size = CGSize(width: 617.5, height: 293.25)
+        let index = TreemapHitTestIndex(segments: segments)
+
+        for x in stride(from: CGFloat(0.25), to: size.width, by: 3.75) {
+            for y in stride(from: CGFloat(0.25), to: size.height, by: 4.5) {
+                let point = CGPoint(x: x, y: y)
+                let expected = segments.last { segment in
+                    TreemapRenderer.displayRect(for: segment, in: size).contains(point)
+                }
+                XCTAssertEqual(index.segment(at: point, in: size)?.id, expected?.id)
+            }
+        }
+    }
+
     func testSmallTilesDoNotProduceAnOutOfBoundsSelectionStrokeRect() {
         let segment = makeTreemapSegment(
             id: "tiny",

--- a/RadixCoreTests/TreemapGeometryTests.swift
+++ b/RadixCoreTests/TreemapGeometryTests.swift
@@ -183,7 +183,11 @@ final class TreemapGeometryTests: XCTestCase {
                 let expected = segments.last { segment in
                     TreemapRenderer.displayRect(for: segment, in: size).contains(point)
                 }
-                XCTAssertEqual(index.segment(at: point, in: size)?.id, expected?.id)
+                XCTAssertEqual(
+                    index.segment(at: point, in: size)?.id,
+                    expected?.id,
+                    "Hit-test mismatch at (\(point.x), \(point.y))"
+                )
             }
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved file search accuracy by preventing search index reuse across different file trees with the same snapshot identifier.
  - Incremental scans now more conservatively fall back to a full scan when subtree scan history can’t be safely used.
  - Prevented overflow in directory size and descendant file-count calculations across scanning and summary steps.
  - Improved treemap hit testing consistency for fractional chart sizes.
- **Security & Reliability**
  - Added explicit, enforced byte-size limits when previewing/importing scan archives, rejecting oversized sections early.
- **Tests**
  - Added coverage for clamping behavior, archive oversize rejection, search index caching isolation, incremental rescan edge cases, and hit testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->