### PR TITLE
feat(scan): add focused folder rescans

### DIFF
--- a/Radix/App/RadixCommands.swift
+++ b/Radix/App/RadixCommands.swift
@@ -85,7 +85,7 @@ struct RadixCommands: Commands {
                 appModel.presentOpenPanelAndScan()
             }
             .keyboardShortcut("o")
-            .disabled(scanState.isScanning)
+            .disabled(scanState.isScanOperationInProgress)
 
             Button("Import Snapshot…", systemImage: "square.and.arrow.down") {
                 appModel.importScanSnapshot()
@@ -115,11 +115,17 @@ struct RadixCommands: Commands {
 
             Divider()
 
-            Button("Rescan", systemImage: "arrow.clockwise") {
+            Button("Rescan Current Folder", systemImage: "arrow.clockwise") {
                 appModel.rescan()
             }
             .keyboardShortcut("r")
-            .disabled(!scanState.canRescan)
+            .disabled(!appModel.canRescanCurrentFolder)
+
+            Button("Rescan Entire Scan", systemImage: "arrow.clockwise.circle") {
+                appModel.rescanEntireScan()
+            }
+            .keyboardShortcut("r", modifiers: [.command, .shift])
+            .disabled(!appModel.canRescanEntireScan)
 
             Button("Stop Scan", systemImage: "stop") {
                 appModel.stopScan()

--- a/Radix/ContentView.swift
+++ b/Radix/ContentView.swift
@@ -12,6 +12,7 @@ struct ContentView: View {
     private static let discardPileDragActivationDistance: CGFloat = 10
 
     @EnvironmentObject private var appModel: AppModel
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.scenePhase) private var scenePhase
 
     @State private var splitViewVisibility: NavigationSplitViewVisibility = .all
@@ -109,6 +110,7 @@ struct ContentView: View {
                 )
                 .padding(.top, 12)
                 .padding(.horizontal, 16)
+                .topBannerTransition()
             } else if appModel.exportConfirmation != nil {
                 ExportConfirmationBanner(
                     onReveal: {
@@ -120,8 +122,17 @@ struct ContentView: View {
                 )
                 .padding(.top, 12)
                 .padding(.horizontal, 16)
+                .topBannerTransition()
             }
         }
+        .animation(
+            TopBannerPresentation.animation(reduceMotion: reduceMotion),
+            value: appModel.archiveOperation?.id
+        )
+        .animation(
+            TopBannerPresentation.animation(reduceMotion: reduceMotion),
+            value: appModel.exportConfirmation?.id
+        )
         .sheet(item: activeSheetBinding) { sheet in
             switch sheet {
             case .onboarding:
@@ -304,6 +315,7 @@ private struct ArchiveOperationBanner: View {
                     .font(.subheadline.weight(.semibold))
                 messageText
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
             .lineLimit(1)
 
             Button {
@@ -315,10 +327,7 @@ private struct ArchiveOperationBanner: View {
             .buttonStyle(.borderless)
             .help("Cancel")
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 9)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
-        .shadow(color: .black.opacity(0.12), radius: 10, y: 4)
+        .topBannerSurface()
     }
 
     private var messageText: some View {
@@ -362,6 +371,7 @@ private struct ExportConfirmationBanner: View {
 
             Text("Snapshot Exported")
                 .font(.subheadline.weight(.semibold))
+                .frame(maxWidth: .infinity, alignment: .leading)
 
             Button("Show in Finder") {
                 onReveal()
@@ -377,10 +387,7 @@ private struct ExportConfirmationBanner: View {
             .buttonStyle(.borderless)
             .help("Dismiss")
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 9)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
-        .shadow(color: .black.opacity(0.12), radius: 10, y: 4)
+        .topBannerSurface()
     }
 }
 

--- a/Radix/ContentView.swift
+++ b/Radix/ContentView.swift
@@ -800,6 +800,8 @@ private extension ContentView {
             startScan: { appModel.startScan($0) },
             stopScan: { appModel.stopScan() },
             rescan: { appModel.rescan() },
+            rescanFolder: { appModel.rescanFolder(id: $0) },
+            canRescanCurrentFolder: { appModel.canRescanCurrentFolder },
             compareScans: { appModel.compareScanSnapshots() },
             canCompareScans: { appModel.canCompareScanSnapshots },
             handleDroppedURLs: { appModel.handleDroppedURLs($0) },

--- a/Radix/Features/FileList/FileBrowserTableView.swift
+++ b/Radix/Features/FileList/FileBrowserTableView.swift
@@ -145,6 +145,9 @@ struct FileBrowserTableView: View {
         .onChange(of: scanState.snapshot?.id) { _, _ in
             updateModelContent()
         }
+        .onChange(of: scanState.fileTreeStore?.contentID) { _, _ in
+            updateModelContent()
+        }
         .onChange(of: hiddenNodeIDs) { _, _ in
             updateModelContent()
         }

--- a/Radix/Features/FileList/FileBrowserTableView.swift
+++ b/Radix/Features/FileList/FileBrowserTableView.swift
@@ -14,6 +14,14 @@ struct FileBrowserActions {
     let setDiscardPileDragActiveAfterThreshold: (Bool) -> Void
 }
 
+private struct FileBrowserContentRefreshID: Hashable {
+    let tableContentID: String
+    let tableContentRevision: Int
+    let snapshotID: UUID?
+    let treeContentID: UUID?
+    let hiddenNodeIDs: Set<FileNodeRecord.ID>
+}
+
 struct FileBrowserTableView: View {
     @ObservedObject var scanState: ScanCoordinator
     @ObservedObject var navigation: WorkspaceNavigationModel
@@ -101,6 +109,16 @@ struct FileBrowserTableView: View {
         navigation.tableContentRevision
     }
 
+    private var contentRefreshID: FileBrowserContentRefreshID {
+        FileBrowserContentRefreshID(
+            tableContentID: contentID,
+            tableContentRevision: contentRevision,
+            snapshotID: scanState.snapshot?.id,
+            treeContentID: scanState.fileTreeStore?.contentID,
+            hiddenNodeIDs: hiddenNodeIDs
+        )
+    }
+
     var body: some View {
         Group {
             if !showsTableChrome {
@@ -130,26 +148,13 @@ struct FileBrowserTableView: View {
             isSearchFieldFocused = true
         }
         .onExitCommand(perform: exitCommandHandler)
-        .onAppear {
+        .task(id: contentRefreshID) {
+            await Task.yield()
+            guard !Task.isCancelled else { return }
             updateModelContent()
         }
         .onDisappear {
             model.cleanup()
-        }
-        .onChange(of: contentID) { _, _ in
-            updateModelContent()
-        }
-        .onChange(of: contentRevision) { _, _ in
-            updateModelContent()
-        }
-        .onChange(of: scanState.snapshot?.id) { _, _ in
-            updateModelContent()
-        }
-        .onChange(of: scanState.fileTreeStore?.contentID) { _, _ in
-            updateModelContent()
-        }
-        .onChange(of: hiddenNodeIDs) { _, _ in
-            updateModelContent()
         }
         .onChange(of: focusedWorkspaceTarget) { _, target in
             if target != nil {

--- a/Radix/Features/FileList/FileBrowserTableView.swift
+++ b/Radix/Features/FileList/FileBrowserTableView.swift
@@ -8,6 +8,7 @@ struct FileBrowserActions {
     let selectNodesAfterViewUpdate: (Set<String>, String?) -> Void
     let expandSummarizedNode: (FileNodeRecord) -> Void
     let zoomIntoSelection: () -> Void
+    let rescanFolder: (FileNodeRecord.ID) -> Void
     let selectedFileActions: SelectedFileActions
     let bulkFileActions: BulkFileActions
     let setDiscardPileDragActiveAfterThreshold: (Bool) -> Void
@@ -362,6 +363,13 @@ struct FileBrowserTableView: View {
                     actions.zoomIntoSelection()
                 }
                 .disabled(!canRequestZoom(for: node))
+            }
+
+            if node.isDirectory {
+                Button("Rescan Folder", systemImage: "arrow.clockwise") {
+                    actions.rescanFolder(id)
+                }
+                .disabled(!scanState.canRescanFolder(id: id))
             }
 
             Divider()

--- a/Radix/Features/Workspace/ActiveWorkspaceView.swift
+++ b/Radix/Features/Workspace/ActiveWorkspaceView.swift
@@ -183,6 +183,7 @@ struct ActiveWorkspaceView: View {
             selectNodesAfterViewUpdate: actions.selectNodes,
             expandSummarizedNode: actions.expandSummarizedNode,
             zoomIntoSelection: actions.zoomIntoSelection,
+            rescanFolder: actions.rescanFolder,
             selectedFileActions: actions.selectedFileActions,
             bulkFileActions: actions.bulkFileActions,
             setDiscardPileDragActiveAfterThreshold: actions.setDiscardPileDragActiveAfterThreshold

--- a/Radix/Features/Workspace/WorkspaceHeaderView.swift
+++ b/Radix/Features/Workspace/WorkspaceHeaderView.swift
@@ -31,7 +31,7 @@ struct WorkspaceHeaderView: View {
 
                 if let finishedAt = snapshot.finishedAt {
                     VStack(alignment: .trailing, spacing: 2) {
-                        Text("Last Scan")
+                        Text("Last Updated")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                         Text(RadixFormatters.date(finishedAt))

--- a/Radix/Features/Workspace/WorkspaceStateViews.swift
+++ b/Radix/Features/Workspace/WorkspaceStateViews.swift
@@ -307,8 +307,7 @@ struct FolderRescanProgressBanner: View {
     }
 
     private var progressDetail: String {
-        let currentName = URL(filePath: progress.metrics.currentPath).lastPathComponent
-        if !currentName.isEmpty {
+        if let currentName = progress.metrics.currentItemName {
             return currentName
         }
         return String(

--- a/Radix/Features/Workspace/WorkspaceStateViews.swift
+++ b/Radix/Features/Workspace/WorkspaceStateViews.swift
@@ -191,41 +191,30 @@ struct ScanCompletionNoticeBanner: View {
     let dismiss: () -> Void
 
     var body: some View {
-        HStack(alignment: .top, spacing: 12) {
+        HStack(spacing: 12) {
             Image(systemName: iconName)
                 .foregroundStyle(iconColor)
-                .font(.title3)
 
-            VStack(alignment: .leading, spacing: 3) {
+            VStack(alignment: .leading, spacing: 2) {
                 Text(title)
-                    .font(.headline)
+                    .font(.subheadline.weight(.semibold))
 
                 if let detail {
                     Text(detail)
-                        .font(.callout)
+                        .font(.caption)
                         .foregroundStyle(.secondary)
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
             Button(action: dismiss) {
-                Image(systemName: "xmark")
-                    .foregroundStyle(.secondary)
-                    .padding(4)
-                    .contentShape(Rectangle())
+                Label("Dismiss", systemImage: "xmark.circle.fill")
             }
-            .buttonStyle(.plain)
+            .labelStyle(.iconOnly)
+            .buttonStyle(.borderless)
             .help("Dismiss")
-            .accessibilityLabel("Dismiss")
         }
-        .padding(14)
-        .frame(maxWidth: 560)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
-        .overlay {
-            RoundedRectangle(cornerRadius: 12)
-                .stroke(.separator.opacity(0.5), lineWidth: 0.5)
-        }
-        .shadow(color: .black.opacity(0.12), radius: 12, y: 5)
+        .topBannerSurface()
     }
 
     private var title: String {
@@ -299,11 +288,7 @@ struct FolderRescanProgressBanner: View {
             .buttonStyle(.borderless)
             .help("Cancel")
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 9)
-        .frame(maxWidth: 560)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
-        .shadow(color: .black.opacity(0.12), radius: 10, y: 4)
+        .topBannerSurface()
     }
 
     private var progressDetail: String {

--- a/Radix/Features/Workspace/WorkspaceStateViews.swift
+++ b/Radix/Features/Workspace/WorkspaceStateViews.swift
@@ -236,6 +236,11 @@ struct ScanCompletionNoticeBanner: View {
             return String(localized: "No changes since the previous scan")
         case .fullFallback:
             return String(localized: "Complete rescan finished")
+        case .folderUpdated(let name):
+            return String(
+                localized: "\(name) updated",
+                comment: "Confirmation shown after one folder was refreshed inside an existing scan."
+            )
         }
     }
 
@@ -260,6 +265,56 @@ struct ScanCompletionNoticeBanner: View {
             return .orange
         }
         return .green
+    }
+}
+
+struct FolderRescanProgressBanner: View {
+    let state: FolderRescanState
+    @ObservedObject var progress: ScanProgressState
+    let cancel: () -> Void
+
+    var body: some View {
+        HStack(spacing: 12) {
+            ProgressView(value: progress.metrics.progressFraction, total: 1)
+                .frame(width: 96)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(
+                    "Rescanning \(state.nodeName)",
+                    comment: "Progress banner title while refreshing one folder inside an existing scan."
+                )
+                .font(.subheadline.weight(.semibold))
+
+                Text(progressDetail)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            Button(action: cancel) {
+                Label("Cancel", systemImage: "xmark.circle.fill")
+            }
+            .labelStyle(.iconOnly)
+            .buttonStyle(.borderless)
+            .help("Cancel")
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 9)
+        .frame(maxWidth: 560)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
+        .shadow(color: .black.opacity(0.12), radius: 10, y: 4)
+    }
+
+    private var progressDetail: String {
+        let currentName = URL(filePath: progress.metrics.currentPath).lastPathComponent
+        if !currentName.isEmpty {
+            return currentName
+        }
+        return String(
+            localized: "Preparing folder scan",
+            comment: "Progress detail before a focused folder rescan reports its current item."
+        )
     }
 }
 

--- a/Radix/Features/Workspace/WorkspaceView.swift
+++ b/Radix/Features/Workspace/WorkspaceView.swift
@@ -76,6 +76,8 @@ struct BulkFileActions {
 }
 
 struct WorkspaceView: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     @ObservedObject var scanState: ScanCoordinator
     @ObservedObject var navigation: WorkspaceNavigationModel
     @Binding var isInspectorPresented: Bool
@@ -132,7 +134,7 @@ struct WorkspaceView: View {
                 )
                 .padding(.horizontal, 20)
                 .padding(.top, 12)
-                .transition(.move(edge: .top).combined(with: .opacity))
+                .topBannerTransition()
             } else if let notice = scanState.scanCompletionNotice {
                 ScanCompletionNoticeBanner(
                     notice: notice,
@@ -140,11 +142,17 @@ struct WorkspaceView: View {
                 )
                 .padding(.horizontal, 20)
                 .padding(.top, 12)
-                .transition(.move(edge: .top).combined(with: .opacity))
+                .topBannerTransition()
             }
         }
-        .animation(.easeOut(duration: 0.2), value: scanState.folderRescanState)
-        .animation(.easeOut(duration: 0.2), value: scanState.scanCompletionNotice)
+        .animation(
+            TopBannerPresentation.animation(reduceMotion: reduceMotion),
+            value: scanState.folderRescanState
+        )
+        .animation(
+            TopBannerPresentation.animation(reduceMotion: reduceMotion),
+            value: scanState.scanCompletionNotice
+        )
         .hidingWindowToolbarBackgroundWhenAvailable()
         .toolbar {
             ToolbarItem(placement: .automatic) { Spacer() }

--- a/Radix/Features/Workspace/WorkspaceView.swift
+++ b/Radix/Features/Workspace/WorkspaceView.swift
@@ -18,6 +18,8 @@ struct WorkspaceActions {
     let startScan: (ScanTarget) -> Void
     let stopScan: () -> Void
     let rescan: () -> Void
+    let rescanFolder: (FileNodeRecord.ID) -> Void
+    let canRescanCurrentFolder: () -> Bool
     let compareScans: () -> Void
     let canCompareScans: () -> Bool
     let handleDroppedURLs: ([URL]) -> Bool
@@ -122,7 +124,16 @@ struct WorkspaceView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color(nsColor: .windowBackgroundColor))
         .overlay(alignment: .top) {
-            if let notice = scanState.scanCompletionNotice {
+            if let folderRescanState = scanState.folderRescanState {
+                FolderRescanProgressBanner(
+                    state: folderRescanState,
+                    progress: scanState.progress,
+                    cancel: actions.stopScan
+                )
+                .padding(.horizontal, 20)
+                .padding(.top, 12)
+                .transition(.move(edge: .top).combined(with: .opacity))
+            } else if let notice = scanState.scanCompletionNotice {
                 ScanCompletionNoticeBanner(
                     notice: notice,
                     dismiss: scanState.dismissScanCompletionNotice
@@ -132,6 +143,7 @@ struct WorkspaceView: View {
                 .transition(.move(edge: .top).combined(with: .opacity))
             }
         }
+        .animation(.easeOut(duration: 0.2), value: scanState.folderRescanState)
         .animation(.easeOut(duration: 0.2), value: scanState.scanCompletionNotice)
         .hidingWindowToolbarBackgroundWhenAvailable()
         .toolbar {
@@ -142,7 +154,7 @@ struct WorkspaceView: View {
                 } label: {
                     Label("Choose Folder", systemImage: "folder.badge.plus")
                 }
-                .disabled(scanState.isScanning)
+                .disabled(scanState.isScanOperationInProgress)
                 .help("Choose Folder")
 
                 if scanState.canStopScan {
@@ -156,10 +168,10 @@ struct WorkspaceView: View {
                     Button {
                         actions.rescan()
                     } label: {
-                        Label("Rescan", systemImage: "arrow.clockwise")
+                        Label(rescanButtonTitle, systemImage: "arrow.clockwise")
                     }
-                    .disabled(!scanState.canRescan)
-                    .help("Rescan")
+                    .disabled(!actions.canRescanCurrentFolder())
+                    .help(rescanButtonTitle)
 
                     Button {
                         actions.compareScans()
@@ -193,6 +205,18 @@ struct WorkspaceView: View {
 }
 
 private extension WorkspaceView {
+    var rescanButtonTitle: String {
+        guard let snapshot = scanState.snapshot,
+              let focusNode = navigation.currentFocusNode,
+              focusNode.id != snapshot.root.id else {
+            return String(localized: "Rescan Entire Scan")
+        }
+        return String(
+            localized: "Rescan \(focusNode.name)",
+            comment: "Toolbar action that refreshes the currently focused folder."
+        )
+    }
+
     var visualizationModePicker: some View {
         Picker("Disk Map Style", selection: $visualizationMode) {
             Label("Sunburst", systemImage: "chart.pie")

--- a/Radix/Localizable.xcstrings
+++ b/Radix/Localizable.xcstrings
@@ -35,6 +35,41 @@
         }
       }
     },
+    "%@ updated" : {
+      "comment" : "Confirmation shown after one folder was refreshed inside an existing scan.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ aktualisiert"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ actualizado"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ mis à jour"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ aggiornato"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 已更新"
+          }
+        }
+      }
+    },
     "Checking for changes in %@" : {
       "comment" : "Progress title while Radix prepares an incremental rescan.",
       "localizations" : {
@@ -7857,36 +7892,36 @@
         }
       }
     },
-    "Last Scan" : {
+    "Last Updated" : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Letzter Scan"
+            "value" : "Zuletzt aktualisiert"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Último análisis"
+            "value" : "Última actualización"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dernière analyse"
+            "value" : "Dernière mise à jour"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ultima scansione"
+            "value" : "Ultimo aggiornamento"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "上次扫描"
+            "value" : "上次更新"
           }
         }
       }
@@ -13015,6 +13050,76 @@
         }
       }
     },
+    "Failed to rescan %@: %@" : {
+      "comment" : "Error shown when refreshing one folder in an existing scan fails.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ konnte nicht erneut gescannt werden: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo volver a analizar %@: %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible de réanalyser %@ : %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossibile scansionare nuovamente %@: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法重新扫描 %@：%@"
+          }
+        }
+      }
+    },
+    "Preparing folder scan" : {
+      "comment" : "Progress detail before a focused folder rescan reports its current item.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ordnerscan wird vorbereitet"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparando el análisis de la carpeta"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Préparation de l’analyse du dossier"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparazione della scansione della cartella"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在准备文件夹扫描"
+          }
+        }
+      }
+    },
     "Rescan" : {
       "localizations" : {
         "de" : {
@@ -13045,6 +13150,178 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重新扫描"
+          }
+        }
+      }
+    },
+    "Rescan %@" : {
+      "comment" : "Toolbar action that refreshes the currently focused folder.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ erneut scannen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Volver a analizar %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réanalyser %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scansiona nuovamente %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新扫描 %@"
+          }
+        }
+      }
+    },
+    "Rescan Current Folder" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktuellen Ordner erneut scannen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Volver a analizar la carpeta actual"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réanalyser le dossier actuel"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scansiona nuovamente la cartella attuale"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新扫描当前文件夹"
+          }
+        }
+      }
+    },
+    "Rescan Entire Scan" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gesamten Scan erneut ausführen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Volver a realizar todo el análisis"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relancer l’analyse complète"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ripeti l’intera scansione"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新扫描整个范围"
+          }
+        }
+      }
+    },
+    "Rescan Folder" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ordner erneut scannen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Volver a analizar la carpeta"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réanalyser le dossier"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scansiona nuovamente la cartella"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新扫描文件夹"
+          }
+        }
+      }
+    },
+    "Rescanning %@" : {
+      "comment" : "Progress banner title while refreshing one folder inside an existing scan.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ wird erneut gescannt"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Volviendo a analizar %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nouvelle analyse de %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nuova scansione di %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在重新扫描 %@"
           }
         }
       }

--- a/Radix/Models/ScanProgress.swift
+++ b/Radix/Models/ScanProgress.swift
@@ -59,6 +59,12 @@ nonisolated struct ScanMetrics: Sendable {
         Int((progressFraction * 100).rounded(.down))
     }
 
+    nonisolated var currentItemName: String? {
+        guard !currentPath.isEmpty else { return nil }
+        let name = URL(filePath: currentPath).lastPathComponent
+        return name.isEmpty ? nil : name
+    }
+
     nonisolated mutating func recalculateProgress(isComplete: Bool = false) {
         if isComplete {
             progressFraction = 1

--- a/Radix/Models/ScanSnapshot.swift
+++ b/Radix/Models/ScanSnapshot.swift
@@ -312,6 +312,46 @@ nonisolated struct ScanSnapshot: Identifiable, Sendable {
         )
     }
 
+    /// Marks a snapshot after one of its subtrees has been refreshed. The
+    /// original scan identity and incremental checkpoint are retained because
+    /// locations outside the replacement may still reflect the earlier scan.
+    nonisolated func updatedAfterSubtreeRescan(
+        finishedAt: Date,
+        volumeCapacity: VolumeCapacitySnapshot?,
+        reconcilesVolumeCapacity: Bool
+    ) -> ScanSnapshot {
+        let updatedCapacity = target.kind == .volume
+            ? volumeCapacity ?? self.volumeCapacity
+            : self.volumeCapacity
+        let updatedStore: FileTreeStore
+        if reconcilesVolumeCapacity {
+            updatedStore = VolumeCapacityAccounting.reconciledStore(
+                treeStore,
+                target: target,
+                capacity: updatedCapacity,
+                hasActiveExclusions: scanOptions?.exclusionPatterns.isEmpty == false
+                    || VolumeCapacityAccounting.hasActiveExclusions(in: treeStore)
+            )
+        } else {
+            updatedStore = treeStore
+        }
+
+        return ScanSnapshot(
+            id: id,
+            target: target,
+            treeStore: updatedStore,
+            startedAt: startedAt,
+            finishedAt: finishedAt,
+            scanWarnings: scanWarnings,
+            aggregateStats: updatedStore.aggregateStats,
+            isComplete: isComplete,
+            scanOptions: scanOptions,
+            volumeCapacity: updatedCapacity,
+            source: source,
+            incrementalCheckpoint: incrementalCheckpoint
+        )
+    }
+
     nonisolated func scoped(to target: ScanTarget) -> ScanSnapshot? {
         try? scoped(to: target, cancellationCheck: {})
     }

--- a/Radix/Services/FileBrowserModel.swift
+++ b/Radix/Services/FileBrowserModel.swift
@@ -109,6 +109,7 @@ final class FileBrowserModel: ObservableObject {
             needsRefreshAfterCleanup ||
             self.contentID != contentID ||
             snapshotID != nextSnapshotID ||
+            self.fileTreeStore?.contentID != fileTreeStore?.contentID ||
             self.hiddenNodeIDs != hiddenNodeIDs ||
             self.nodes != nodes else {
             return

--- a/Radix/Services/IncrementalScanService.swift
+++ b/Radix/Services/IncrementalScanService.swift
@@ -55,6 +55,18 @@ nonisolated final class IncrementalScanService: ScanEventStreaming, @unchecked S
         fullScan(target: target, options: options, executionMode: .full)
     }
 
+    nonisolated func scanSubtree(
+        target: ScanTarget,
+        preservingBehaviorOf scanTarget: ScanTarget,
+        options: ScanOptions
+    ) -> AsyncThrowingStream<ScanProgressEvent, Error> {
+        engine.scan(
+            target: target,
+            options: options,
+            preservingBehaviorOf: scanTarget
+        )
+    }
+
     private nonisolated func fullScan(
         target: ScanTarget,
         options: ScanOptions,

--- a/Radix/Services/ScanCoordinator.swift
+++ b/Radix/Services/ScanCoordinator.swift
@@ -15,11 +15,26 @@ enum AppModelPhase: Equatable, Sendable {
 
 protocol ScanEventStreaming: Sendable {
     nonisolated func scan(target: ScanTarget, options: ScanOptions) -> AsyncThrowingStream<ScanProgressEvent, Error>
+    nonisolated func scanSubtree(
+        target: ScanTarget,
+        preservingBehaviorOf scanTarget: ScanTarget,
+        options: ScanOptions
+    ) -> AsyncThrowingStream<ScanProgressEvent, Error>
     nonisolated func rescan(
         target: ScanTarget,
         options: ScanOptions,
         from baseline: ScanSnapshot
     ) -> AsyncThrowingStream<ScanProgressEvent, Error>
+}
+
+extension ScanEventStreaming {
+    nonisolated func scanSubtree(
+        target: ScanTarget,
+        preservingBehaviorOf scanTarget: ScanTarget,
+        options: ScanOptions
+    ) -> AsyncThrowingStream<ScanProgressEvent, Error> {
+        scan(target: target, options: options)
+    }
 }
 
 enum ScanExpansionResult {
@@ -33,6 +48,16 @@ nonisolated enum ScanCompletionNotice: Equatable, Sendable {
     case incrementalUpdated
     case noChanges
     case fullFallback(IncrementalRescanFallbackReason)
+    case folderUpdated(name: String)
+}
+
+nonisolated struct FolderRescanState: Equatable, Sendable {
+    let nodeName: String
+}
+
+nonisolated struct VolumeCapacityRefresh: Equatable, Sendable {
+    let capacity: VolumeCapacitySnapshot?
+    let reconcilesTree: Bool
 }
 
 @MainActor
@@ -59,11 +84,13 @@ final class ScanCoordinator: ObservableObject {
     @Published private(set) var expandingNodeID: FileNodeRecord.ID?
     @Published private(set) var trashSafetyPolicy: TrashSafetyPolicy
     @Published private(set) var scanCompletionNotice: ScanCompletionNotice?
+    @Published private(set) var folderRescanState: FolderRescanState?
 
     let progress: ScanProgressState
 
     private let scanService: any ScanEventStreaming
     private let snapshotTransformService: any ScanSnapshotTransforming
+    private let volumeCapacityProvider: @Sendable (URL) async -> VolumeCapacityRefresh
     private let progressThrottleDuration: Duration
     private let progressClock = ContinuousClock()
 
@@ -83,12 +110,28 @@ final class ScanCoordinator: ObservableObject {
     init(
         scanService: any ScanEventStreaming = IncrementalScanService(),
         snapshotTransformService: any ScanSnapshotTransforming = ScanSnapshotTransformService(),
+        volumeCapacityProvider: @escaping @Sendable (URL) async -> VolumeCapacityRefresh = { url in
+            await Task.detached(priority: .utility) {
+                let capacity = (try? ScanMetadataLoader().metadata(
+                    for: url,
+                    includeVolumeDetails: true
+                ))?.volumeCapacity
+                let fileSystemType = ScanEngine.defaultVolumeFileSystemType(for: url)
+                return VolumeCapacityRefresh(
+                    capacity: capacity,
+                    reconcilesTree: fileSystemType.map {
+                        ScanEngine.shouldReconcileVolumeCapacity(fileSystemType: $0)
+                    } ?? false
+                )
+            }.value
+        },
         progressThrottleDuration: Duration = .milliseconds(100),
         progress: ScanProgressState = ScanProgressState(),
         trashSafetyPolicy: TrashSafetyPolicy = .live()
     ) {
         self.scanService = scanService
         self.snapshotTransformService = snapshotTransformService
+        self.volumeCapacityProvider = volumeCapacityProvider
         self.progressThrottleDuration = progressThrottleDuration
         self.progress = progress
         self.trashSafetyPolicy = trashSafetyPolicy
@@ -103,12 +146,16 @@ final class ScanCoordinator: ObservableObject {
         phase == .scanning
     }
 
+    var isScanOperationInProgress: Bool {
+        activeScanID != nil
+    }
+
     var canRescan: Bool {
-        selectedTarget != nil && !isScanning
+        selectedTarget != nil && !isScanOperationInProgress
     }
 
     var canStopScan: Bool {
-        isScanning
+        isScanOperationInProgress
     }
 
     var snapshotSource: ScanSnapshotSource {
@@ -121,6 +168,23 @@ final class ScanCoordinator: ObservableObject {
 
     func replaceTrashSafetyPolicy(_ policy: TrashSafetyPolicy) {
         trashSafetyPolicy = policy
+    }
+
+    func canRescanFolder(id nodeID: FileNodeRecord.ID) -> Bool {
+        guard !isScanOperationInProgress,
+              expandingNodeID == nil,
+              let snapshot,
+              snapshot.isComplete,
+              snapshot.source.allowsFileMutation,
+              let options = snapshot.scanOptions,
+              let node = snapshot.treeStore.node(id: nodeID) else {
+            return false
+        }
+        return node.isDirectory
+            && !node.isSymbolicLink
+            && !node.isSynthetic
+            && (!node.isPackage || options.treatPackagesAsDirectories)
+            && nodeID != snapshot.root.id
     }
 
     func startScan(
@@ -156,10 +220,61 @@ final class ScanCoordinator: ObservableObject {
         }
     }
 
+    @discardableResult
+    func rescanFolder(id nodeID: FileNodeRecord.ID) -> Bool {
+        guard canRescanFolder(id: nodeID),
+              let baseline = snapshot,
+              let node = baseline.treeStore.node(id: nodeID),
+              var options = baseline.scanOptions else {
+            return false
+        }
+
+        cancelExpansion(completeWith: .cancelled)
+        dismissScanCompletionNotice()
+        scanErrorMessage = nil
+        scanMetrics = ScanMetrics()
+        progress.executionMode = nil
+        resetProgressThrottling()
+
+        if options.exclusionRootPath == nil {
+            options.exclusionRootPath = baseline.target.url.path
+        }
+        options = ScanEngine.subtreeScanOptions(
+            options,
+            at: node.url,
+            scanTarget: baseline.target
+        )
+
+        let rescanID = UUID()
+        let baselineContextID = snapshotContextID
+        let baselineRevision = snapshotRevision
+        activeScanID = rescanID
+        folderRescanState = FolderRescanState(nodeName: node.name)
+
+        let subtreeTarget = ScanTarget(url: node.url, kind: .folder)
+        let stream = scanService.scanSubtree(
+            target: subtreeTarget,
+            preservingBehaviorOf: baseline.target,
+            options: options
+        )
+        scanTask = Task { [weak self] in
+            await self?.consumeFolderRescanStream(
+                stream,
+                node: node,
+                baseline: baseline,
+                rescanID: rescanID,
+                snapshotContextID: baselineContextID,
+                snapshotRevision: baselineRevision
+            )
+        }
+        return true
+    }
+
     func stopScan(resetState: Bool = true) {
         activeScanID = nil
         scanTask?.cancel()
         scanTask = nil
+        folderRescanState = nil
         resetProgressThrottling()
         cancelExpansion(completeWith: .cancelled)
 
@@ -189,7 +304,7 @@ final class ScanCoordinator: ObservableObject {
         publishSnapshot(snapshot, startsNewContext: true)
         if snapshot == nil {
             phase = .idle
-        } else if !isScanning {
+        } else if !isScanOperationInProgress {
             phase = .displaying
         }
     }
@@ -258,7 +373,7 @@ final class ScanCoordinator: ObservableObject {
 
                 publishSnapshot(updatedSnapshot, startsNewContext: false)
                 completedScanSnapshot = nil
-                if !isScanning {
+                if !isScanOperationInProgress {
                     phase = .displaying
                 }
                 return true
@@ -276,7 +391,8 @@ final class ScanCoordinator: ObservableObject {
         options: ScanOptions,
         completion: @escaping (ScanExpansionResult) -> Void
     ) {
-        guard node.isAutoSummarized else {
+        guard !isScanOperationInProgress,
+              node.isAutoSummarized else {
             completion(.skipped)
             return
         }
@@ -319,6 +435,102 @@ final class ScanCoordinator: ObservableObject {
         }
 
         completeScanIfActive(scanID: scanID)
+    }
+
+    private func consumeFolderRescanStream(
+        _ stream: AsyncThrowingStream<ScanProgressEvent, Error>,
+        node: FileNodeRecord,
+        baseline: ScanSnapshot,
+        rescanID: UUID,
+        snapshotContextID baselineContextID: UUID,
+        snapshotRevision baselineRevision: UInt64
+    ) async {
+        do {
+            var replacement: ScanSnapshot?
+            for try await event in stream {
+                guard activeScanID == rescanID else { return }
+                switch event {
+                case .progress(var metrics):
+                    metrics.progressFraction = min(metrics.progressFraction * 0.95, 0.95)
+                    handleProgress(metrics, operationID: rescanID)
+                case .finished(let snapshot):
+                    replacement = snapshot
+                case .executionMode, .warning:
+                    break
+                }
+            }
+
+            try Task.checkCancellation()
+            guard folderRescanContextIsCurrent(
+                id: rescanID,
+                snapshotContextID: baselineContextID,
+                snapshotRevision: baselineRevision
+            ),
+                  let replacement else {
+                completeFolderRescanAsCancelled(id: rescanID)
+                return
+            }
+
+            let capacityRefresh: VolumeCapacityRefresh
+            if baseline.target.kind == .volume {
+                capacityRefresh = await volumeCapacityProvider(baseline.target.url)
+            } else {
+                capacityRefresh = VolumeCapacityRefresh(
+                    capacity: baseline.volumeCapacity,
+                    reconcilesTree: false
+                )
+            }
+
+            try Task.checkCancellation()
+            guard folderRescanContextIsCurrent(
+                id: rescanID,
+                snapshotContextID: baselineContextID,
+                snapshotRevision: baselineRevision
+            ) else {
+                completeFolderRescanAsCancelled(id: rescanID)
+                return
+            }
+
+            let updatedSnapshot = try await snapshotTransformService.replacingNodeForSubtreeRescan(
+                in: baseline,
+                id: node.id,
+                with: replacement.treeStore,
+                additionalWarnings: replacement.scanWarnings,
+                volumeCapacity: capacityRefresh.capacity,
+                reconcilesVolumeCapacity: capacityRefresh.reconcilesTree
+            )
+
+            try Task.checkCancellation()
+            guard folderRescanContextIsCurrent(
+                id: rescanID,
+                snapshotContextID: baselineContextID,
+                snapshotRevision: baselineRevision
+            ),
+                  let updatedSnapshot else {
+                completeFolderRescanAsCancelled(id: rescanID)
+                return
+            }
+
+            finishFolderRescan(
+                with: updatedSnapshot,
+                nodeName: node.name,
+                rescanID: rescanID
+            )
+        } catch is CancellationError {
+            completeFolderRescanAsCancelled(id: rescanID)
+        } catch {
+            failFolderRescan(error, nodeName: node.name, rescanID: rescanID)
+        }
+    }
+
+    private func folderRescanContextIsCurrent(
+        id rescanID: UUID,
+        snapshotContextID baselineContextID: UUID,
+        snapshotRevision baselineRevision: UInt64
+    ) -> Bool {
+        activeScanID == rescanID
+            && snapshotContextID == baselineContextID
+            && snapshotRevision == baselineRevision
     }
 
     private func consumeExpansionStream(
@@ -372,7 +584,7 @@ final class ScanCoordinator: ObservableObject {
         case .executionMode(let mode):
             handleExecutionMode(mode)
         case .progress(let metrics):
-            handleProgress(metrics, scanID: scanID)
+            handleProgress(metrics, operationID: scanID)
         case .warning:
             break
         case .finished(let snapshot):
@@ -389,8 +601,8 @@ final class ScanCoordinator: ObservableObject {
         progress.executionMode = mode
     }
 
-    private func handleProgress(_ metrics: ScanMetrics, scanID: UUID) {
-        guard activeScanID == scanID else { return }
+    private func handleProgress(_ metrics: ScanMetrics, operationID: UUID) {
+        guard activeScanID == operationID else { return }
 
         if shouldPublishProgressImmediately {
             publishProgress(metrics)
@@ -398,7 +610,7 @@ final class ScanCoordinator: ObservableObject {
         }
 
         pendingProgressMetrics = metrics
-        schedulePendingProgressPublish(scanID: scanID)
+        schedulePendingProgressPublish(operationID: operationID)
     }
 
     private var shouldPublishProgressImmediately: Bool {
@@ -408,7 +620,7 @@ final class ScanCoordinator: ObservableObject {
         return lastProgressPublishTime.duration(to: progressClock.now) >= progressThrottleDuration
     }
 
-    private func schedulePendingProgressPublish(scanID: UUID) {
+    private func schedulePendingProgressPublish(operationID: UUID) {
         guard progressPublishTask == nil else { return }
 
         let delay: Duration
@@ -426,12 +638,12 @@ final class ScanCoordinator: ObservableObject {
                 return
             }
 
-            self?.publishPendingProgress(scanID: scanID)
+            self?.publishPendingProgress(operationID: operationID)
         }
     }
 
-    private func publishPendingProgress(scanID: UUID) {
-        guard activeScanID == scanID else { return }
+    private func publishPendingProgress(operationID: UUID) {
+        guard activeScanID == operationID else { return }
         progressPublishTask = nil
         guard let pendingProgressMetrics else { return }
         publishProgress(pendingProgressMetrics)
@@ -448,7 +660,7 @@ final class ScanCoordinator: ObservableObject {
     private func finishScan(with snapshot: ScanSnapshot, scanID: UUID) {
         guard activeScanID == scanID else { return }
 
-        flushPendingProgress(scanID: scanID)
+        flushPendingProgress(operationID: scanID)
         apply(snapshot: snapshot)
         completedScanSnapshot = snapshot
 
@@ -487,6 +699,13 @@ final class ScanCoordinator: ObservableObject {
             automaticallyDismisses = false
         }
 
+        publishCompletionNotice(notice, automaticallyDismisses: automaticallyDismisses)
+    }
+
+    private func publishCompletionNotice(
+        _ notice: ScanCompletionNotice?,
+        automaticallyDismisses: Bool
+    ) {
         completionNoticeDismissTask?.cancel()
         completionNoticeDismissTask = nil
         scanCompletionNotice = notice
@@ -548,8 +767,58 @@ final class ScanCoordinator: ObservableObject {
         scanTask = nil
     }
 
-    private func flushPendingProgress(scanID: UUID) {
-        guard activeScanID == scanID else { return }
+    private func finishFolderRescan(
+        with updatedSnapshot: ScanSnapshot,
+        nodeName: String,
+        rescanID: UUID
+    ) {
+        guard activeScanID == rescanID else { return }
+
+        flushPendingProgress(operationID: rescanID)
+        publishSnapshot(updatedSnapshot, startsNewContext: false)
+        completedScanSnapshot = updatedSnapshot
+
+        var completedMetrics = scanMetrics
+        completedMetrics.recalculateProgress(isComplete: true)
+        publishProgress(completedMetrics)
+
+        activeScanID = nil
+        scanTask = nil
+        folderRescanState = nil
+        phase = .displaying
+        publishCompletionNotice(.folderUpdated(name: nodeName), automaticallyDismisses: true)
+    }
+
+    private func completeFolderRescanAsCancelled(id rescanID: UUID) {
+        guard activeScanID == rescanID else { return }
+
+        resetProgressThrottling()
+        activeScanID = nil
+        scanTask = nil
+        folderRescanState = nil
+        phase = snapshot == nil ? .idle : .displaying
+    }
+
+    private func failFolderRescan(
+        _ error: Error,
+        nodeName: String,
+        rescanID: UUID
+    ) {
+        guard activeScanID == rescanID else { return }
+
+        resetProgressThrottling()
+        activeScanID = nil
+        scanTask = nil
+        folderRescanState = nil
+        phase = snapshot == nil ? .idle : .displaying
+        scanErrorMessage = String(
+            localized: "Failed to rescan \(nodeName): \(error.localizedDescription)",
+            comment: "Error shown when refreshing one folder in an existing scan fails."
+        )
+    }
+
+    private func flushPendingProgress(operationID: UUID) {
+        guard activeScanID == operationID else { return }
         progressPublishTask?.cancel()
         progressPublishTask = nil
 

--- a/Radix/Services/ScanEngine.swift
+++ b/Radix/Services/ScanEngine.swift
@@ -596,7 +596,7 @@ actor ScanEngine {
         )
     }
 
-    private nonisolated static func defaultVolumeFileSystemType(for url: URL) -> String? {
+    nonisolated static func defaultVolumeFileSystemType(for url: URL) -> String? {
         var fileSystemStats = statfs()
         let result = url.withUnsafeFileSystemRepresentation { path in
             guard let path else { return Int32(-1) }
@@ -783,11 +783,20 @@ actor ScanEngine {
     }
 
     nonisolated func scan(target: ScanTarget, options: ScanOptions) -> AsyncThrowingStream<ScanProgressEvent, Error> {
+        scan(target: target, options: options, preservingBehaviorOf: target)
+    }
+
+    nonisolated func scan(
+        target: ScanTarget,
+        options: ScanOptions,
+        preservingBehaviorOf scanTarget: ScanTarget
+    ) -> AsyncThrowingStream<ScanProgressEvent, Error> {
         AsyncThrowingStream { continuation in
             let task = Task(priority: .userInitiated) {
                 do {
                     let snapshot = try await self.performScan(
                         target: target,
+                        scanTarget: scanTarget,
                         options: options,
                         continuation: continuation
                     )
@@ -946,6 +955,7 @@ actor ScanEngine {
     // that bug (see testNewScanCanFinishWhilePreviousEnumerationIsStillCancelling).
     private nonisolated func performScan(
         target: ScanTarget,
+        scanTarget: ScanTarget,
         options: ScanOptions,
         continuation: AsyncThrowingStream<ScanProgressEvent, Error>.Continuation
     ) async throws -> ScanSnapshot {
@@ -960,7 +970,8 @@ actor ScanEngine {
         var warnings: [ScanWarning] = []
         var emissionState = ScanEmissionState()
         let behavior = ScanBehavior(
-            excludesStartupVolumeInternals: target.kind == .volume && target.url.path == "/"
+            excludesStartupVolumeInternals: scanTarget.kind == .volume
+                && scanTarget.url.path == "/"
         )
         let exclusionMatcher = ScanExclusionMatcher(
             patterns: options.exclusionPatterns,

--- a/Radix/Services/ScanSnapshotTransformService.swift
+++ b/Radix/Services/ScanSnapshotTransformService.swift
@@ -21,6 +21,15 @@ protocol ScanSnapshotTransforming: Sendable {
         additionalWarnings: [ScanWarning]
     ) async throws -> ScanSnapshot?
 
+    func replacingNodeForSubtreeRescan(
+        in snapshot: ScanSnapshot,
+        id targetID: String,
+        with replacement: FileTreeStore,
+        additionalWarnings: [ScanWarning],
+        volumeCapacity: VolumeCapacitySnapshot?,
+        reconcilesVolumeCapacity: Bool
+    ) async throws -> ScanSnapshot?
+
     func removingNode(
         in snapshot: ScanSnapshot,
         id targetID: String
@@ -38,6 +47,26 @@ protocol ScanSnapshotTransforming: Sendable {
 }
 
 extension ScanSnapshotTransforming {
+    func replacingNodeForSubtreeRescan(
+        in snapshot: ScanSnapshot,
+        id targetID: String,
+        with replacement: FileTreeStore,
+        additionalWarnings: [ScanWarning],
+        volumeCapacity: VolumeCapacitySnapshot?,
+        reconcilesVolumeCapacity: Bool
+    ) async throws -> ScanSnapshot? {
+        try await replacingNode(
+            in: snapshot,
+            id: targetID,
+            with: replacement,
+            additionalWarnings: additionalWarnings
+        )?.updatedAfterSubtreeRescan(
+            finishedAt: Date(),
+            volumeCapacity: volumeCapacity,
+            reconcilesVolumeCapacity: reconcilesVolumeCapacity
+        )
+    }
+
     func replacingSubtrees(
         in snapshot: ScanSnapshot,
         replacements: [String: FileTreeStore],
@@ -100,6 +129,28 @@ actor ScanSnapshotTransformService {
             cancellationCheck: {
                 try Task.checkCancellation()
             }
+        )
+    }
+
+    func replacingNodeForSubtreeRescan(
+        in snapshot: ScanSnapshot,
+        id targetID: String,
+        with replacement: FileTreeStore,
+        additionalWarnings: [ScanWarning] = [],
+        volumeCapacity: VolumeCapacitySnapshot?,
+        reconcilesVolumeCapacity: Bool
+    ) async throws -> ScanSnapshot? {
+        try snapshot.replacingNode(
+            id: targetID,
+            with: replacement,
+            additionalWarnings: additionalWarnings,
+            cancellationCheck: {
+                try Task.checkCancellation()
+            }
+        )?.updatedAfterSubtreeRescan(
+            finishedAt: Date(),
+            volumeCapacity: volumeCapacity,
+            reconcilesVolumeCapacity: reconcilesVolumeCapacity
         )
     }
 

--- a/Radix/Shared/TopBannerStyle.swift
+++ b/Radix/Shared/TopBannerStyle.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+enum TopBannerPresentation {
+    static func animation(reduceMotion: Bool) -> Animation? {
+        reduceMotion ? nil : .easeOut(duration: 0.2)
+    }
+}
+
+private struct TopBannerSurfaceModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .padding(.horizontal, 12)
+            .padding(.vertical, 9)
+            .frame(maxWidth: 560)
+            .background(
+                .regularMaterial,
+                in: RoundedRectangle(cornerRadius: 10, style: .continuous)
+            )
+            .overlay {
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .stroke(.separator.opacity(0.5), lineWidth: 0.5)
+            }
+            .shadow(color: .black.opacity(0.12), radius: 10, y: 4)
+    }
+}
+
+extension View {
+    func topBannerSurface() -> some View {
+        modifier(TopBannerSurfaceModifier())
+    }
+
+    func topBannerTransition() -> some View {
+        transition(.move(edge: .top).combined(with: .opacity))
+    }
+}

--- a/Radix/ViewModels/AppModel.swift
+++ b/Radix/ViewModels/AppModel.swift
@@ -700,7 +700,7 @@ final class AppModel: ObservableObject {
     }
 
     func presentOpenPanelAndScan() {
-        guard !scanCoordinator.isScanning else { return }
+        guard !scanCoordinator.isScanOperationInProgress else { return }
         if let target = dependencies.systemActions.presentOpenPanel() {
             startScan(target)
         }
@@ -708,13 +708,13 @@ final class AppModel: ObservableObject {
 
     var canExportCurrentScan: Bool {
         scanCoordinator.snapshot?.isComplete == true &&
-            !scanCoordinator.isScanning &&
+            !scanCoordinator.isScanOperationInProgress &&
             !isExportPanelPresented &&
             !isArchiveOperationInProgress
     }
 
     private var canPresentScanSnapshotPanel: Bool {
-        !scanCoordinator.isScanning &&
+        !scanCoordinator.isScanOperationInProgress &&
             !isExportPanelPresented &&
             !isArchiveOperationInProgress &&
             pendingComparisonSetup == nil &&
@@ -745,7 +745,7 @@ final class AppModel: ObservableObject {
     }
 
     private var canConfirmImportPreview: Bool {
-        !scanCoordinator.isScanning &&
+        !scanCoordinator.isScanOperationInProgress &&
             !isExportPanelPresented &&
             !isArchiveOperationInProgress
     }
@@ -787,7 +787,7 @@ final class AppModel: ObservableObject {
 
     private var canExportCurrentScanIgnoringPresentedPanel: Bool {
         scanCoordinator.snapshot?.isComplete == true &&
-            !scanCoordinator.isScanning &&
+            !scanCoordinator.isScanOperationInProgress &&
             !isArchiveOperationInProgress
     }
 
@@ -886,7 +886,7 @@ final class AppModel: ObservableObject {
     }
 
     private var importUnavailableMessage: String {
-        if scanCoordinator.isScanning {
+        if scanCoordinator.isScanOperationInProgress {
             return String(localized: "Stop the current scan before importing a snapshot.", comment: "Error shown when importing is attempted during a scan.")
         }
         if isExportPanelPresented {
@@ -905,7 +905,7 @@ final class AppModel: ObservableObject {
     }
 
     private var comparisonUnavailableMessage: String {
-        if scanCoordinator.isScanning {
+        if scanCoordinator.isScanOperationInProgress {
             return String(localized: "Stop the current scan before comparing snapshots.", comment: "Error shown when comparison is attempted during a scan.")
         }
         if isExportPanelPresented {
@@ -1685,9 +1685,49 @@ final class AppModel: ObservableObject {
             .path
     }
 
+    var canRescanEntireScan: Bool {
+        guard scanCoordinator.canRescan,
+              !isArchiveOperationInProgress else {
+            return false
+        }
+        if let snapshot = scanCoordinator.snapshot {
+            return snapshot.source.allowsFileMutation
+        }
+        return scanCoordinator.phase == .failed
+    }
+
+    var canRescanCurrentFolder: Bool {
+        guard let snapshot = scanCoordinator.snapshot,
+              snapshot.source.allowsFileMutation,
+              let focusedNodeID = navigationModel.focusedNodeID else {
+            return canRescanEntireScan
+        }
+        if focusedNodeID == snapshot.root.id {
+            return canRescanEntireScan
+        }
+        return !isArchiveOperationInProgress
+            && scanCoordinator.canRescanFolder(id: focusedNodeID)
+    }
+
     func rescan() {
-        guard let selectedTarget = scanCoordinator.selectedTarget else { return }
+        guard let snapshot = scanCoordinator.snapshot,
+              let focusedNodeID = navigationModel.focusedNodeID,
+              focusedNodeID != snapshot.root.id else {
+            rescanEntireScan()
+            return
+        }
+        rescanFolder(id: focusedNodeID)
+    }
+
+    func rescanEntireScan() {
+        guard canRescanEntireScan,
+              let selectedTarget = scanCoordinator.selectedTarget else { return }
         scheduleScanStart(selectedTarget, intent: .rescan)
+    }
+
+    func rescanFolder(id nodeID: FileNodeRecord.ID) {
+        guard !isArchiveOperationInProgress else { return }
+        scanCoordinator.rescanFolder(id: nodeID)
     }
 
     func cachedFreeSpaceAvailableCapacity(for snapshot: ScanSnapshot, focusNode: FileNodeRecord) -> Int64? {

--- a/RadixCoreTests/FileBrowserModelTests.swift
+++ b/RadixCoreTests/FileBrowserModelTests.swift
@@ -719,6 +719,58 @@ final class FileBrowserModelTests: XCTestCase {
     }
 
     @MainActor
+    func testEntireScanSearchRefreshesForNewTreeContentWithSameSnapshotAndVisibleRows() async throws {
+        let visible = makeTestFileNode(id: "/root/visible.txt", name: "visible.txt", size: 10)
+        let alpha = makeTestFileNode(id: "/root/archive/alpha.txt", name: "alpha.txt", size: 20)
+        let archive = makeTestDirectoryNode(id: "/root/archive", name: "archive", children: [alpha])
+        let root = makeTestDirectoryNode(id: "/root", name: "root", children: [archive, visible])
+        let store = FileTreeStore(root: root, childrenByID: [
+            root.id: [archive, visible],
+            archive.id: [alpha],
+        ])
+        let snapshot = makeTestSnapshot(root: root, store: store)
+        let model = FileBrowserModel(searchDebounceDuration: .zero)
+
+        model.updateContent(
+            nodes: [visible],
+            contentID: "\(snapshot.id.uuidString)|\(root.id)",
+            snapshot: snapshot,
+            fileTreeStore: store
+        )
+        model.setSearchScope(.entireScan)
+        model.setActiveSearchText("alpha")
+        try await waitForSearchToFinish(model)
+        XCTAssertEqual(model.displayedNodes.map(\.id), [alpha.id])
+
+        let beta = makeTestFileNode(id: "/root/archive/beta.txt", name: "beta.txt", size: 20)
+        let replacementArchive = makeTestDirectoryNode(
+            id: archive.id,
+            name: archive.name,
+            children: [beta]
+        )
+        let replacementStore = FileTreeStore(
+            root: replacementArchive,
+            childrenByID: [replacementArchive.id: [beta]]
+        )
+        let updatedSnapshot = try XCTUnwrap(
+            snapshot.replacingNode(id: archive.id, with: replacementStore)
+        )
+
+        model.updateContent(
+            nodes: [visible],
+            contentID: "\(snapshot.id.uuidString)|\(root.id)",
+            snapshot: updatedSnapshot,
+            fileTreeStore: updatedSnapshot.treeStore
+        )
+        try await waitForSearchToFinish(model)
+        XCTAssertTrue(model.displayedNodes.isEmpty)
+
+        model.setActiveSearchText("beta")
+        try await waitForSearchToFinish(model)
+        XCTAssertEqual(model.displayedNodes.map(\.id), [beta.id])
+    }
+
+    @MainActor
     func testDelayedEntireScanResultCannotReplaceNewerQuery() async throws {
         let slow = makeTestFileNode(id: "/root/slow.txt", name: "slow.txt", size: 5)
         let fast = makeTestFileNode(id: "/root/fast.txt", name: "fast.txt", size: 10)

--- a/RadixCoreTests/ScanCoordinatorTests.swift
+++ b/RadixCoreTests/ScanCoordinatorTests.swift
@@ -279,6 +279,232 @@ final class ScanCoordinatorTests: XCTestCase {
     }
 
     @MainActor
+    func testFolderRescanKeepsBaselineVisibleAndAtomicallyReplacesSubtree() async throws {
+        let service = ControlledScanService()
+        let coordinator = ScanCoordinator(
+            scanService: service,
+            progressThrottleDuration: .zero
+        )
+        let rootTarget = makeCoordinatorTarget("/scan/home")
+        let folderTarget = makeCoordinatorTarget("/scan/home/Downloads")
+        let checkpoint = ScanIncrementalCheckpoint(volumeUUID: "test-volume", eventID: 42)
+        let baseline = makeCoordinatorHomeSnapshot(
+            target: rootTarget,
+            downloadsTarget: folderTarget,
+            rootName: "home",
+            scanOptions: ScanOptions(includeHiddenFiles: true),
+            incrementalCheckpoint: checkpoint
+        )
+        let originalSibling = try XCTUnwrap(
+            baseline.treeStore.node(id: rootTarget.id + "/notes.txt")
+        )
+        coordinator.restoreCompletedSnapshot(baseline)
+
+        XCTAssertTrue(coordinator.rescanFolder(id: folderTarget.id))
+        XCTAssertFalse(coordinator.rescanFolder(id: folderTarget.id))
+        XCTAssertEqual(coordinator.snapshot?.id, baseline.id)
+        XCTAssertEqual(coordinator.snapshot?.treeStore.contentID, baseline.treeStore.contentID)
+        XCTAssertEqual(
+            coordinator.folderRescanState,
+            FolderRescanState(nodeName: "Downloads")
+        )
+        XCTAssertTrue(coordinator.isScanOperationInProgress)
+        XCTAssertEqual(service.requests.map(\.target), [
+            ScanTarget(url: folderTarget.url, kind: .folder)
+        ])
+        XCTAssertEqual(service.subtreeBehaviorTargets, [rootTarget])
+        XCTAssertEqual(service.requests.first?.options.includeHiddenFiles, true)
+        XCTAssertEqual(service.requests.first?.options.exclusionRootPath, rootTarget.id)
+
+        service.yield(
+            .progress(makeCoordinatorMetrics(
+                path: folderTarget.id + "/new.dat",
+                filesVisited: 1
+            )),
+            scanIndex: 0
+        )
+        let first = makeTestFileNode(
+            id: folderTarget.id + "/new.dat",
+            name: "new.dat",
+            size: 50
+        )
+        let second = makeTestFileNode(
+            id: folderTarget.id + "/other.dat",
+            name: "other.dat",
+            size: 30
+        )
+        let replacementRoot = makeTestDirectoryNode(
+            id: folderTarget.id,
+            name: "Downloads",
+            children: [first, second]
+        )
+        let replacementStore = FileTreeStore(
+            root: replacementRoot,
+            childrenByID: [replacementRoot.id: [first, second]]
+        )
+        let replacementWarning = ScanWarning(
+            path: first.id,
+            message: "replacement warning",
+            category: .fileSystem
+        )
+        let replacement = makeCoordinatorSnapshot(
+            target: folderTarget,
+            root: replacementRoot,
+            store: replacementStore,
+            warnings: [replacementWarning]
+        )
+
+        service.yield(.finished(replacement), scanIndex: 0)
+        service.finish(scanIndex: 0)
+
+        try await waitUntil("folder rescan finished") {
+            coordinator.scanCompletionNotice == .folderUpdated(name: "Downloads")
+        }
+
+        let updated = try XCTUnwrap(coordinator.snapshot)
+        XCTAssertEqual(updated.id, baseline.id)
+        XCTAssertEqual(updated.target, baseline.target)
+        XCTAssertEqual(updated.incrementalCheckpoint, checkpoint)
+        XCTAssertEqual(updated.treeStore.children(of: folderTarget.id).map(\.id), [
+            first.id,
+            second.id,
+        ])
+        XCTAssertEqual(updated.treeStore.node(id: originalSibling.id), originalSibling)
+        XCTAssertEqual(updated.scanWarnings.map(\.path), [replacementWarning.path])
+        XCTAssertGreaterThan(
+            try XCTUnwrap(updated.finishedAt),
+            try XCTUnwrap(baseline.finishedAt)
+        )
+        XCTAssertFalse(coordinator.isScanOperationInProgress)
+        XCTAssertNil(coordinator.folderRescanState)
+    }
+
+    @MainActor
+    func testFolderRescanRefreshesWholeVolumeCapacityAccounting() async throws {
+        let service = ControlledScanService()
+        let refreshedCapacity = VolumeCapacitySnapshot(
+            totalCapacity: 1_000_000_000,
+            availableCapacity: 300_000_000
+        )
+        let coordinator = ScanCoordinator(
+            scanService: service,
+            volumeCapacityProvider: { _ in
+                VolumeCapacityRefresh(
+                    capacity: refreshedCapacity,
+                    reconcilesTree: true
+                )
+            },
+            progressThrottleDuration: .zero
+        )
+        let volumeTarget = ScanTarget(
+            url: URL(filePath: "/test-volume", directoryHint: .isDirectory),
+            kind: .volume
+        )
+        let oldFile = makeTestFileNode(
+            id: volumeTarget.id + "/Folder/old.dat",
+            name: "old.dat",
+            size: 20
+        )
+        let folder = makeTestDirectoryNode(
+            id: volumeTarget.id + "/Folder",
+            name: "Folder",
+            children: [oldFile]
+        )
+        let root = makeTestDirectoryNode(
+            id: volumeTarget.id,
+            name: "Test Volume",
+            children: [folder]
+        )
+        let baselineStore = FileTreeStore(root: root, childrenByID: [
+            root.id: [folder],
+            folder.id: [oldFile],
+        ])
+        let baseline = ScanSnapshot(
+            target: volumeTarget,
+            treeStore: baselineStore,
+            startedAt: .now,
+            finishedAt: .now,
+            scanWarnings: [],
+            aggregateStats: baselineStore.aggregateStats,
+            isComplete: true,
+            scanOptions: ScanOptions(),
+            volumeCapacity: VolumeCapacitySnapshot(
+                totalCapacity: 1_000_000_000,
+                availableCapacity: 400_000_000
+            ),
+            incrementalCheckpoint: ScanIncrementalCheckpoint(
+                volumeUUID: "test-volume",
+                eventID: 10
+            )
+        )
+        coordinator.restoreCompletedSnapshot(baseline)
+
+        XCTAssertTrue(coordinator.rescanFolder(id: folder.id))
+        let replacementFile = makeTestFileNode(
+            id: folder.id + "/new.dat",
+            name: "new.dat",
+            size: 40
+        )
+        let replacementRoot = makeTestDirectoryNode(
+            id: folder.id,
+            name: folder.name,
+            children: [replacementFile]
+        )
+        let replacementStore = FileTreeStore(
+            root: replacementRoot,
+            childrenByID: [replacementRoot.id: [replacementFile]]
+        )
+        service.yield(
+            .finished(makeCoordinatorSnapshot(
+                target: ScanTarget(url: folder.url, kind: .folder),
+                root: replacementRoot,
+                store: replacementStore
+            )),
+            scanIndex: 0
+        )
+        service.finish(scanIndex: 0)
+
+        try await waitUntil("volume folder rescan finished") {
+            coordinator.folderRescanState == nil
+        }
+
+        let updated = try XCTUnwrap(coordinator.snapshot)
+        XCTAssertEqual(updated.volumeCapacity, refreshedCapacity)
+        XCTAssertEqual(updated.root.allocatedSize, refreshedCapacity.usedCapacity)
+        XCTAssertEqual(updated.treeStore.node(id: replacementFile.id)?.allocatedSize, 40)
+        XCTAssertEqual(
+            updated.incrementalCheckpoint,
+            baseline.incrementalCheckpoint
+        )
+    }
+
+    @MainActor
+    func testStoppingFolderRescanKeepsExistingSnapshot() async throws {
+        let service = ControlledScanService()
+        let coordinator = ScanCoordinator(scanService: service)
+        let rootTarget = makeCoordinatorTarget("/scan/cancel-folder")
+        let folderTarget = makeCoordinatorTarget("/scan/cancel-folder/Folder")
+        let baseline = makeCoordinatorHomeSnapshot(
+            target: rootTarget,
+            downloadsTarget: folderTarget,
+            rootName: "root",
+            scanOptions: ScanOptions()
+        )
+        coordinator.restoreCompletedSnapshot(baseline)
+
+        XCTAssertTrue(coordinator.rescanFolder(id: folderTarget.id))
+        coordinator.stopScan()
+
+        try await waitUntil("folder stream cancellation") {
+            service.terminationCount > 0
+        }
+        XCTAssertEqual(coordinator.snapshot?.treeStore.contentID, baseline.treeStore.contentID)
+        XCTAssertFalse(coordinator.isScanOperationInProgress)
+        XCTAssertNil(coordinator.folderRescanState)
+        XCTAssertNil(coordinator.scanCompletionNotice)
+    }
+
+    @MainActor
     func testProgressMetricsDoNotPublishCoordinatorChanges() {
         let coordinator = ScanCoordinator()
         var coordinatorChangeCount = 0
@@ -866,6 +1092,88 @@ final class ScanCoordinatorTests: XCTestCase {
         XCTAssertEqual(service.rescanRequests.map(\.target), [target])
         XCTAssertEqual(service.rescanRequests.map(\.baselineID), [snapshot.id])
         XCTAssertEqual(service.rescanRequests.map(\.options), [scanOptions])
+    }
+
+    @MainActor
+    func testAppModelRescanUsesFocusedFolderAndPreservesNavigation() async throws {
+        let service = ControlledScanService()
+        let rootTarget = makeCoordinatorTarget("/app/focused-rescan")
+        let folderTarget = makeCoordinatorTarget("/app/focused-rescan/Downloads")
+        let model = AppModel(
+            dependencies: makeCoordinatorAppDependencies(
+                scanService: service,
+                systemActions: makeCoordinatorSidebarActions(targets: [rootTarget])
+            )
+        )
+
+        model.startScan(rootTarget)
+        try await waitUntil("focused baseline request") {
+            service.requests.count == 1
+        }
+        let scanOptions = try XCTUnwrap(service.requests.first?.options)
+        let baseline = makeCoordinatorHomeSnapshot(
+            target: rootTarget,
+            downloadsTarget: folderTarget,
+            rootName: "root",
+            scanOptions: scanOptions,
+            incrementalCheckpoint: ScanIncrementalCheckpoint(
+                volumeUUID: "test-volume",
+                eventID: 10
+            )
+        )
+        service.yield(.finished(baseline), scanIndex: 0)
+        service.finish(scanIndex: 0)
+        try await waitUntil("focused baseline finished") {
+            model.scanState.phase == .displaying
+        }
+
+        model.focus(nodeID: folderTarget.id)
+        XCTAssertEqual(model.navigation.focusedNodeID, folderTarget.id)
+        XCTAssertTrue(model.canRescanCurrentFolder)
+        model.rescan()
+
+        try await waitUntil("focused folder request") {
+            service.requests.count == 2
+        }
+        XCTAssertEqual(service.requests[1].target, ScanTarget(
+            url: folderTarget.url,
+            kind: .folder
+        ))
+        XCTAssertTrue(service.rescanRequests.isEmpty)
+        XCTAssertEqual(model.scanState.snapshot?.id, baseline.id)
+
+        let refreshedFile = makeTestFileNode(
+            id: folderTarget.id + "/refreshed.dat",
+            name: "refreshed.dat",
+            size: 90
+        )
+        let refreshedRoot = makeTestDirectoryNode(
+            id: folderTarget.id,
+            name: "Downloads",
+            children: [refreshedFile]
+        )
+        let refreshedStore = FileTreeStore(
+            root: refreshedRoot,
+            childrenByID: [refreshedRoot.id: [refreshedFile]]
+        )
+        service.yield(
+            .finished(makeCoordinatorSnapshot(
+                target: folderTarget,
+                root: refreshedRoot,
+                store: refreshedStore
+            )),
+            scanIndex: 1
+        )
+        service.finish(scanIndex: 1)
+
+        try await waitUntil("focused folder applied") {
+            model.scanState.scanCompletionNotice == .folderUpdated(name: "Downloads")
+        }
+        XCTAssertEqual(model.navigation.focusedNodeID, folderTarget.id)
+        XCTAssertEqual(
+            model.scanState.snapshot?.treeStore.children(of: folderTarget.id).map(\.id),
+            [refreshedFile.id]
+        )
     }
 
     @MainActor
@@ -1973,6 +2281,7 @@ private final class ControlledScanService: ScanEventStreaming, @unchecked Sendab
     private var continuations: [Continuation] = []
     private var storedRequests: [ControlledScanRequest] = []
     private var storedRescanRequests: [ControlledRescanRequest] = []
+    private var storedSubtreeBehaviorTargets: [ScanTarget] = []
     private var storedTerminationCount = 0
 
     var requests: [ControlledScanRequest] {
@@ -1991,6 +2300,12 @@ private final class ControlledScanService: ScanEventStreaming, @unchecked Sendab
         lock.lock()
         defer { lock.unlock() }
         return storedRescanRequests
+    }
+
+    var subtreeBehaviorTargets: [ScanTarget] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedSubtreeBehaviorTargets
     }
 
     func scan(target: ScanTarget, options: ScanOptions) -> AsyncThrowingStream<ScanProgressEvent, Error> {
@@ -2022,6 +2337,17 @@ private final class ControlledScanService: ScanEventStreaming, @unchecked Sendab
                 baselineID: baseline.id
             )
         )
+        lock.unlock()
+        return scan(target: target, options: options)
+    }
+
+    func scanSubtree(
+        target: ScanTarget,
+        preservingBehaviorOf scanTarget: ScanTarget,
+        options: ScanOptions
+    ) -> AsyncThrowingStream<ScanProgressEvent, Error> {
+        lock.lock()
+        storedSubtreeBehaviorTargets.append(scanTarget)
         lock.unlock()
         return scan(target: target, options: options)
     }
@@ -2115,7 +2441,9 @@ private func makeCoordinatorSnapshot(
 private func makeCoordinatorHomeSnapshot(
     target homeTarget: ScanTarget,
     downloadsTarget: ScanTarget,
-    rootName: String
+    rootName: String,
+    scanOptions: ScanOptions? = nil,
+    incrementalCheckpoint: ScanIncrementalCheckpoint? = nil
 ) -> ScanSnapshot {
     let downloadFile = makeTestFileNode(
         id: downloadsTarget.id + "/download.txt",
@@ -2141,7 +2469,13 @@ private func makeCoordinatorHomeSnapshot(
         homeRoot.id: [downloadsNode, siblingFile],
         downloadsNode.id: [downloadFile],
     ])
-    return makeCoordinatorSnapshot(target: homeTarget, root: homeRoot, store: homeStore)
+    return makeCoordinatorSnapshot(
+        target: homeTarget,
+        root: homeRoot,
+        store: homeStore,
+        scanOptions: scanOptions,
+        incrementalCheckpoint: incrementalCheckpoint
+    )
 }
 
 private func makeCoordinatorSnapshot(

--- a/RadixCoreTests/ScanModelTests.swift
+++ b/RadixCoreTests/ScanModelTests.swift
@@ -382,6 +382,55 @@ final class ScanModelTests: XCTestCase {
         XCTAssertNil(snapshot.replacingNode(id: "/root/missing", with: treeStore))
     }
 
+    func testSubtreeUpdateRefreshesAPFSCapacityWithoutReconcilingItIntoTree() {
+        let target = ScanTarget(
+            url: URL(filePath: "/volume", directoryHint: .isDirectory),
+            kind: .volume
+        )
+        let file = makeNode(
+            id: "/volume/file.dat",
+            isDirectory: false,
+            isSynthetic: false,
+            isAccessible: true,
+            allocatedSize: 40
+        )
+        let root = FileNodeRecord.directory(
+            id: target.id,
+            url: target.url,
+            name: "volume",
+            children: [file],
+            lastModified: nil,
+            isPackage: false,
+            isAccessible: true
+        )
+        let treeStore = FileTreeStore(root: root, childrenByID: [root.id: [file]])
+        let snapshot = ScanSnapshot(
+            target: target,
+            treeStore: treeStore,
+            startedAt: .now,
+            finishedAt: .now,
+            scanWarnings: [],
+            aggregateStats: treeStore.aggregateStats,
+            isComplete: true,
+            scanOptions: ScanOptions(),
+            volumeCapacity: nil
+        )
+        let refreshedCapacity = VolumeCapacitySnapshot(
+            totalCapacity: 1_000_000_000,
+            availableCapacity: 300_000_000
+        )
+
+        let updated = snapshot.updatedAfterSubtreeRescan(
+            finishedAt: .now,
+            volumeCapacity: refreshedCapacity,
+            reconcilesVolumeCapacity: false
+        )
+
+        XCTAssertEqual(updated.volumeCapacity, refreshedCapacity)
+        XCTAssertEqual(updated.root.allocatedSize, 40)
+        XCTAssertEqual(updated.treeStore.children(of: root.id).map(\.id), [file.id])
+    }
+
     func testSnapshotRemovingNodeRemovesSubtreeAndRebuildsAncestors() throws {
         let removedLeaf = makeNode(
             id: "/root/folder/removed.bin",

--- a/RadixCoreTests/ScanModelTests.swift
+++ b/RadixCoreTests/ScanModelTests.swift
@@ -2,6 +2,19 @@ import XCTest
 @testable import RadixCore
 
 final class ScanModelTests: XCTestCase {
+    func testScanMetricsCurrentItemNameIsNilForEmptyPath() {
+        let metrics = ScanMetrics()
+
+        XCTAssertNil(metrics.currentItemName)
+    }
+
+    func testScanMetricsCurrentItemNameUsesLastPathComponent() {
+        var metrics = ScanMetrics()
+        metrics.currentPath = "/Users/example/Downloads/archive.zip"
+
+        XCTAssertEqual(metrics.currentItemName, "archive.zip")
+    }
+
     func testScanTargetInfersMountedVolumeRoots() {
         let volumeURL = URL(filePath: "/Volumes/External Drive", directoryHint: .isDirectory)
         let folderURL = URL(filePath: "/Users/example/Documents", directoryHint: .isDirectory)


### PR DESCRIPTION
## Summary

- add focused folder rescans that atomically refresh one subtree while preserving the surrounding scan and navigation
- make Command-R rescan the current focus, keep whole-scan rescanning on Shift-Command-R, and add a folder context-menu action
- show cancellable progress and completion feedback, rename Last Scan to Last Updated, and localize the new UI

## Correctness

- serialize scan operations and keep imported snapshots read-only
- preserve original scan options, exclusions, incremental checkpoints, and startup-volume namespace behavior
- refresh whole-volume capacity while keeping APFS container capacity separate from tree allocation
- preserve the preparing-state progress fallback when the scanner has not reported a current path

## Testing

- swift test: 702 passed, 18 opt-in tests skipped
- focused rescan, cancellation, navigation, volume-accounting, APFS, progress formatting, and localization coverage
- full Debug macOS xcodebuild passed

Closes #28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added folder-level rescanning with separate “Rescan Current Folder” (r) and “Rescan Entire Scan” (⌘R), including in-progress folder rescan progress banners with cancel.
* **Bug Fixes**
  * Improved command/toolbar enablement using consistent “scan operation in progress” state.
  * Updated rescan/folder-update confirmation and “Last Updated” labeling, plus refined top-banner animation behavior (including reduced motion).
  * Fixed file list refresh behavior when underlying tree content changes.
* **Tests**
  * Expanded coverage for subtree and folder rescans, focused-folder rescan flow, progress/cancellation, and refresh timing/state preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->