### PR TITLE
perf(scan): share cached trees across logical scopes

### DIFF
--- a/Radix/Models/FileTreeStore.swift
+++ b/Radix/Models/FileTreeStore.swift
@@ -340,20 +340,110 @@ nonisolated private struct FileTreeTopologyArena: Sendable {
 }
 
 nonisolated struct FileTreeStore: Sendable {
+    private struct NodeMembership: Sendable {
+        private var words: [UInt64]
+
+        init(nodeCapacity: Int) {
+            words = Array(repeating: 0, count: (nodeCapacity + 63) / 64)
+        }
+
+        mutating func insert(_ index: FileTreeNodeIndex) {
+            let offset = Int(index.rawValue)
+            words[offset >> 6] |= UInt64(1) << UInt64(offset & 63)
+        }
+
+        func contains(_ index: FileTreeNodeIndex) -> Bool {
+            let offset = Int(index.rawValue)
+            guard offset >= 0, offset >> 6 < words.count else { return false }
+            return words[offset >> 6] & (UInt64(1) << UInt64(offset & 63)) != 0
+        }
+    }
+
+    private struct LogicalScope: Sendable {
+        let rootIndex: FileTreeNodeIndex
+        let membership: NodeMembership
+        let orderedNodeIndices: [FileTreeNodeIndex]
+        let aggregateStats: ScanAggregateStats
+        let replacementRecords: [FileTreeNodeIndex: FileNodeRecord]
+        let reorderedChildren: [FileTreeNodeIndex: [FileTreeNodeIndex]]
+    }
+
+    private enum ChildIndexCollection: RandomAccessCollection, Sendable {
+        typealias Index = Int
+
+        case backing(ArraySlice<FileTreeNodeIndex>)
+        case replacement([FileTreeNodeIndex])
+
+        var startIndex: Int { 0 }
+
+        var endIndex: Int {
+            switch self {
+            case .backing(let indices): indices.count
+            case .replacement(let indices): indices.count
+            }
+        }
+
+        subscript(position: Int) -> FileTreeNodeIndex {
+            switch self {
+            case .backing(let indices):
+                indices[indices.index(indices.startIndex, offsetBy: position)]
+            case .replacement(let indices):
+                indices[position]
+            }
+        }
+    }
+
     let contentID: UUID
     let rootID: String
     private let nodeRecords: [FileNodeRecord]
     private let topologyArena: FileTreeTopologyArena
     private let precomputedAggregateStats: ScanAggregateStats?
+    private let logicalScope: LogicalScope?
+
+    private nonisolated var activeRootIndex: FileTreeNodeIndex {
+        logicalScope?.rootIndex ?? topologyArena.rootIndex
+    }
+
+    private nonisolated var activeOrderedNodeIndices: [FileTreeNodeIndex] {
+        logicalScope?.orderedNodeIndices ?? topologyArena.orderedNodeIndices
+    }
+
+    private nonisolated func contains(_ index: FileTreeNodeIndex) -> Bool {
+        logicalScope?.membership.contains(index)
+            ?? nodeRecords.indices.contains(Int(index.rawValue))
+    }
+
+    private nonisolated func activeChildren(
+        of index: FileTreeNodeIndex
+    ) -> ChildIndexCollection {
+        guard contains(index) else { return .replacement([]) }
+        if let children = logicalScope?.reorderedChildren[index] {
+            return .replacement(children)
+        }
+        return .backing(topologyArena.children(of: index))
+    }
+
+    private nonisolated func activeParentIndex(
+        of index: FileTreeNodeIndex
+    ) -> FileTreeNodeIndex? {
+        guard contains(index), index != activeRootIndex,
+              let parentIndex = topologyArena.parentIndex(of: index),
+              contains(parentIndex) else {
+            return nil
+        }
+        return parentIndex
+    }
 
     nonisolated var nodesByID: [String: FileNodeRecord] {
-        Dictionary(uniqueKeysWithValues: nodeRecords.map { ($0.id, $0) })
+        Dictionary(uniqueKeysWithValues: activeOrderedNodeIndices.compactMap { index in
+            node(at: index).map { ($0.id, $0) }
+        })
     }
 
     nonisolated var childIDsByID: [String: [String]] {
         var result: [String: [String]] = [:]
-        for parentIndex in topologyArena.orderedNodeIndices {
-            let children = topologyArena.children(of: parentIndex)
+        for parentIndex in activeOrderedNodeIndices {
+            let children = activeChildren(of: parentIndex)
             guard !children.isEmpty,
                   let parent = self.node(at: parentIndex) else {
                 continue
@@ -366,8 +456,8 @@ nonisolated struct FileTreeStore: Sendable {
     nonisolated var parentIDByID: [String: String] {
         var result: [String: String] = [:]
         result.reserveCapacity(max(nodeCount - 1, 0))
-        for nodeIndex in topologyArena.orderedNodeIndices {
-            guard let parentIndex = topologyArena.parentIndex(of: nodeIndex),
+        for nodeIndex in activeOrderedNodeIndices {
+            guard let parentIndex = activeParentIndex(of: nodeIndex),
                   let record = node(at: nodeIndex),
                   let parent = node(at: parentIndex) else {
                 continue
@@ -467,17 +557,20 @@ nonisolated struct FileTreeStore: Sendable {
     }
 
     nonisolated var root: FileNodeRecord {
-        guard let root = node(at: topologyArena.rootIndex) else {
+        guard let root = node(at: activeRootIndex) else {
             preconditionFailure("FileTreeStore rootID does not exist in nodesByID.")
         }
         return root
     }
 
     nonisolated var nodeCount: Int {
-        nodeRecords.count
+        logicalScope?.orderedNodeIndices.count ?? nodeRecords.count
     }
 
     nonisolated var aggregateStats: ScanAggregateStats {
+        if let logicalScope {
+            return logicalScope.aggregateStats
+        }
         if let precomputedAggregateStats {
             return precomputedAggregateStats
         }
@@ -488,11 +581,11 @@ nonisolated struct FileTreeStore: Sendable {
     private nonisolated func computedAggregateStats() -> ScanAggregateStats {
         var accumulator = AggregateStatsAccumulator()
 
-        for nodeIndex in topologyArena.orderedNodeIndices {
+        for nodeIndex in activeOrderedNodeIndices {
             guard let node = node(at: nodeIndex) else { continue }
             accumulator.include(
                 node,
-                hasMaterializedChildren: !topologyArena.children(of: nodeIndex).isEmpty
+                hasMaterializedChildren: !activeChildren(of: nodeIndex).isEmpty
             )
         }
 
@@ -569,6 +662,7 @@ nonisolated struct FileTreeStore: Sendable {
             orderedNodeIDs: topology.orderedNodeIDs
         )
         self.precomputedAggregateStats = topology.didDropReferences ? nil : aggregateStats
+        self.logicalScope = nil
     }
 
     nonisolated init(
@@ -612,6 +706,7 @@ nonisolated struct FileTreeStore: Sendable {
         )
         self.nodeRecords = orderedNodeIDs.compactMap { nodesByID[$0] }
         self.precomputedAggregateStats = aggregateStats
+        self.logicalScope = nil
         assert(orderedNodeIDs.count == nodesByID.count)
         assert(parentIDByID == self.parentIDByID)
     }
@@ -778,19 +873,22 @@ nonisolated struct FileTreeStore: Sendable {
         self.nodeRecords = nodes
         self.topologyArena = topologyArena
         self.precomputedAggregateStats = statsAccumulator.stats(root: nodes[rootOffset])
+        self.logicalScope = nil
     }
 
     private nonisolated init(
         rootID: String,
         nodeRecords: [FileNodeRecord],
         topologyArena: FileTreeTopologyArena,
-        aggregateStats: ScanAggregateStats
+        aggregateStats: ScanAggregateStats,
+        logicalScope: LogicalScope? = nil
     ) {
         self.contentID = UUID()
         self.rootID = rootID
         self.nodeRecords = nodeRecords
         self.topologyArena = topologyArena
         self.precomputedAggregateStats = aggregateStats
+        self.logicalScope = logicalScope
     }
 
     nonisolated static func sortedChildren(_ children: [FileNodeRecord]) -> [FileNodeRecord] {
@@ -886,6 +984,21 @@ nonisolated struct FileTreeStore: Sendable {
         cancellationCheck: () throws -> Void
     ) throws -> [FileTreeNodeIndex]
     where Children: Collection, Children.Element == FileTreeNodeIndex {
+        try restoringDisplayOrderAfterChanges(
+            childIndices,
+            isChanged: { changedByOffset[Int($0.rawValue)] },
+            nodeAt: nodeAt,
+            cancellationCheck: cancellationCheck
+        )
+    }
+
+    private nonisolated static func restoringDisplayOrderAfterChanges<Children>(
+        _ childIndices: Children,
+        isChanged: (FileTreeNodeIndex) -> Bool,
+        nodeAt: (FileTreeNodeIndex) -> FileNodeRecord,
+        cancellationCheck: () throws -> Void
+    ) throws -> [FileTreeNodeIndex]
+    where Children: Collection, Children.Element == FileTreeNodeIndex {
         func copiedChildren() throws -> [FileTreeNodeIndex] {
             var result: [FileTreeNodeIndex] = []
             result.reserveCapacity(childIndices.count)
@@ -904,7 +1017,7 @@ nonisolated struct FileTreeStore: Sendable {
             if position.isMultiple(of: 256) {
                 try cancellationCheck()
             }
-            if changedByOffset[Int(childIndex.rawValue)] {
+            if isChanged(childIndex) {
                 firstChangedPosition = firstChangedPosition ?? position
                 changedCount += 1
             }
@@ -951,7 +1064,7 @@ nonisolated struct FileTreeStore: Sendable {
                 try cancellationCheck()
             }
             let entry = (nodeIndex: childIndex, originalPosition: position)
-            if changedByOffset[Int(childIndex.rawValue)] {
+            if isChanged(childIndex) {
                 changedChildren.append(entry)
             } else {
                 unchangedChildren.append(entry)
@@ -1014,14 +1127,18 @@ nonisolated struct FileTreeStore: Sendable {
     }
 
     nonisolated func nodeIndex(id: String?) -> FileTreeNodeIndex? {
-        guard let id else { return nil }
-        return topologyArena.indexByNodeID[id]
+        guard let id,
+              let index = topologyArena.indexByNodeID[id],
+              contains(index) else {
+            return nil
+        }
+        return index
     }
 
     nonisolated func node(at index: FileTreeNodeIndex) -> FileNodeRecord? {
         let offset = Int(index.rawValue)
-        guard nodeRecords.indices.contains(offset) else { return nil }
-        return nodeRecords[offset]
+        guard nodeRecords.indices.contains(offset), contains(index) else { return nil }
+        return logicalScope?.replacementRecords[index] ?? nodeRecords[offset]
     }
 
     /// Replaces existing records while preserving node membership and parent links.
@@ -1309,16 +1426,17 @@ nonisolated struct FileTreeStore: Sendable {
     }
 
     nonisolated func parentIndex(of index: FileTreeNodeIndex) -> FileTreeNodeIndex? {
-        topologyArena.parentIndex(of: index)
+        activeParentIndex(of: index)
     }
 
     nonisolated func childIndices(of index: FileTreeNodeIndex) -> [FileTreeNodeIndex] {
-        Array(topologyArena.children(of: index))
+        guard contains(index) else { return [] }
+        return Array(activeChildren(of: index))
     }
 
     nonisolated func parentID(of id: String?) -> String? {
         guard let index = nodeIndex(id: id),
-              let parentIndex = topologyArena.parentIndex(of: index) else {
+              let parentIndex = activeParentIndex(of: index) else {
             return nil
         }
         return node(at: parentIndex)?.id
@@ -1327,12 +1445,12 @@ nonisolated struct FileTreeStore: Sendable {
     nonisolated func childIDs(of id: String?) -> [String] {
         let resolvedID = id ?? rootID
         guard let parentIndex = nodeIndex(id: resolvedID) else { return [] }
-        return topologyArena.children(of: parentIndex).compactMap { node(at: $0)?.id }
+        return activeChildren(of: parentIndex).compactMap { node(at: $0)?.id }
     }
 
     nonisolated func parent(of id: String?) -> FileNodeRecord? {
         guard let index = nodeIndex(id: id),
-              let parentIndex = topologyArena.parentIndex(of: index) else {
+              let parentIndex = activeParentIndex(of: index) else {
             return nil
         }
         return node(at: parentIndex)
@@ -1352,7 +1470,7 @@ nonisolated struct FileTreeStore: Sendable {
     ) throws -> [FileNodeRecord] {
         let resolvedID = id ?? rootID
         guard let parentIndex = nodeIndex(id: resolvedID) else { return [] }
-        let childIndices = topologyArena.children(of: parentIndex)
+        let childIndices = activeChildren(of: parentIndex)
 
         var children: [FileNodeRecord] = []
         children.reserveCapacity(childIndices.count)
@@ -1374,7 +1492,7 @@ nonisolated struct FileTreeStore: Sendable {
 
         let resolvedID = id ?? rootID
         guard let parentIndex = nodeIndex(id: resolvedID) else { return [] }
-        let childIndices = topologyArena.children(of: parentIndex)
+        let childIndices = activeChildren(of: parentIndex)
 
         var children: [FileNodeRecord] = []
         children.reserveCapacity(min(maxCount, childIndices.count))
@@ -1393,13 +1511,13 @@ nonisolated struct FileTreeStore: Sendable {
     nonisolated func containsChildren(id: String?) -> Bool {
         let resolvedID = id ?? rootID
         guard let index = nodeIndex(id: resolvedID) else { return false }
-        return !topologyArena.children(of: index).isEmpty
+        return !activeChildren(of: index).isEmpty
     }
 
     nonisolated func childCount(of id: String?) -> Int {
         let resolvedID = id ?? rootID
         guard let index = nodeIndex(id: resolvedID) else { return 0 }
-        return topologyArena.children(of: index).count
+        return activeChildren(of: index).count
     }
 
     nonisolated func subtreeNodeCount(rootedAt nodeID: String) -> Int {
@@ -1408,28 +1526,28 @@ nonisolated struct FileTreeStore: Sendable {
         var stack = [rootIndex]
         while let nodeIndex = stack.popLast() {
             count += 1
-            stack.append(contentsOf: topologyArena.children(of: nodeIndex))
+            stack.append(contentsOf: activeChildren(of: nodeIndex))
         }
         return count
     }
 
     nonisolated func indexedNodeIDs(excludingRoot: Bool = false) -> [String] {
-        topologyArena.orderedNodeIndices.compactMap { nodeIndex in
-            guard !excludingRoot || nodeIndex != topologyArena.rootIndex else { return nil }
+        activeOrderedNodeIndices.compactMap { nodeIndex in
+            guard !excludingRoot || nodeIndex != activeRootIndex else { return nil }
             return node(at: nodeIndex)?.id
         }
     }
 
     nonisolated func indexedNodeIndices() -> [FileTreeNodeIndex] {
-        topologyArena.orderedNodeIndices
+        activeOrderedNodeIndices
     }
 
     nonisolated func forEachIndexedNodeID(
         excludingRoot: Bool = false,
         _ body: (String) throws -> Void
     ) rethrows {
-        for nodeIndex in topologyArena.orderedNodeIndices {
-            if excludingRoot && nodeIndex == topologyArena.rootIndex {
+        for nodeIndex in activeOrderedNodeIndices {
+            if excludingRoot && nodeIndex == activeRootIndex {
                 continue
             }
             if let nodeID = node(at: nodeIndex)?.id {
@@ -1445,7 +1563,7 @@ nonisolated struct FileTreeStore: Sendable {
 
         var result: [FileNodeRecord] = [record]
         var cursor = index
-        while let parentIndex = topologyArena.parentIndex(of: cursor),
+        while let parentIndex = activeParentIndex(of: cursor),
               let parent = self.node(at: parentIndex) {
             result.append(parent)
             cursor = parentIndex
@@ -1463,7 +1581,7 @@ nonisolated struct FileTreeStore: Sendable {
             if cursor == ancestorIndex {
                 return true
             }
-            guard let parentIndex = topologyArena.parentIndex(of: cursor) else { return false }
+            guard let parentIndex = activeParentIndex(of: cursor) else { return false }
             cursor = parentIndex
         }
     }
@@ -1474,7 +1592,7 @@ nonisolated struct FileTreeStore: Sendable {
 
     nonisolated func preparedNodeSet(for nodeIDs: Set<String>) -> PreparedFileTreeNodeSet {
         PreparedFileTreeNodeSet(
-            indices: Set(nodeIDs.compactMap { topologyArena.indexByNodeID[$0] })
+            indices: Set(nodeIDs.compactMap { nodeIndex(id: $0) })
         )
     }
 
@@ -1491,7 +1609,7 @@ nonisolated struct FileTreeStore: Sendable {
         of nodeIndex: FileTreeNodeIndex
     ) -> Bool {
         var cursor = nodeIndex
-        while let parentIndex = topologyArena.parentIndex(of: cursor) {
+        while let parentIndex = activeParentIndex(of: cursor) {
             if ancestorIndices.contains(parentIndex) {
                 return true
             }
@@ -2147,6 +2265,153 @@ nonisolated struct FileTreeStore: Sendable {
         return accumulator.stats(root: root)
     }
 
+    /// Creates an immutable view rooted inside the same compact backing store.
+    /// Node and topology buffers remain shared; only membership, traversal order,
+    /// and sparse shared-allocation corrections belong to the logical scope.
+    nonisolated func logicalScope(rootedAt targetID: String) -> FileTreeStore? {
+        try? logicalScope(rootedAt: targetID, cancellationCheck: {})
+    }
+
+    nonisolated func logicalScope(
+        rootedAt targetID: String,
+        cancellationCheck: () throws -> Void
+    ) throws -> FileTreeStore? {
+        try cancellationCheck()
+        guard let targetIndex = nodeIndex(id: targetID) else { return nil }
+
+        var membership = NodeMembership(nodeCapacity: nodeRecords.count)
+        var orderedNodeIndices: [FileTreeNodeIndex] = []
+        let targetRecord = nodeRecords[Int(targetIndex.rawValue)]
+        if !topologyArena.children(of: targetIndex).isEmpty {
+            orderedNodeIndices.reserveCapacity(min(
+                nodeRecords.count,
+                Self.saturatingAdd(targetRecord.descendantFileCount, 1)
+            ))
+        }
+        var statsAccumulator = AggregateStatsAccumulator()
+        var hardLinkAccumulator = HardLinkIdentityOwnerAccumulator()
+        var hardLinkClaimIndices: [FileTreeNodeIndex] = []
+        var stack = [targetIndex]
+
+        while let nodeIndex = stack.popLast() {
+            if orderedNodeIndices.count.isMultiple(of: 256) {
+                try cancellationCheck()
+            }
+            let node = nodeRecords[Int(nodeIndex.rawValue)]
+            let children = topologyArena.children(of: nodeIndex)
+            membership.insert(nodeIndex)
+            orderedNodeIndices.append(nodeIndex)
+            statsAccumulator.include(node, hasMaterializedChildren: !children.isEmpty)
+            if let claim = HardLinkDeduplicator.claim(for: node) {
+                hardLinkAccumulator.record(claim)
+                hardLinkClaimIndices.append(nodeIndex)
+            }
+            for (offset, childIndex) in children.reversed().enumerated() {
+                if offset.isMultiple(of: 256) {
+                    try cancellationCheck()
+                }
+                stack.append(childIndex)
+            }
+        }
+
+        let allocationReplacements = try HardLinkDeduplicator.rebalancedAllocatedSizeReplacements(
+            hardLinkAccumulator: hardLinkAccumulator,
+            claimNodeIndices: hardLinkClaimIndices,
+            nodeAt: { nodeRecords[Int($0.rawValue)] },
+            cancellationCheck: cancellationCheck
+        )
+        var replacementRecords: [FileTreeNodeIndex: FileNodeRecord] = [:]
+        replacementRecords.reserveCapacity(allocationReplacements.count)
+        var changedRecordIndices = Set<FileTreeNodeIndex>()
+        changedRecordIndices.reserveCapacity(allocationReplacements.count)
+        var affectedDirectoryIndices = Set<FileTreeNodeIndex>()
+
+        for replacement in allocationReplacements {
+            try cancellationCheck()
+            let source = nodeRecords[Int(replacement.nodeIndex.rawValue)]
+            replacementRecords[replacement.nodeIndex] = source.replacingAllocatedSize(
+                replacement.allocatedSize
+            )
+            changedRecordIndices.insert(replacement.nodeIndex)
+
+            var ancestorIndex = topologyArena.parentIndex(of: replacement.nodeIndex)
+            while let currentIndex = ancestorIndex, membership.contains(currentIndex) {
+                try cancellationCheck()
+                affectedDirectoryIndices.insert(currentIndex)
+                guard currentIndex != targetIndex else { break }
+                ancestorIndex = topologyArena.parentIndex(of: currentIndex)
+            }
+        }
+
+        var reorderedChildren: [FileTreeNodeIndex: [FileTreeNodeIndex]] = [:]
+        reorderedChildren.reserveCapacity(affectedDirectoryIndices.count)
+        for directoryIndex in orderedNodeIndices.reversed()
+        where affectedDirectoryIndices.contains(directoryIndex) {
+            try cancellationCheck()
+            let sourceChildren = topologyArena.children(of: directoryIndex)
+            let children = try Self.restoringDisplayOrderAfterChanges(
+                sourceChildren,
+                isChanged: { changedRecordIndices.contains($0) },
+                nodeAt: { index in
+                    replacementRecords[index] ?? nodeRecords[Int(index.rawValue)]
+                },
+                cancellationCheck: cancellationCheck
+            )
+
+            var totals = MaterializedDirectoryTotals()
+            for (offset, childIndex) in children.enumerated() {
+                if offset.isMultiple(of: 256) {
+                    try cancellationCheck()
+                }
+                totals.include(replacementRecords[childIndex] ?? nodeRecords[Int(childIndex.rawValue)])
+            }
+
+            let source = nodeRecords[Int(directoryIndex.rawValue)]
+            let repaired = Self.repairingDirectoryRecord(source, totals: totals)
+            if repaired != source {
+                replacementRecords[directoryIndex] = repaired
+                changedRecordIndices.insert(directoryIndex)
+            }
+            if !children.elementsEqual(sourceChildren) {
+                reorderedChildren[directoryIndex] = children
+            }
+        }
+
+        if !reorderedChildren.isEmpty {
+            orderedNodeIndices.removeAll(keepingCapacity: true)
+            stack = [targetIndex]
+            while let nodeIndex = stack.popLast() {
+                if orderedNodeIndices.count.isMultiple(of: 256) {
+                    try cancellationCheck()
+                }
+                orderedNodeIndices.append(nodeIndex)
+                if let children = reorderedChildren[nodeIndex] {
+                    stack.append(contentsOf: children.reversed())
+                } else {
+                    stack.append(contentsOf: topologyArena.children(of: nodeIndex).reversed())
+                }
+            }
+        }
+
+        let scopedRoot = replacementRecords[targetIndex]
+            ?? nodeRecords[Int(targetIndex.rawValue)]
+        let scope = LogicalScope(
+            rootIndex: targetIndex,
+            membership: membership,
+            orderedNodeIndices: orderedNodeIndices,
+            aggregateStats: statsAccumulator.stats(root: scopedRoot),
+            replacementRecords: replacementRecords,
+            reorderedChildren: reorderedChildren
+        )
+        return FileTreeStore(
+            rootID: targetID,
+            nodeRecords: nodeRecords,
+            topologyArena: topologyArena,
+            aggregateStats: scope.aggregateStats,
+            logicalScope: scope
+        )
+    }
+
     nonisolated func subtree(rootedAt targetID: String) -> FileTreeStore? {
         try? subtree(rootedAt: targetID, cancellationCheck: {})
     }
@@ -2265,7 +2530,7 @@ nonisolated struct FileTreeStore: Sendable {
             let currentID = record.id
             scopedNodes[currentID] = record
 
-            let childIndices = topologyArena.children(of: currentIndex)
+            let childIndices = activeChildren(of: currentIndex)
             guard !childIndices.isEmpty else { continue }
 
             var scopedChildren: [String] = []
@@ -2308,7 +2573,7 @@ nonisolated struct FileTreeStore: Sendable {
             try cancellationCheck()
             guard let currentID = node(at: currentIndex)?.id else { continue }
             result.append(currentID)
-            stack.append(contentsOf: topologyArena.children(of: currentIndex))
+            stack.append(contentsOf: activeChildren(of: currentIndex))
         }
 
         return result

--- a/Radix/Models/FileTreeStore.swift
+++ b/Radix/Models/FileTreeStore.swift
@@ -409,15 +409,25 @@ nonisolated struct FileTreeStore: Sendable {
     }
 
     private nonisolated func contains(_ index: FileTreeNodeIndex) -> Bool {
-        logicalScope?.membership.contains(index)
-            ?? nodeRecords.indices.contains(Int(index.rawValue))
+        guard let logicalScope else {
+            return nodeRecords.indices.contains(Int(index.rawValue))
+        }
+        return logicalScope.membership.contains(index)
     }
 
     private nonisolated func activeChildren(
         of index: FileTreeNodeIndex
     ) -> ChildIndexCollection {
-        guard contains(index) else { return .replacement([]) }
-        if let children = logicalScope?.reorderedChildren[index] {
+        guard let logicalScope else {
+            guard nodeRecords.indices.contains(Int(index.rawValue)) else {
+                return .replacement([])
+            }
+            return .backing(topologyArena.children(of: index))
+        }
+        guard logicalScope.membership.contains(index) else {
+            return .replacement([])
+        }
+        if let children = logicalScope.reorderedChildren[index] {
             return .replacement(children)
         }
         return .backing(topologyArena.children(of: index))
@@ -426,9 +436,17 @@ nonisolated struct FileTreeStore: Sendable {
     private nonisolated func activeParentIndex(
         of index: FileTreeNodeIndex
     ) -> FileTreeNodeIndex? {
-        guard contains(index), index != activeRootIndex,
+        guard let logicalScope else {
+            guard nodeRecords.indices.contains(Int(index.rawValue)),
+                  index != topologyArena.rootIndex else {
+                return nil
+            }
+            return topologyArena.parentIndex(of: index)
+        }
+        guard logicalScope.membership.contains(index),
+              index != logicalScope.rootIndex,
               let parentIndex = topologyArena.parentIndex(of: index),
-              contains(parentIndex) else {
+              logicalScope.membership.contains(parentIndex) else {
             return nil
         }
         return parentIndex
@@ -1132,17 +1150,20 @@ nonisolated struct FileTreeStore: Sendable {
 
     nonisolated func nodeIndex(id: String?) -> FileTreeNodeIndex? {
         guard let id,
-              let index = topologyArena.indexByNodeID[id],
-              contains(index) else {
+              let index = topologyArena.indexByNodeID[id] else {
             return nil
         }
+        guard let logicalScope else { return index }
+        guard logicalScope.membership.contains(index) else { return nil }
         return index
     }
 
     nonisolated func node(at index: FileTreeNodeIndex) -> FileNodeRecord? {
         let offset = Int(index.rawValue)
-        guard nodeRecords.indices.contains(offset), contains(index) else { return nil }
-        return logicalScope?.replacementRecords[index] ?? nodeRecords[offset]
+        guard nodeRecords.indices.contains(offset) else { return nil }
+        guard let logicalScope else { return nodeRecords[offset] }
+        guard logicalScope.membership.contains(index) else { return nil }
+        return logicalScope.replacementRecords[index] ?? nodeRecords[offset]
     }
 
     /// Replaces existing records while preserving node membership and parent links.
@@ -1513,6 +1534,16 @@ nonisolated struct FileTreeStore: Sendable {
     ) throws -> [FileNodeRecord] {
         let resolvedID = id ?? rootID
         guard let parentIndex = nodeIndex(id: resolvedID) else { return [] }
+        if logicalScope == nil {
+            let childIndices = topologyArena.children(of: parentIndex)
+            var children: [FileNodeRecord] = []
+            children.reserveCapacity(childIndices.count)
+            for childIndex in childIndices {
+                try cancellationCheck()
+                children.append(nodeRecords[Int(childIndex.rawValue)])
+            }
+            return children
+        }
         let childIndices = activeChildren(of: parentIndex)
 
         var children: [FileNodeRecord] = []
@@ -1535,6 +1566,16 @@ nonisolated struct FileTreeStore: Sendable {
 
         let resolvedID = id ?? rootID
         guard let parentIndex = nodeIndex(id: resolvedID) else { return [] }
+        if logicalScope == nil {
+            let childIndices = topologyArena.children(of: parentIndex)
+            var children: [FileNodeRecord] = []
+            children.reserveCapacity(min(maxCount, childIndices.count))
+            for childIndex in childIndices.prefix(maxCount) {
+                try cancellationCheck()
+                children.append(nodeRecords[Int(childIndex.rawValue)])
+            }
+            return children
+        }
         let childIndices = activeChildren(of: parentIndex)
 
         var children: [FileNodeRecord] = []

--- a/Radix/Models/FileTreeStore.swift
+++ b/Radix/Models/FileTreeStore.swift
@@ -347,9 +347,14 @@ nonisolated struct FileTreeStore: Sendable {
             words = Array(repeating: 0, count: (nodeCapacity + 63) / 64)
         }
 
-        mutating func insert(_ index: FileTreeNodeIndex) {
+        @discardableResult
+        mutating func insert(_ index: FileTreeNodeIndex) -> Bool {
             let offset = Int(index.rawValue)
-            words[offset >> 6] |= UInt64(1) << UInt64(offset & 63)
+            let wordIndex = offset >> 6
+            let mask = UInt64(1) << UInt64(offset & 63)
+            let inserted = words[wordIndex] & mask == 0
+            words[wordIndex] |= mask
+            return inserted
         }
 
         func contains(_ index: FileTreeNodeIndex) -> Bool {
@@ -1747,13 +1752,14 @@ nonisolated struct FileTreeStore: Sendable {
         if removalIDs.contains(rootID) {
             return FileTreeStore(root: emptyRootNode())
         }
+        let removalRootIndices = removalIDs.compactMap { nodeIndex(id: $0) }
         if logicalScope != nil {
-            return try materialized(cancellationCheck: cancellationCheck).removingSubtrees(
-                rootedAt: removalIDs,
+            return try compactedSubtree(
+                rootedAt: activeRootIndex,
+                excludingSubtreesAt: removalRootIndices,
                 cancellationCheck: cancellationCheck
             )
         }
-        let removalRootIndices = removalIDs.compactMap { nodeIndex(id: $0) }
         return try compactedStore(
             removingSubtreesAt: removalRootIndices,
             cancellationCheck: cancellationCheck
@@ -1774,8 +1780,9 @@ nonisolated struct FileTreeStore: Sendable {
             return nil
         }
         if logicalScope != nil {
-            return try materialized(cancellationCheck: cancellationCheck).removingSubtree(
-                id: targetID,
+            return try compactedSubtree(
+                rootedAt: activeRootIndex,
+                excludingSubtreesAt: [targetIndex],
                 cancellationCheck: cancellationCheck
             )
         }
@@ -2548,20 +2555,59 @@ nonisolated struct FileTreeStore: Sendable {
     ) throws -> FileTreeStore? {
         try cancellationCheck()
         guard let targetIndex = nodeIndex(id: targetID) else { return nil }
+        return try compactedSubtree(
+            rootedAt: targetIndex,
+            excludingSubtreesAt: [],
+            cancellationCheck: cancellationCheck
+        )
+    }
+
+    private nonisolated func compactedSubtree(
+        rootedAt targetIndex: FileTreeNodeIndex,
+        excludingSubtreesAt excludedRootIndices: [FileTreeNodeIndex],
+        cancellationCheck: () throws -> Void
+    ) throws -> FileTreeStore {
+        let excludesSubtrees = !excludedRootIndices.isEmpty
+        var excludedMembership: NodeMembership?
+        var affectedAncestorMembership: NodeMembership?
+        var affectedAncestorCount = 0
+        if excludesSubtrees {
+            var excluded = NodeMembership(nodeCapacity: nodeRecords.count)
+            var affected = NodeMembership(nodeCapacity: nodeRecords.count)
+            for excludedRootIndex in excludedRootIndices {
+                excluded.insert(excludedRootIndex)
+                var cursor = topologyArena.parentIndex(of: excludedRootIndex)
+                while let ancestorIndex = cursor {
+                    try cancellationCheck()
+                    if affected.insert(ancestorIndex) {
+                        affectedAncestorCount += 1
+                    }
+                    guard ancestorIndex != targetIndex else { break }
+                    cursor = topologyArena.parentIndex(of: ancestorIndex)
+                }
+            }
+            excludedMembership = excluded
+            affectedAncestorMembership = affected
+        }
 
         var scopedNodes: [FileNodeRecord] = []
         var parentRawIndices: [UInt32] = []
         var orderedNodeIndices: [FileTreeNodeIndex] = []
+        var affectedScopedIndices: [FileTreeNodeIndex] = []
         var statsAccumulator = AggregateStatsAccumulator()
         var hardLinkAccumulator = HardLinkIdentityOwnerAccumulator()
         var hardLinkClaimIndices: [FileTreeNodeIndex] = []
         var stack = [(sourceIndex: targetIndex, scopedParentRawIndex: UInt32.max)]
+        affectedScopedIndices.reserveCapacity(affectedAncestorCount)
 
         while let entry = stack.popLast() {
             if scopedNodes.count.isMultiple(of: 256) {
                 try cancellationCheck()
             }
             let sourceIndex = entry.sourceIndex
+            if excludedMembership?.contains(sourceIndex) == true {
+                continue
+            }
             let sourceOffset = Int(sourceIndex.rawValue)
             let scopedIndex = FileTreeNodeIndex(rawValue: UInt32(scopedNodes.count))
             let node = nodeRecords[sourceOffset]
@@ -2569,6 +2615,9 @@ nonisolated struct FileTreeStore: Sendable {
             scopedNodes.append(node)
             parentRawIndices.append(entry.scopedParentRawIndex)
             orderedNodeIndices.append(scopedIndex)
+            if affectedAncestorMembership?.contains(sourceIndex) == true {
+                affectedScopedIndices.append(scopedIndex)
+            }
             statsAccumulator.include(node, hasMaterializedChildren: !sourceChildren.isEmpty)
             if let claim = HardLinkDeduplicator.claim(for: node) {
                 hardLinkAccumulator.record(claim)
@@ -2615,6 +2664,31 @@ nonisolated struct FileTreeStore: Sendable {
             let childRawOffset = nextChildRawOffset[parentOffset]
             childIndices[Int(childRawOffset)] = FileTreeNodeIndex(rawValue: UInt32(scopedOffset))
             nextChildRawOffset[parentOffset] += 1
+        }
+
+        if !affectedScopedIndices.isEmpty {
+            let affectedScopedIndexSet = Set(affectedScopedIndices)
+            for scopedIndex in affectedScopedIndices.reversed() {
+                try cancellationCheck()
+                let scopedOffset = Int(scopedIndex.rawValue)
+                guard scopedNodes[scopedOffset].isDirectory else { continue }
+
+                let span = childSpans[scopedOffset]
+                let childStart = Int(span.start)
+                let childEnd = childStart + Int(span.count)
+                let reorderedChildren = try Self.restoringDisplayOrderAfterChanges(
+                    childIndices[childStart..<childEnd],
+                    isChanged: { affectedScopedIndexSet.contains($0) },
+                    nodeAt: { scopedNodes[Int($0.rawValue)] },
+                    cancellationCheck: cancellationCheck
+                )
+                childIndices.replaceSubrange(childStart..<childEnd, with: reorderedChildren)
+                let children = reorderedChildren.map { scopedNodes[Int($0.rawValue)] }
+                scopedNodes[scopedOffset] = Self.repairingDirectoryRecord(
+                    scopedNodes[scopedOffset],
+                    children: children
+                )
+            }
         }
 
         let scopedRootIndex = FileTreeNodeIndex(rawValue: 0)

--- a/Radix/Models/FileTreeStore.swift
+++ b/Radix/Models/FileTreeStore.swift
@@ -567,6 +567,10 @@ nonisolated struct FileTreeStore: Sendable {
         logicalScope?.orderedNodeIndices.count ?? nodeRecords.count
     }
 
+    nonisolated var backingNodeCapacity: Int {
+        nodeRecords.count
+    }
+
     nonisolated var aggregateStats: ScanAggregateStats {
         if let logicalScope {
             return logicalScope.aggregateStats
@@ -1153,6 +1157,14 @@ nonisolated struct FileTreeStore: Sendable {
               let parentIndex = nodeIndex(id: parentID) else {
             return nil
         }
+        if logicalScope != nil {
+            return try? materialized(cancellationCheck: {}).replacingRecordsPreservingTopology(
+                replacements,
+                orderedChildIDs: orderedChildIDs,
+                of: parentID,
+                aggregateStats: aggregateStats
+            )
+        }
 
         var indexedReplacements: [(Int, FileNodeRecord)] = []
         indexedReplacements.reserveCapacity(replacements.count)
@@ -1200,6 +1212,15 @@ nonisolated struct FileTreeStore: Sendable {
         guard replacementRoot.id == rootID,
               let oldRootIndex = nodeIndex(id: rootID) else {
             return nil
+        }
+        if logicalScope != nil {
+            return try? materialized(cancellationCheck: {}).replacingRootLeaf(
+                removing: removedLeafID,
+                adding: addedLeaf,
+                root: replacementRoot,
+                orderedChildIDs: orderedChildIDs,
+                aggregateStats: aggregateStats
+            )
         }
 
         let oldRootChildren = topologyArena.children(of: oldRootIndex)
@@ -1304,6 +1325,28 @@ nonisolated struct FileTreeStore: Sendable {
         cancellationCheck: () throws -> Void
     ) throws -> FileTreeStore {
         guard !replacements.isEmpty else { return self }
+        if logicalScope != nil {
+            var replacementsByID: [(String, Int64)] = []
+            replacementsByID.reserveCapacity(replacements.count)
+            for replacement in replacements {
+                try cancellationCheck()
+                guard let nodeID = node(at: replacement.nodeIndex)?.id else {
+                    preconditionFailure("Allocated-size replacement index is out of range.")
+                }
+                replacementsByID.append((nodeID, replacement.allocatedSize))
+            }
+            let materializedStore = try materialized(cancellationCheck: cancellationCheck)
+            let remappedReplacements = replacementsByID.map { nodeID, allocatedSize in
+                guard let nodeIndex = materializedStore.nodeIndex(id: nodeID) else {
+                    preconditionFailure("Materialized scope is missing an allocated-size replacement.")
+                }
+                return (nodeIndex: nodeIndex, allocatedSize: allocatedSize)
+            }
+            return try materializedStore.replacingAllocatedSizes(
+                remappedReplacements,
+                cancellationCheck: cancellationCheck
+            )
+        }
 
         var updatedRecords = nodeRecords
         var updatedChildIndices = topologyArena.childIndices
@@ -1663,6 +1706,12 @@ nonisolated struct FileTreeStore: Sendable {
         if removalIDs.contains(rootID) {
             return FileTreeStore(root: emptyRootNode())
         }
+        if logicalScope != nil {
+            return try materialized(cancellationCheck: cancellationCheck).removingSubtrees(
+                rootedAt: removalIDs,
+                cancellationCheck: cancellationCheck
+            )
+        }
         let removalRootIndices = removalIDs.compactMap { nodeIndex(id: $0) }
         return try compactedStore(
             removingSubtreesAt: removalRootIndices,
@@ -1682,6 +1731,12 @@ nonisolated struct FileTreeStore: Sendable {
         guard let targetIndex = nodeIndex(id: targetID),
               parentIndex(of: targetIndex) != nil else {
             return nil
+        }
+        if logicalScope != nil {
+            return try materialized(cancellationCheck: cancellationCheck).removingSubtree(
+                id: targetID,
+                cancellationCheck: cancellationCheck
+            )
         }
         return try compactedStore(
             removingSubtreesAt: [targetIndex],
@@ -1927,6 +1982,13 @@ nonisolated struct FileTreeStore: Sendable {
     ) throws -> FileTreeStore? {
         try cancellationCheck()
         guard nodeIndex(id: targetID) != nil else { return nil }
+        if logicalScope != nil {
+            return try materialized(cancellationCheck: cancellationCheck).replacingSubtree(
+                id: targetID,
+                with: replacement,
+                cancellationCheck: cancellationCheck
+            )
+        }
 
         let replacementNodesByID = replacement.nodesByID
         let replacementChildIDsByID = replacement.childIDsByID
@@ -2041,6 +2103,12 @@ nonisolated struct FileTreeStore: Sendable {
            replacement.rootID == rootID {
             return try HardLinkDeduplicator.rebalancedStore(
                 replacement,
+                cancellationCheck: cancellationCheck
+            )
+        }
+        if logicalScope != nil {
+            return try materialized(cancellationCheck: cancellationCheck).replacingSubtrees(
+                replacements,
                 cancellationCheck: cancellationCheck
             )
         }
@@ -2263,6 +2331,21 @@ nonisolated struct FileTreeStore: Sendable {
         }
 
         return accumulator.stats(root: root)
+    }
+
+    /// Returns an independently mutable compact store for the visible scope.
+    /// Unscoped stores already own a complete backing arena and pass through.
+    nonisolated func materialized(
+        cancellationCheck: () throws -> Void
+    ) throws -> FileTreeStore {
+        guard logicalScope != nil else { return self }
+        guard let store = try subtree(
+            rootedAt: rootID,
+            cancellationCheck: cancellationCheck
+        ) else {
+            preconditionFailure("Logical scope root is missing from its backing store.")
+        }
+        return store
     }
 
     /// Creates an immutable view rooted inside the same compact backing store.

--- a/Radix/Models/FileTreeStore.swift
+++ b/Radix/Models/FileTreeStore.swift
@@ -674,6 +674,33 @@ nonisolated struct FileTreeStore: Sendable {
         )
     }
 
+    private nonisolated init(
+        verifiedRootIndex rootIndex: FileTreeNodeIndex,
+        nodes: [FileNodeRecord],
+        parentRawIndices: [UInt32],
+        childSpans: [FileTreeChildSpan],
+        childIndices: [FileTreeNodeIndex],
+        orderedNodeIndices: [FileTreeNodeIndex],
+        aggregateStats: ScanAggregateStats
+    ) {
+        let topologyArena = FileTreeTopologyArena(
+            verifiedRootIndex: rootIndex,
+            nodes: nodes,
+            parentRawIndices: parentRawIndices,
+            childSpans: childSpans,
+            childIndices: childIndices,
+            orderedNodeIndices: orderedNodeIndices
+        )
+        let rootOffset = Int(rootIndex.rawValue)
+        precondition(nodes.indices.contains(rootOffset), "Verified FileTreeStore root is missing.")
+        self.init(
+            rootID: nodes[rootOffset].id,
+            nodeRecords: nodes,
+            topologyArena: topologyArena,
+            aggregateStats: aggregateStats
+        )
+    }
+
     /// Fast construction for scanner output with a precomputed traversal order.
     nonisolated init(
         verifiedRootIndex rootIndex: FileTreeNodeIndex,
@@ -2128,30 +2155,93 @@ nonisolated struct FileTreeStore: Sendable {
         rootedAt targetID: String,
         cancellationCheck: () throws -> Void
     ) throws -> FileTreeStore? {
-        guard let contents = try subtreeContents(
-            rootedAt: targetID,
-            cancellationCheck: cancellationCheck
-        ) else { return nil }
+        try cancellationCheck()
+        guard let targetIndex = nodeIndex(id: targetID) else { return nil }
 
-        var parentIDsByID: [String: String] = [:]
-        parentIDsByID.reserveCapacity(max(contents.nodesByID.count - 1, 0))
-        var visitedChildCount = 0
-        for (parentID, childIDs) in contents.childIDsByID {
-            for childID in childIDs {
-                if visitedChildCount.isMultiple(of: 256) {
+        var scopedNodes: [FileNodeRecord] = []
+        var parentRawIndices: [UInt32] = []
+        var orderedNodeIndices: [FileTreeNodeIndex] = []
+        var statsAccumulator = AggregateStatsAccumulator()
+        var hardLinkAccumulator = HardLinkIdentityOwnerAccumulator()
+        var hardLinkClaimIndices: [FileTreeNodeIndex] = []
+        var stack = [(sourceIndex: targetIndex, scopedParentRawIndex: UInt32.max)]
+
+        while let entry = stack.popLast() {
+            if scopedNodes.count.isMultiple(of: 256) {
+                try cancellationCheck()
+            }
+            let sourceIndex = entry.sourceIndex
+            let sourceOffset = Int(sourceIndex.rawValue)
+            let scopedIndex = FileTreeNodeIndex(rawValue: UInt32(scopedNodes.count))
+            let node = nodeRecords[sourceOffset]
+            let sourceChildren = topologyArena.children(of: sourceIndex)
+            scopedNodes.append(node)
+            parentRawIndices.append(entry.scopedParentRawIndex)
+            orderedNodeIndices.append(scopedIndex)
+            statsAccumulator.include(node, hasMaterializedChildren: !sourceChildren.isEmpty)
+            if let claim = HardLinkDeduplicator.claim(for: node) {
+                hardLinkAccumulator.record(claim)
+                hardLinkClaimIndices.append(scopedIndex)
+            }
+            for (childOffset, childIndex) in sourceChildren.reversed().enumerated() {
+                if childOffset.isMultiple(of: 256) {
                     try cancellationCheck()
                 }
-                parentIDsByID[childID] = parentID
-                visitedChildCount += 1
+                stack.append((
+                    sourceIndex: childIndex,
+                    scopedParentRawIndex: scopedIndex.rawValue
+                ))
             }
         }
+
+        var childSpans = Array(repeating: FileTreeChildSpan(), count: scopedNodes.count)
+        for (scopedOffset, parentRawIndex) in parentRawIndices.enumerated() {
+            if scopedOffset.isMultiple(of: 256) {
+                try cancellationCheck()
+            }
+            if parentRawIndex != UInt32.max {
+                childSpans[Int(parentRawIndex)].count += 1
+            }
+        }
+
+        var childCount = 0
+        for scopedOffset in childSpans.indices {
+            if scopedOffset.isMultiple(of: 256) {
+                try cancellationCheck()
+            }
+            childSpans[scopedOffset].start = UInt32(childCount)
+            childCount += Int(childSpans[scopedOffset].count)
+        }
+
+        var nextChildRawOffset = childSpans.map(\.start)
+        var childIndices = Array(repeating: FileTreeNodeIndex(rawValue: 0), count: childCount)
+        for (scopedOffset, parentRawIndex) in parentRawIndices.enumerated()
+        where parentRawIndex != UInt32.max {
+            if scopedOffset.isMultiple(of: 256) {
+                try cancellationCheck()
+            }
+            let parentOffset = Int(parentRawIndex)
+            let childRawOffset = nextChildRawOffset[parentOffset]
+            childIndices[Int(childRawOffset)] = FileTreeNodeIndex(rawValue: UInt32(scopedOffset))
+            nextChildRawOffset[parentOffset] += 1
+        }
+
+        let scopedRootIndex = FileTreeNodeIndex(rawValue: 0)
         let scopedStore = FileTreeStore(
-            rootID: targetID,
-            nodesByID: contents.nodesByID,
-            childIDsByID: contents.childIDsByID,
-            parentIDByID: parentIDsByID
+            verifiedRootIndex: scopedRootIndex,
+            nodes: scopedNodes,
+            parentRawIndices: parentRawIndices,
+            childSpans: childSpans,
+            childIndices: childIndices,
+            orderedNodeIndices: orderedNodeIndices,
+            aggregateStats: statsAccumulator.stats(root: scopedNodes[0])
         )
-        return try HardLinkDeduplicator.rebalancedStore(scopedStore, cancellationCheck: cancellationCheck)
+        return try HardLinkDeduplicator.rebalancedStore(
+            scopedStore,
+            hardLinkAccumulator: hardLinkAccumulator,
+            claimNodeIndices: hardLinkClaimIndices,
+            cancellationCheck: cancellationCheck
+        )
     }
 
     nonisolated func subtreeContents(rootedAt targetID: String) -> FileTreeSubtreeContents? {

--- a/Radix/Models/FileTreeStore.swift
+++ b/Radix/Models/FileTreeStore.swift
@@ -2389,6 +2389,8 @@ nonisolated struct FileTreeStore: Sendable {
                 hardLinkAccumulator.record(claim)
                 hardLinkClaimIndices.append(nodeIndex)
             }
+            guard !children.isEmpty else { continue }
+            stack.reserveCapacity(stack.count + children.count)
             for (offset, childIndex) in children.reversed().enumerated() {
                 if offset.isMultiple(of: 256) {
                     try cancellationCheck()

--- a/Radix/Models/ScanSnapshot.swift
+++ b/Radix/Models/ScanSnapshot.swift
@@ -361,7 +361,7 @@ nonisolated struct ScanSnapshot: Identifiable, Sendable {
         cancellationCheck: () throws -> Void
     ) throws -> ScanSnapshot? {
         try cancellationCheck()
-        guard let scopedStore = try treeStore.subtree(
+        guard let scopedStore = try treeStore.logicalScope(
             rootedAt: target.id,
             cancellationCheck: cancellationCheck
         ) else { return nil }

--- a/Radix/Services/ScanArchiveNodeIO.swift
+++ b/Radix/Services/ScanArchiveNodeIO.swift
@@ -33,6 +33,49 @@ nonisolated private struct ScanArchiveCompactTopology {
     let parentsPrecedeChildren: Bool
 }
 
+nonisolated private enum ScanArchiveNodeOrdinalLookup {
+    case dense([Int])
+    case sparse([FileTreeNodeIndex: Int])
+
+    init(
+        orderedNodeIndices: [FileTreeNodeIndex],
+        backingNodeCapacity: Int,
+        cancellationCheck: () throws -> Void
+    ) throws {
+        if backingNodeCapacity <= max(orderedNodeIndices.count * 4, 4_096) {
+            var ordinals = Array(repeating: -1, count: backingNodeCapacity)
+            for (ordinal, nodeIndex) in orderedNodeIndices.enumerated() {
+                if ordinal.isMultiple(of: 256) {
+                    try cancellationCheck()
+                }
+                ordinals[Int(nodeIndex.rawValue)] = ordinal
+            }
+            self = .dense(ordinals)
+        } else {
+            var ordinals: [FileTreeNodeIndex: Int] = [:]
+            ordinals.reserveCapacity(orderedNodeIndices.count)
+            for (ordinal, nodeIndex) in orderedNodeIndices.enumerated() {
+                if ordinal.isMultiple(of: 256) {
+                    try cancellationCheck()
+                }
+                ordinals[nodeIndex] = ordinal
+            }
+            self = .sparse(ordinals)
+        }
+    }
+
+    subscript(nodeIndex: FileTreeNodeIndex) -> Int? {
+        switch self {
+        case .dense(let ordinals):
+            let offset = Int(nodeIndex.rawValue)
+            guard ordinals.indices.contains(offset), ordinals[offset] >= 0 else { return nil }
+            return ordinals[offset]
+        case .sparse(let ordinals):
+            return ordinals[nodeIndex]
+        }
+    }
+}
+
 nonisolated private struct ScanArchiveStreamingJSONWriter {
     private static let flushByteCount = 1024 * 1024
 
@@ -144,24 +187,16 @@ extension ScanArchiveService {
         defer { try? fileHandle.close() }
 
         let orderedNodeIndices = treeStore.indexedNodeIndices()
-        var ordinalByNodeOffset = Array(repeating: -1, count: treeStore.nodeCount)
-        for (ordinal, nodeIndex) in orderedNodeIndices.enumerated() {
-            if ordinal.isMultiple(of: 256) {
-                try Task.checkCancellation()
-            }
-            let offset = Int(nodeIndex.rawValue)
-            guard ordinalByNodeOffset.indices.contains(offset) else {
-                throw ScanArchiveError.topology(localized: "node index is out of range")
-            }
-            ordinalByNodeOffset[offset] = ordinal
-        }
+        let ordinalByNodeIndex = try ScanArchiveNodeOrdinalLookup(
+            orderedNodeIndices: orderedNodeIndices,
+            backingNodeCapacity: treeStore.backingNodeCapacity,
+            cancellationCheck: Task.checkCancellation
+        )
 
         guard let rootIndex = treeStore.nodeIndex(id: treeStore.rootID) else {
             throw ScanArchiveError.topology(localized: "root node is missing from node order")
         }
-        let rootOffset = Int(rootIndex.rawValue)
-        guard ordinalByNodeOffset.indices.contains(rootOffset),
-              ordinalByNodeOffset[rootOffset] >= 0 else {
+        guard let rootOrdinal = ordinalByNodeIndex[rootIndex] else {
             throw ScanArchiveError.topology(localized: "root node is missing from node order")
         }
 
@@ -169,16 +204,14 @@ extension ScanArchiveService {
             fileHandle: fileHandle,
             encoding: encoding
         )
-        try writer.append("{\"r\":\(ordinalByNodeOffset[rootOffset]),\"c\":{")
+        try writer.append("{\"r\":\(rootOrdinal),\"c\":{")
         var wroteParent = false
 
         for (processedOffset, parentIndex) in orderedNodeIndices.enumerated() {
             try Task.checkCancellation()
             let childIndices = treeStore.childIndices(of: parentIndex)
             if !childIndices.isEmpty {
-                let parentOffset = Int(parentIndex.rawValue)
-                guard ordinalByNodeOffset.indices.contains(parentOffset),
-                      ordinalByNodeOffset[parentOffset] >= 0 else {
+                guard let parentOrdinal = ordinalByNodeIndex[parentIndex] else {
                     throw ScanArchiveError.topology(localized: "parent node is missing from node order")
                 }
 
@@ -186,21 +219,19 @@ extension ScanArchiveService {
                     try writer.append(",")
                 }
                 wroteParent = true
-                try writer.append("\"\(ordinalByNodeOffset[parentOffset])\":[")
+                try writer.append("\"\(parentOrdinal)\":[")
 
                 for (childOffset, childIndex) in childIndices.enumerated() {
                     if childOffset.isMultiple(of: 256) {
                         try Task.checkCancellation()
                     }
-                    let nodeOffset = Int(childIndex.rawValue)
-                    guard ordinalByNodeOffset.indices.contains(nodeOffset),
-                          ordinalByNodeOffset[nodeOffset] >= 0 else {
+                    guard let childOrdinal = ordinalByNodeIndex[childIndex] else {
                         throw ScanArchiveError.topology(localized: "child node is missing from node order")
                     }
                     if childOffset > 0 {
                         try writer.append(",")
                     }
-                    try writer.append(String(ordinalByNodeOffset[nodeOffset]))
+                    try writer.append(String(childOrdinal))
                 }
                 try writer.append("]")
             }

--- a/RadixCoreTests/DiskMapVisualizationFilterModelTests.swift
+++ b/RadixCoreTests/DiskMapVisualizationFilterModelTests.swift
@@ -76,6 +76,50 @@ final class DiskMapVisualizationFilterModelTests: XCTestCase {
         XCTAssertFalse(model.isInputPending(for: request))
     }
 
+    func testDiscardPileFilterMaterializesOnlyTheLogicalScope() async throws {
+        let hidden = makeTestFileNode(id: "/root/Home/hidden.bin", name: "hidden.bin", size: 20)
+        let visible = makeTestFileNode(id: "/root/Home/visible.bin", name: "visible.bin", size: 30)
+        let home = makeTestDirectoryNode(id: "/root/Home", name: "Home", children: [hidden, visible])
+        let outside = makeTestFileNode(id: "/root/System.bin", name: "System.bin", size: 100)
+        let root = makeTestDirectoryNode(id: "/root", name: "root", children: [home, outside])
+        let containingSnapshot = makeTestSnapshot(
+            root: root,
+            store: FileTreeStore(root: root, childrenByID: [
+                root.id: [home, outside],
+                home.id: [hidden, visible],
+            ])
+        )
+        let target = ScanTarget(url: home.url)
+        let snapshot = try XCTUnwrap(containingSnapshot.scoped(to: target))
+        let model = DiskMapVisualizationFilterModel()
+        let baseInput = DiskMapFreeSpaceVisualization.input(
+            snapshot: snapshot,
+            focusNode: snapshot.root,
+            showFreeSpace: false,
+            availableCapacity: nil
+        )
+        let request = DiskMapVisualizationFilterRequest(
+            baseInput: baseInput,
+            snapshotID: snapshot.id,
+            focusNodeID: snapshot.root.id,
+            hiddenNodeIDs: [hidden.id]
+        )
+
+        XCTAssertNil(baseInput.treeStore.node(id: outside.id))
+        model.update(baseInput: baseInput, request: request)
+
+        let filteredInput = try await waitForFilteredInput(
+            model: model,
+            baseInput: baseInput,
+            request: request,
+            removedNodeID: hidden.id
+        )
+
+        XCTAssertEqual(filteredInput.rootNode.allocatedSize, visible.allocatedSize)
+        XCTAssertNotNil(filteredInput.treeStore.node(id: visible.id))
+        XCTAssertNil(filteredInput.treeStore.node(id: outside.id))
+    }
+
     func testDiscardPileFilterReleasesCachedInputBeforeReplacementCompletes() async throws {
         let firstHidden = makeTestFileNode(id: "/root/first-hidden.bin", name: "first-hidden.bin", size: 20)
         let secondHidden = makeTestFileNode(id: "/root/second-hidden.bin", name: "second-hidden.bin", size: 30)

--- a/RadixCoreTests/FileBrowserModelTests.swift
+++ b/RadixCoreTests/FileBrowserModelTests.swift
@@ -166,6 +166,36 @@ final class FileBrowserModelTests: XCTestCase {
         }
     }
 
+    func testEntireScanSearchCannotObserveLogicalScopeSiblings() async throws {
+        let visible = makeTestFileNode(
+            id: "/root/Home/report-visible.pdf",
+            name: "report-visible.pdf",
+            size: 20
+        )
+        let home = makeTestDirectoryNode(id: "/root/Home", name: "Home", children: [visible])
+        let outside = makeTestFileNode(
+            id: "/root/report-outside.pdf",
+            name: "report-outside.pdf",
+            size: 30
+        )
+        let root = makeTestDirectoryNode(id: "/root", name: "root", children: [home, outside])
+        let store = FileTreeStore(root: root, childrenByID: [
+            root.id: [home, outside],
+            home.id: [visible],
+        ])
+        let scope = try XCTUnwrap(store.logicalScope(rootedAt: home.id))
+
+        let results = try await FileSearchService().search(
+            snapshotID: UUID(),
+            treeStore: scope,
+            query: FileBrowserQuery(text: "report"),
+            sortOrder: [FileNodeTableComparator(field: .allocatedSize, order: .reverse)]
+        )
+
+        XCTAssertEqual(results.map(\.id), [visible.id])
+        XCTAssertNil(scope.node(id: outside.id))
+    }
+
     func testStructuredQueryCombinesTextKindAndAllocatedSizeAcrossScopes() async throws {
         let smallTarget = makeTestFileNode(
             id: "/root/small-target.bin",

--- a/RadixCoreTests/FileTreeStoreTests.swift
+++ b/RadixCoreTests/FileTreeStoreTests.swift
@@ -502,6 +502,16 @@ final class FileTreeStoreTests: XCTestCase {
         XCTAssertEqual(store.aggregateStats.totalLogicalSize, stats.totalLogicalSize)
         XCTAssertEqual(store.aggregateStats.fileCount, stats.fileCount)
         XCTAssertEqual(store.aggregateStats.directoryCount, stats.directoryCount)
+
+        let scopedStore = try XCTUnwrap(store.subtree(rootedAt: folder.id))
+
+        XCTAssertEqual(scopedStore.indexedNodeIDs(), [folder.id, nested.id])
+        XCTAssertEqual(scopedStore.childIDs(of: folder.id), [nested.id])
+        XCTAssertEqual(scopedStore.parentID(of: nested.id), folder.id)
+        XCTAssertNil(scopedStore.parentID(of: folder.id))
+        XCTAssertNil(scopedStore.node(id: sibling.id))
+        XCTAssertEqual(scopedStore.aggregateStats.fileCount, 1)
+        XCTAssertEqual(scopedStore.aggregateStats.directoryCount, 1)
     }
 
     func testWideTreeChildMapDoesNotReserveOneEntryPerChild() {
@@ -961,6 +971,32 @@ final class FileTreeStoreTests: XCTestCase {
         XCTAssertEqual(updatedStore.root.allocatedSize, 0)
         XCTAssertEqual(updatedStore.aggregateStats.directoryCount, depth + 1)
         XCTAssertEqual(updatedStore.aggregateStats.fileCount, 0)
+    }
+
+    func testSubtreeProjectionHonorsCancellationAcrossWideDirectories() {
+        let children = (0..<1_024).map { offset in
+            makeFileNode(
+                id: "/root/file-\(offset).bin",
+                name: "file-\(offset).bin",
+                size: 1
+            )
+        }
+        let root = makeDirectoryNode(id: "/root", name: "root", children: children)
+        let store = FileTreeStore(root: root, childrenByID: [root.id: children])
+        var cancellationCheckCount = 0
+
+        XCTAssertThrowsError(try store.subtree(
+            rootedAt: root.id,
+            cancellationCheck: {
+                cancellationCheckCount += 1
+                if cancellationCheckCount >= 4 {
+                    throw CancellationError()
+                }
+            }
+        )) { error in
+            XCTAssertTrue(error is CancellationError)
+        }
+        XCTAssertGreaterThanOrEqual(cancellationCheckCount, 4)
     }
 
     func testVolumeReconciliationUpdatesAndReordersExistingRemainderWithoutChangingTopology() throws {

--- a/RadixCoreTests/FileTreeStoreTests.swift
+++ b/RadixCoreTests/FileTreeStoreTests.swift
@@ -422,6 +422,23 @@ final class FileTreeStoreTests: XCTestCase {
             }
             XCTAssertEqual(cancellationCheckCount, cancellationCheckLimit)
         }
+        guard let logicalScope = store.logicalScope(rootedAt: root.id) else {
+            XCTFail("Expected logical scope.")
+            return
+        }
+        var logicalScopeCheckCount = 0
+        XCTAssertThrowsError(try logicalScope.removingSubtree(
+            id: children[512].id,
+            cancellationCheck: {
+                logicalScopeCheckCount += 1
+                if logicalScopeCheckCount == 10 {
+                    throw CancellationError()
+                }
+            }
+        )) { error in
+            XCTAssertTrue(error is CancellationError)
+        }
+        XCTAssertEqual(logicalScopeCheckCount, 10)
         XCTAssertEqual(store.nodeCount, children.count + 1)
         XCTAssertNotNil(store.node(id: children[512].id))
     }
@@ -652,16 +669,27 @@ final class FileTreeStoreTests: XCTestCase {
         XCTAssertNil(scope.node(id: outsideHardLink.id))
         XCTAssertNil(scope.node(id: outsideClone.id))
 
+        let materializedScope = try scope.materialized(cancellationCheck: {})
+        let expectedFiltered = try XCTUnwrap(try materializedScope.removingSubtree(
+            id: regular.id,
+            cancellationCheck: {}
+        ))
         let filtered = try XCTUnwrap(try scope.removingSubtree(
             id: regular.id,
             cancellationCheck: {}
         ))
+        assertEquivalent(filtered, expectedFiltered)
         XCTAssertEqual(filtered.root.allocatedSize, 200)
         XCTAssertEqual(filtered.nodeCount, 3)
         XCTAssertNil(filtered.node(id: regular.id))
         XCTAssertNil(filtered.node(id: outsideHardLink.id))
         XCTAssertEqual(filtered.node(id: visibleHardLink.id)?.allocatedSize, 100)
         XCTAssertEqual(filtered.node(id: visibleClone.id)?.allocatedSize, 100)
+
+        let batchRemovalIDs = [regular.id, visibleClone.id]
+        let expectedBatch = materializedScope.removingSubtrees(rootedAt: batchRemovalIDs)
+        let filteredBatch = scope.removingSubtrees(rootedAt: batchRemovalIDs)
+        assertEquivalent(filteredBatch, expectedBatch)
 
         let rescannedRegular = makeFileNode(id: regular.id, name: regular.name, size: 75)
         let replaced = try XCTUnwrap(try scope.replacingSubtree(
@@ -1314,6 +1342,55 @@ final class FileTreeStoreTests: XCTestCase {
         XCTAssertEqual(restored.aggregateStats.accessibleItemCount, originalStats.accessibleItemCount)
         XCTAssertEqual(restored.aggregateStats.inaccessibleItemCount, originalStats.inaccessibleItemCount)
     }
+}
+
+private func assertEquivalent(
+    _ actual: FileTreeStore,
+    _ expected: FileTreeStore,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) {
+    let expectedNodeIDs = expected.indexedNodeIDs()
+    XCTAssertEqual(actual.indexedNodeIDs(), expectedNodeIDs, file: file, line: line)
+    XCTAssertEqual(actual.nodesByID, expected.nodesByID, file: file, line: line)
+    XCTAssertEqual(actual.childIDsByID, expected.childIDsByID, file: file, line: line)
+    XCTAssertEqual(actual.parentIDByID, expected.parentIDByID, file: file, line: line)
+    XCTAssertEqual(
+        actual.aggregateStats.totalAllocatedSize,
+        expected.aggregateStats.totalAllocatedSize,
+        file: file,
+        line: line
+    )
+    XCTAssertEqual(
+        actual.aggregateStats.totalLogicalSize,
+        expected.aggregateStats.totalLogicalSize,
+        file: file,
+        line: line
+    )
+    XCTAssertEqual(
+        actual.aggregateStats.fileCount,
+        expected.aggregateStats.fileCount,
+        file: file,
+        line: line
+    )
+    XCTAssertEqual(
+        actual.aggregateStats.directoryCount,
+        expected.aggregateStats.directoryCount,
+        file: file,
+        line: line
+    )
+    XCTAssertEqual(
+        actual.aggregateStats.accessibleItemCount,
+        expected.aggregateStats.accessibleItemCount,
+        file: file,
+        line: line
+    )
+    XCTAssertEqual(
+        actual.aggregateStats.inaccessibleItemCount,
+        expected.aggregateStats.inaccessibleItemCount,
+        file: file,
+        line: line
+    )
 }
 
 private func makeFileNode(

--- a/RadixCoreTests/FileTreeStoreTests.swift
+++ b/RadixCoreTests/FileTreeStoreTests.swift
@@ -512,6 +512,145 @@ final class FileTreeStoreTests: XCTestCase {
         XCTAssertNil(scopedStore.node(id: sibling.id))
         XCTAssertEqual(scopedStore.aggregateStats.fileCount, 1)
         XCTAssertEqual(scopedStore.aggregateStats.directoryCount, 1)
+
+        let logicalScope = try XCTUnwrap(store.logicalScope(rootedAt: folder.id))
+
+        XCTAssertNotEqual(logicalScope.contentID, store.contentID)
+        XCTAssertEqual(logicalScope.rootID, folder.id)
+        XCTAssertEqual(logicalScope.root, folder)
+        XCTAssertEqual(logicalScope.nodeCount, 2)
+        XCTAssertEqual(logicalScope.indexedNodeIndices(), [folderIndex, nestedIndex])
+        XCTAssertEqual(logicalScope.indexedNodeIDs(), [folder.id, nested.id])
+        XCTAssertEqual(logicalScope.indexedNodeIDs(excludingRoot: true), [nested.id])
+        XCTAssertEqual(logicalScope.nodesByID, [folder.id: folder, nested.id: nested])
+        XCTAssertEqual(logicalScope.childIDsByID, [folder.id: [nested.id]])
+        XCTAssertEqual(logicalScope.parentIDByID, [nested.id: folder.id])
+        XCTAssertEqual(logicalScope.childIndices(of: folderIndex), [nestedIndex])
+        XCTAssertEqual(logicalScope.parentIndex(of: nestedIndex), folderIndex)
+        XCTAssertNil(logicalScope.parentIndex(of: folderIndex))
+        XCTAssertNil(logicalScope.node(id: root.id))
+        XCTAssertNil(logicalScope.node(id: sibling.id))
+        XCTAssertNil(logicalScope.node(at: rootIndex))
+        XCTAssertNil(logicalScope.parentID(of: folder.id))
+        XCTAssertEqual(logicalScope.path(to: nested.id).map(\.id), [folder.id, nested.id])
+        XCTAssertTrue(logicalScope.isAncestor(folder.id, of: nested.id))
+        XCTAssertFalse(logicalScope.isAncestor(root.id, of: nested.id))
+        XCTAssertEqual(logicalScope.aggregateStats.fileCount, 1)
+        XCTAssertEqual(logicalScope.aggregateStats.directoryCount, 1)
+    }
+
+    func testLogicalScopePreservesCountsAccessibilityAndNestedScoping() throws {
+        let summarized = makeTestSummarizedDirectoryNode(
+            id: "/root/Home/Summary",
+            name: "Summary",
+            size: 30,
+            descendantFileCount: 7
+        )
+        let inaccessible = makeFileNode(
+            id: "/root/Home/Private.bin",
+            name: "Private.bin",
+            size: 20,
+            isAccessible: false
+        )
+        let home = makeDirectoryNode(
+            id: "/root/Home",
+            name: "Home",
+            children: [summarized, inaccessible]
+        )
+        let sibling = makeFileNode(id: "/root/System.bin", name: "System.bin", size: 100)
+        let root = makeDirectoryNode(id: "/root", name: "root", children: [home, sibling])
+        let store = FileTreeStore(root: root, childrenByID: [
+            root.id: [home, sibling],
+            home.id: [summarized, inaccessible],
+        ])
+
+        let homeScope = try XCTUnwrap(store.logicalScope(rootedAt: home.id))
+
+        XCTAssertEqual(homeScope.root.allocatedSize, 50)
+        XCTAssertEqual(homeScope.aggregateStats.fileCount, 8)
+        XCTAssertEqual(homeScope.aggregateStats.directoryCount, 2)
+        XCTAssertEqual(homeScope.aggregateStats.accessibleItemCount, 1)
+        XCTAssertEqual(homeScope.aggregateStats.inaccessibleItemCount, 2)
+        XCTAssertEqual(homeScope.subtreeNodeCount(rootedAt: home.id), 3)
+        XCTAssertEqual(homeScope.subtreeNodeCount(rootedAt: root.id), 0)
+
+        let nestedScope = try XCTUnwrap(homeScope.logicalScope(rootedAt: summarized.id))
+
+        XCTAssertEqual(nestedScope.rootID, summarized.id)
+        XCTAssertEqual(nestedScope.nodeCount, 1)
+        XCTAssertEqual(nestedScope.aggregateStats.fileCount, 7)
+        XCTAssertEqual(nestedScope.aggregateStats.directoryCount, 1)
+        XCTAssertNil(nestedScope.node(id: inaccessible.id))
+        XCTAssertNil(nestedScope.parent(of: summarized.id))
+    }
+
+    func testLogicalScopeReownsHardLinkAndCloneAllocationAndRepairsOrder() throws {
+        let hardLinkIdentity = FileIdentity(device: 9, inode: 1)
+        let cloneIdentity = CloneIdentity(device: 9, cloneID: 2)
+        let outsideHardLink = sharedFileNode(
+            id: "/root/A/hard.bin",
+            allocatedSize: 100,
+            fileIdentity: hardLinkIdentity,
+            linkCount: 2
+        )
+        let visibleHardLink = sharedFileNode(
+            id: "/root/Home/z-hard.bin",
+            allocatedSize: 0,
+            unduplicatedAllocatedSize: 100,
+            fileIdentity: hardLinkIdentity,
+            linkCount: 2
+        )
+        let outsideClone = sharedFileNode(
+            id: "/root/A/clone.bin",
+            allocatedSize: 100,
+            dataAllocatedSize: 80,
+            fileIdentity: FileIdentity(device: 9, inode: 2),
+            cloneIdentity: cloneIdentity
+        )
+        let visibleClone = sharedFileNode(
+            id: "/root/Home/z-clone.bin",
+            allocatedSize: 20,
+            unduplicatedAllocatedSize: 100,
+            dataAllocatedSize: 80,
+            fileIdentity: FileIdentity(device: 9, inode: 3),
+            cloneIdentity: cloneIdentity
+        )
+        let regular = makeFileNode(id: "/root/Home/regular.bin", name: "regular.bin", size: 50)
+        let outside = makeDirectoryNode(
+            id: "/root/A",
+            name: "A",
+            children: [outsideHardLink, outsideClone]
+        )
+        let home = makeDirectoryNode(
+            id: "/root/Home",
+            name: "Home",
+            children: [visibleHardLink, visibleClone, regular]
+        )
+        let root = makeDirectoryNode(id: "/root", name: "root", children: [outside, home])
+        let store = FileTreeStore(root: root, childrenByID: [
+            root.id: [outside, home],
+            outside.id: [outsideHardLink, outsideClone],
+            home.id: [visibleHardLink, visibleClone, regular],
+        ])
+
+        XCTAssertEqual(store.childIDs(of: home.id), [regular.id, visibleClone.id, visibleHardLink.id])
+
+        let scope = try XCTUnwrap(store.logicalScope(rootedAt: home.id))
+
+        XCTAssertEqual(scope.root.allocatedSize, 250)
+        XCTAssertEqual(scope.aggregateStats.totalAllocatedSize, 250)
+        XCTAssertEqual(scope.node(id: visibleHardLink.id)?.allocatedSize, 100)
+        XCTAssertEqual(scope.node(id: visibleClone.id)?.allocatedSize, 100)
+        XCTAssertEqual(
+            scope.childIDs(of: home.id),
+            [visibleClone.id, visibleHardLink.id, regular.id]
+        )
+        XCTAssertEqual(
+            scope.indexedNodeIDs(),
+            [home.id, visibleClone.id, visibleHardLink.id, regular.id]
+        )
+        XCTAssertNil(scope.node(id: outsideHardLink.id))
+        XCTAssertNil(scope.node(id: outsideClone.id))
     }
 
     func testWideTreeChildMapDoesNotReserveOneEntryPerChild() {
@@ -997,6 +1136,20 @@ final class FileTreeStoreTests: XCTestCase {
             XCTAssertTrue(error is CancellationError)
         }
         XCTAssertGreaterThanOrEqual(cancellationCheckCount, 4)
+
+        cancellationCheckCount = 0
+        XCTAssertThrowsError(try store.logicalScope(
+            rootedAt: root.id,
+            cancellationCheck: {
+                cancellationCheckCount += 1
+                if cancellationCheckCount >= 4 {
+                    throw CancellationError()
+                }
+            }
+        )) { error in
+            XCTAssertTrue(error is CancellationError)
+        }
+        XCTAssertGreaterThanOrEqual(cancellationCheckCount, 4)
     }
 
     func testVolumeReconciliationUpdatesAndReordersExistingRemainderWithoutChangingTopology() throws {
@@ -1161,6 +1314,38 @@ private func makeFileNode(
         isPackage: false,
         isAccessible: isAccessible,
         isSelfAccessible: isAccessible,
+        isSynthetic: false,
+        isAutoSummarized: false
+    )
+}
+
+private func sharedFileNode(
+    id: String,
+    allocatedSize: Int64,
+    unduplicatedAllocatedSize: Int64? = nil,
+    dataAllocatedSize: Int64? = nil,
+    fileIdentity: FileIdentity,
+    linkCount: UInt64 = 1,
+    cloneIdentity: CloneIdentity? = nil
+) -> FileNodeRecord {
+    FileNodeRecord(
+        id: id,
+        url: URL(filePath: id),
+        name: URL(filePath: id).lastPathComponent,
+        isDirectory: false,
+        isSymbolicLink: false,
+        allocatedSize: allocatedSize,
+        unduplicatedAllocatedSize: unduplicatedAllocatedSize,
+        dataAllocatedSize: dataAllocatedSize,
+        logicalSize: unduplicatedAllocatedSize ?? allocatedSize,
+        descendantFileCount: 1,
+        lastModified: nil,
+        fileIdentity: fileIdentity,
+        linkCount: linkCount,
+        cloneIdentity: cloneIdentity,
+        isPackage: false,
+        isAccessible: true,
+        isSelfAccessible: true,
         isSynthetic: false,
         isAutoSummarized: false
     )

--- a/RadixCoreTests/FileTreeStoreTests.swift
+++ b/RadixCoreTests/FileTreeStoreTests.swift
@@ -651,6 +651,27 @@ final class FileTreeStoreTests: XCTestCase {
         )
         XCTAssertNil(scope.node(id: outsideHardLink.id))
         XCTAssertNil(scope.node(id: outsideClone.id))
+
+        let filtered = try XCTUnwrap(try scope.removingSubtree(
+            id: regular.id,
+            cancellationCheck: {}
+        ))
+        XCTAssertEqual(filtered.root.allocatedSize, 200)
+        XCTAssertEqual(filtered.nodeCount, 3)
+        XCTAssertNil(filtered.node(id: regular.id))
+        XCTAssertNil(filtered.node(id: outsideHardLink.id))
+        XCTAssertEqual(filtered.node(id: visibleHardLink.id)?.allocatedSize, 100)
+        XCTAssertEqual(filtered.node(id: visibleClone.id)?.allocatedSize, 100)
+
+        let rescannedRegular = makeFileNode(id: regular.id, name: regular.name, size: 75)
+        let replaced = try XCTUnwrap(try scope.replacingSubtree(
+            id: regular.id,
+            with: FileTreeStore(root: rescannedRegular),
+            cancellationCheck: {}
+        ))
+        XCTAssertEqual(replaced.root.allocatedSize, 275)
+        XCTAssertEqual(replaced.node(id: regular.id)?.allocatedSize, 75)
+        XCTAssertNil(replaced.node(id: outsideHardLink.id))
     }
 
     func testWideTreeChildMapDoesNotReserveOneEntryPerChild() {

--- a/RadixCoreTests/ScanArchiveServiceTests.swift
+++ b/RadixCoreTests/ScanArchiveServiceTests.swift
@@ -3,6 +3,75 @@ import XCTest
 @testable import RadixCore
 
 final class ScanArchiveServiceTests: XCTestCase {
+    func testExportImportRoundTripsLogicalScopeWithNonDenseNodeIndices() async throws {
+        let service = ScanArchiveService()
+        let containingSnapshot = makeArchiveSnapshot()
+        let target = ScanTarget(url: URL(filePath: "/archive/folder", directoryHint: .isDirectory))
+        let snapshot = try XCTUnwrap(containingSnapshot.scoped(to: target))
+        let archiveURL = try makeTemporaryArchiveURL()
+
+        XCTAssertLessThan(snapshot.treeStore.nodeCount, containingSnapshot.treeStore.nodeCount)
+        XCTAssertEqual(snapshot.treeStore.rootID, target.id)
+        XCTAssertNil(snapshot.treeStore.node(id: containingSnapshot.treeStore.rootID))
+
+        _ = try await service.export(
+            snapshot: snapshot,
+            to: archiveURL,
+            options: ScanArchiveExportOptions(appVersion: "Tests")
+        )
+        let importedSnapshot = try await service.importSnapshot(from: archiveURL).snapshot
+
+        XCTAssertEqual(importedSnapshot.target.id, target.id)
+        XCTAssertEqual(importedSnapshot.treeStore.root, snapshot.treeStore.root)
+        XCTAssertEqual(importedSnapshot.treeStore.nodeCount, snapshot.treeStore.nodeCount)
+        XCTAssertEqual(importedSnapshot.treeStore.indexedNodeIDs(), snapshot.treeStore.indexedNodeIDs())
+        XCTAssertEqual(importedSnapshot.treeStore.childIDsByID, snapshot.treeStore.childIDsByID)
+        XCTAssertEqual(importedSnapshot.aggregateStats.totalAllocatedSize, snapshot.aggregateStats.totalAllocatedSize)
+        XCTAssertEqual(importedSnapshot.scanWarnings.map(\.path), snapshot.scanWarnings.map(\.path))
+    }
+
+    func testExportImportRoundTripsTinyScopeWithoutDenseBackingOrdinalMap() async throws {
+        let service = ScanArchiveService()
+        let siblings = (0..<4_096).map { offset in
+            makeTestFileNode(
+                id: "/root/file-\(offset).bin",
+                name: "file-\(offset).bin",
+                size: 2
+            )
+        }
+        let targetRoot = makeTestSummarizedDirectoryNode(
+            id: "/root/Target",
+            name: "Target",
+            size: 1,
+            descendantFileCount: 10
+        )
+        let root = makeTestDirectoryNode(
+            id: "/root",
+            name: "root",
+            children: siblings + [targetRoot]
+        )
+        let containingSnapshot = makeTestSnapshot(
+            root: root,
+            store: FileTreeStore(root: root, childrenByID: [root.id: siblings + [targetRoot]])
+        )
+        let snapshot = try XCTUnwrap(containingSnapshot.scoped(to: ScanTarget(url: targetRoot.url)))
+        let archiveURL = try makeTemporaryArchiveURL()
+
+        XCTAssertEqual(snapshot.treeStore.nodeCount, 1)
+        XCTAssertGreaterThan(snapshot.treeStore.backingNodeCapacity, 4_096)
+
+        _ = try await service.export(
+            snapshot: snapshot,
+            to: archiveURL,
+            options: ScanArchiveExportOptions(appVersion: "Tests")
+        )
+        let importedSnapshot = try await service.importSnapshot(from: archiveURL).snapshot
+
+        XCTAssertEqual(importedSnapshot.treeStore.root, targetRoot)
+        XCTAssertEqual(importedSnapshot.treeStore.nodeCount, 1)
+        XCTAssertEqual(importedSnapshot.aggregateStats.fileCount, 10)
+    }
+
     func testExportImportRoundTripsSnapshotGraphAndTrustContext() async throws {
         let service = ScanArchiveService()
         let snapshot = makeArchiveSnapshot()

--- a/RadixCoreTests/ScanBenchmarkTests.swift
+++ b/RadixCoreTests/ScanBenchmarkTests.swift
@@ -207,6 +207,7 @@ final class ScanBenchmarkTests: XCTestCase {
         }
 
         let usesHardLinks = environment["RADIX_BENCH_TREE_HARD_LINKS"] == "1"
+        let usesLogicalScope = environment["RADIX_BENCH_TREE_LOGICAL_SCOPE"] == "1"
         let removesDirectory = environment["RADIX_BENCH_TREE_REMOVE_DIRECTORY"] == "1"
         let waitsForSettledFirstFilter =
             environment["RADIX_BENCH_TREE_SETTLED_REPLACEMENT"] == "1"
@@ -335,9 +336,12 @@ final class ScanBenchmarkTests: XCTestCase {
                 inaccessibleItemCount: 0
             )
         )
+        let benchmarkStore = usesLogicalScope
+            ? try XCTUnwrap(store.logicalScope(rootedAt: store.rootID))
+            : store
 
         let startedAt = ContinuousClock.now
-        let updatedStore = try XCTUnwrap(store.removingSubtree(id: removalID))
+        let updatedStore = try XCTUnwrap(benchmarkStore.removingSubtree(id: removalID))
         let filterFinishedAt = ContinuousClock.now
         let sunburstSegments = SunburstLayout.segments(
             in: updatedStore,
@@ -374,6 +378,7 @@ final class ScanBenchmarkTests: XCTestCase {
         print(
             "RADIX_BENCH_TREE_REMOVAL_RESULT nodes=\(nodeCount) " +
             "removed=\(removedNodeCount) hard_links=\(usesHardLinks) " +
+            "logical_scope=\(usesLogicalScope) " +
             "filter=\(String(format: "%.6f", filterElapsedSeconds))s " +
             "sunburst=\(String(format: "%.6f", sunburstElapsedSeconds))s " +
             "sunburst_segments=\(sunburstSegments.count) " +
@@ -383,22 +388,22 @@ final class ScanBenchmarkTests: XCTestCase {
         )
 
         let baseInput = DiskMapVisualizationInput(
-            rootNode: store.root,
-            treeStore: DiskMapTreeStore(store),
-            treeContentID: store.contentID,
+            rootNode: benchmarkStore.root,
+            treeStore: DiskMapTreeStore(benchmarkStore),
+            treeContentID: benchmarkStore.contentID,
             layoutIDComponent: "benchmark"
         )
         let snapshotID = UUID()
         let firstRequest = DiskMapVisualizationFilterRequest(
             baseInput: baseInput,
             snapshotID: snapshotID,
-            focusNodeID: store.root.id,
+            focusNodeID: benchmarkStore.root.id,
             hiddenNodeIDs: [removalID]
         )
         let replacementRequest = DiskMapVisualizationFilterRequest(
             baseInput: baseInput,
             snapshotID: snapshotID,
-            focusNodeID: store.root.id,
+            focusNodeID: benchmarkStore.root.id,
             hiddenNodeIDs: [removalID, replacementRemovalID]
         )
         var filterDurations: [Double] = []
@@ -471,6 +476,7 @@ final class ScanBenchmarkTests: XCTestCase {
         print(
             "RADIX_BENCH_DISCARD_REPLACEMENT_RESULT nodes=\(nodeCount) " +
             "hidden=2 hard_links=\(usesHardLinks) " +
+            "logical_scope=\(usesLogicalScope) " +
             "first_filter=\(waitsForSettledFirstFilter ? "settled" : "rapid") " +
             "iterations=\(replacementIterationCount) " +
             "filter_median=\(String(format: "%.6f", medianFilterDuration))s " +

--- a/RadixCoreTests/ScanComparisonServiceTests.swift
+++ b/RadixCoreTests/ScanComparisonServiceTests.swift
@@ -2,6 +2,28 @@ import XCTest
 @testable import RadixCore
 
 final class ScanComparisonServiceTests: XCTestCase {
+    func testLogicalScopeComparesIdenticallyToMaterializedSubtree() async throws {
+        let visible = makeTestFileNode(id: "/root/Home/file.bin", name: "file.bin", size: 25)
+        let home = makeTestDirectoryNode(id: "/root/Home", name: "Home", children: [visible])
+        let outside = makeTestFileNode(id: "/root/System.bin", name: "System.bin", size: 100)
+        let root = makeTestDirectoryNode(id: "/root", name: "root", children: [home, outside])
+        let store = FileTreeStore(root: root, childrenByID: [
+            root.id: [home, outside],
+            home.id: [visible],
+        ])
+        let logicalScope = try XCTUnwrap(store.logicalScope(rootedAt: home.id))
+        let materializedScope = try XCTUnwrap(store.subtree(rootedAt: home.id))
+
+        let comparison = try await ScanComparisonService().compare(
+            before: makeTestSnapshot(root: logicalScope.root, store: logicalScope),
+            after: makeTestSnapshot(root: materializedScope.root, store: materializedScope)
+        )
+
+        XCTAssertTrue(comparison.rows.isEmpty)
+        XCTAssertEqual(comparison.summary.allocatedDelta, 0)
+        XCTAssertEqual(comparison.summary.fileCountDelta, 0)
+    }
+
     func testComparesSnapshotsByRelativePathAcrossDifferentRoots() async throws {
         let beforeFile = makeTestFileNode(id: "/before/shared.bin", name: "shared.bin", size: 10)
         let beforeRoot = makeTestDirectoryNode(id: "/before", name: "before", children: [beforeFile])

--- a/RadixCoreTests/ScanModelTests.swift
+++ b/RadixCoreTests/ScanModelTests.swift
@@ -586,7 +586,7 @@ final class ScanModelTests: XCTestCase {
         XCTAssertNil(snapshot.removingNodes(ids: [root.id, second.id]))
     }
 
-    func testSnapshotScopedToDescendantUsesSubtreeAndFiltersWarnings() throws {
+    func testSnapshotScopedToDescendantUsesLogicalScopeAndFiltersWarnings() throws {
         let docsFile = makeNode(id: "/root/Documents/report.pdf", isDirectory: false, isSynthetic: false, isAccessible: true)
         let cacheFile = makeNode(id: "/root/Library/cache.db", isDirectory: false, isSynthetic: false, isAccessible: true)
         let docs = FileNodeRecord.directory(
@@ -630,6 +630,9 @@ final class ScanModelTests: XCTestCase {
 
         XCTAssertEqual(scopedSnapshot.target, docsTarget)
         XCTAssertEqual(scopedSnapshot.root.id, docs.id)
+        XCTAssertNotEqual(scopedSnapshot.treeStore.contentID, snapshot.treeStore.contentID)
+        XCTAssertEqual(scopedSnapshot.treeStore.nodeCount, 2)
+        XCTAssertNil(scopedSnapshot.treeStore.parent(of: docs.id))
         XCTAssertEqual(scopedSnapshot.treeStore.children(of: docs.id).map(\.id), [docsFile.id])
         XCTAssertNil(scopedSnapshot.treeStore.node(id: library.id))
         XCTAssertEqual(scopedSnapshot.aggregateStats.totalAllocatedSize, docs.allocatedSize)

--- a/RadixCoreTests/SidebarScanCacheControllerTests.swift
+++ b/RadixCoreTests/SidebarScanCacheControllerTests.swift
@@ -276,6 +276,8 @@ final class SidebarScanCacheControllerTests: XCTestCase {
         let restoredSnapshot = try XCTUnwrap(recorder.restoredSnapshots.first)
         XCTAssertEqual(restoredSnapshot.root.id, scoped.id)
         XCTAssertEqual(restoredSnapshot.root.allocatedSize, 100)
+        XCTAssertEqual(restoredSnapshot.treeStore.nodeCount, 2)
+        XCTAssertNotEqual(restoredSnapshot.treeStore.nodeIndex(id: scoped.id)?.rawValue, 0)
         XCTAssertEqual(restoredSnapshot.treeStore.node(id: scopedFile.id)?.allocatedSize, 100)
         XCTAssertTrue(recorder.startedTargets.isEmpty)
     }


### PR DESCRIPTION
## Summary

- share one immutable physical scan tree across contained logical scan targets
- preserve scope-specific totals and hard-link allocation through lightweight overlays
- materialize compact independent storage only for consumers that require mutation
- optimize scoped traversal, subtree removal, archive I/O, and unscoped chart read paths

## Validation

- `swift test`: 752 passed, 18 skipped
- AddressSanitizer-focused suite: 217 passed
- Xcode Debug app build succeeded
- manually exercised cached parent-to-child switching, scoped File Browser search, sunburst and treemap rendering, navigation, and Discard Pile add/remove/clear behavior using isolated fixtures
- scoped Discard filtering improved from about 2.40 s to 1.33 s; filter plus layout improved from about 2.74 s to 1.43 s in the million-node benchmark
- unscoped treemap layout measured about 0.081–0.085 s versus about 0.175 s on `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added logical directory scopes for browsing, searching, filtering, statistics, and snapshot comparisons.
  * Scoped views now preserve hierarchy, ordering, links, and file allocation details.
  * Added support for exporting and importing scoped snapshots, including sparse node layouts.

* **Bug Fixes**
  * Searches and filters no longer include content outside the selected directory.
  * Improved cancellation handling during large-tree operations.
  * Preserved topology and metadata when restoring or comparing scoped snapshots.

* **Tests**
  * Expanded coverage for scoped browsing, archive round trips, filtering, comparisons, links, ordering, and removal operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->