### PR TITLE
perf(file-browser): improve million-node sorting

### DIFF
--- a/FILE_BROWSER_LARGE_RESULTS_BENCHMARK_RESULTS.md
+++ b/FILE_BROWSER_LARGE_RESULTS_BENCHMARK_RESULTS.md
@@ -1,0 +1,73 @@
+# File Browser Million-Node Benchmark Results
+
+## Environment
+
+- Source baseline: `fbda1505c81a7582ff600a2f66df498fcae2b09b`
+- Hardware: Apple M5 MacBook Air, 10 cores, 32 GB memory
+- OS: macOS 26.6.1 (25G76)
+- Toolchain: Xcode 26.6 (17F113), Apple Swift 6.3.3
+- Build: SwiftPM `release`
+- Fixture: 1,000 directories × 1,000 files plus the root (1,001,001 nodes)
+- Warm iterations per process: 3
+
+The baseline used the unmodified production sources from `main` plus the same test-only benchmark file. Three full-process samples were collected before the production change and three after it. Values below are medians unless noted. RSS is process-wide peak RSS, not an attribution of every resident byte to File Browser.
+
+## Reproduction
+
+```sh
+rtk env RADIX_BENCH_FILE_BROWSER=1 swift test -c release \
+  --filter FileBrowserBenchmarkTests/testMillionNodeFileBrowserBenchmark
+```
+
+Optional fixture and iteration overrides:
+
+- `RADIX_BENCH_FILE_BROWSER_DIRECTORIES`
+- `RADIX_BENCH_FILE_BROWSER_FILES_PER_DIRECTORY`
+- `RADIX_BENCH_FILE_BROWSER_WARM_ITERATIONS`
+
+The benchmark emits stable `RADIX_FILE_BROWSER_BENCH_RESULT` lines for extraction.
+
+## Timing results
+
+| Phase | Baseline | Optimized | Change | Interpretation |
+| --- | ---: | ---: | ---: | --- |
+| Cold index construction estimate | 1.382 s | 1.408 s | +1.9% | Unchanged production path; within cross-run drift. |
+| Warm text search | 0.303 s | 0.311 s | +2.5% | Unchanged production path; within cross-run drift. |
+| First path search | 2.658 s | 2.699 s | +1.6% | Unchanged production path; includes lazy path normalization. |
+| Warm path search | 1.329 s | 1.411 s | +6.2% | Unchanged production path; later runs were consistently warmer/slower, so no causal claim. |
+| Filter-only, 1,000,000 results | 0.191 s | 0.197 s | +2.9% | Unchanged production path; within baseline measurement spread. |
+| Allocated-size sort, 1,000,000 results | 3.048 s | 2.793 s | **−8.4%** | Meaningful improvement beyond the approximately 3% baseline spread. |
+| Main-actor publication, 1,000,000 results | 0.283 s | 0.261 s | −7.8% | Corrected harness includes the synchronous `@Published` replacement and notification; three-process spreads overlap, so no speedup or regression is claimed. |
+| Cold end-to-end model request | 5.024 s | 4.934 s | −1.8% | Within noise; not claimed as an end-to-end speedup. |
+| Cancellation during active sort | 1.348 s | 0.092 s | **−93.2%** | Corrected three-process harness medians; every run threw `CancellationError` after the request rather than merely returning normally. |
+
+Cold-search cancellation completed in sub-millisecond time after the request in both versions. The result count remained exactly 1,000,000 for the large filter and sort phases, and the before/after ordering fingerprint remained `8f64003a74b8684` in every full run.
+
+The publication and cancellation rows were refreshed after review with three new full processes per version and a byte-identical benchmark harness. Other rows retain the original acceptance samples. The refreshed ordering check validates the complete descriptor order plus deterministic name/ID fallback across every adjacent result, including ties spanning sorted runs.
+
+## Peak RSS results
+
+- Peak RSS at completion of the measured sort fell from a 2,034.97 MiB baseline median to 1,946.66 MiB: **88.31 MiB lower (4.3%)**.
+- Relative to the preceding filter phase, the sort raised process peak RSS by 473.27 MiB before and 384.94 MiB after: **88.33 MiB less incremental peak growth (18.7%)**.
+- Fixture construction itself raised peak RSS by about 823 MiB, and the retained search index added about 108 MiB. These are reported to keep fixture/search memory visible, but fixture allocation is not a production File Browser optimization target.
+- The benchmark reports suite peak RSS as well. Because cancellation placement deliberately differs from the earlier provisional harness and process allocators retain freed pages, phase-aligned sort peak is the primary before/after memory comparison.
+
+## Bottleneck and accepted change
+
+Large-result sorting was the dominant actionable phase: approximately 3.05 seconds, versus 2.66 seconds for first-time path search, 1.38 seconds for cold index construction, and 0.25 seconds for main-actor publication.
+
+The accepted production change is limited to sorting:
+
+1. Prepare localized item-kind text and displayed descendant counts only when an active sort descriptor needs them. No cache or persisted state was added.
+2. Sort bounded 16,384-row runs, then merge them through two reusable contiguous buffers with cancellation checks every 256 output rows.
+
+The bounded runs avoid Swift's prior multi-second non-cancellable monolithic sort. Smaller 8,192-row runs reduced throughput without improving measured cancellation; larger 65,536-row runs were faster but increased the observed cancellation bound. A pairwise chunk-merge prototype improved cancellation but materially increased peak RSS, and a heap-based merge removed that memory spike but erased the speed improvement; both prototypes were discarded.
+
+## Validation summary
+
+- Focused `FileBrowserModelTests`: 40 passed, 0 failed.
+- Complete `swift test`: 747 passed, 19 opt-in benchmarks skipped, 0 failed.
+- Complete Debug app build: passed.
+- Complete Release app build: passed.
+- Release bundle, executable, and Swift source list searches found no `RADIX_BENCH_FILE_BROWSER`, `RADIX_FILE_BROWSER_BENCH_RESULT`, `FileBrowserBenchmarkTests`, `FileBrowserPublicationProbe`, test-target path, or benchmark-named file.
+- No Discard Pile, sidebar scan caching, snapshot scoping, chart filtering, localization, archive, or unrelated production files were changed.

--- a/FILE_BROWSER_LARGE_RESULTS_PERFORMANCE_PLAN.md
+++ b/FILE_BROWSER_LARGE_RESULTS_PERFORMANCE_PLAN.md
@@ -1,0 +1,122 @@
+# File Browser Million-Node Performance Plan
+
+## Objective
+
+Measure and, only if the evidence supports it, improve File Browser responsiveness and memory use for a synthetic scan containing approximately one million nodes. The change must preserve File Browser query, sorting, display, and cancellation semantics. A production optimization is optional: if no dominant, worthwhile bottleneck is found, the benchmark and its evidence remain the deliverable.
+
+## Scope and non-goals
+
+This work is limited to the File Browser pipeline in:
+
+- `Radix/Services/FileBrowserSearch.swift`
+- `Radix/Services/FileBrowserResults.swift`
+- `Radix/Services/FileBrowserDisplayState.swift`
+- `Radix/Services/FileBrowserModel.swift`
+- focused tests under `RadixCoreTests/`
+
+Explicitly out of scope:
+
+- Discard Pile behavior or visualization
+- sidebar scan caching
+- snapshot scoping or archive format work
+- sunburst, treemap, or other chart filtering
+- unrelated open issues or cleanup
+- new dependencies
+- speculative caches or persistent model state
+
+The product guarantees remain unchanged: work that scales with scan size stays off the main actor except for the final publication boundary, cancellation remains prompt, files are never mutated, and File Browser results remain a primary navigation surface.
+
+## Current pipeline and initial hypotheses
+
+The existing entire-scan path is:
+
+1. `FileBrowserModel` debounces and schedules an async search.
+2. `FileSearchService` builds and retains one normalized metadata index per snapshot/tree content identity.
+3. Each query scans that index, optionally normalizes paths lazily, materializes matching `FileNodeRecord` values, and sorts the result.
+4. The model returns to the main actor and publishes a new `FileBrowserDisplayState`.
+5. `FileBrowserDisplayState` deduplicates the result and constructs an ID-to-row-index dictionary.
+
+The measurements will test, rather than assume, these candidate costs:
+
+- cold normalization/index construction and its retained memory;
+- linear warm scans for text, path, and metadata-only filters;
+- temporary allocation and comparison cost when sorting a very large match set;
+- main-actor deduplication/index-map construction for a very large published result;
+- cancellation latency within index scans, filtering, and sorting.
+
+## Benchmark design
+
+### Location and opt-in gate
+
+Add a dedicated `RadixCoreTests/FileBrowserBenchmarkTests.swift` file to the Swift Package test target. The benchmark will be skipped unless `RADIX_BENCH_FILE_BROWSER=1` is set. Production files will contain no benchmark environment variables, result logging, fixture generators, timers, RSS samplers, or benchmark-only conditionals.
+
+The default fixture will contain one root plus 1,000 directories and 1,000 files per directory (1,001,001 total nodes). Environment overrides may reduce the fixture for benchmark development, but the recorded acceptance run must use the million-node default. The fixture will use the verified indexed `FileTreeStore` initializer so fixture setup does not add dictionary-based topology construction noise to the measured search phases.
+
+File names, paths, types, sizes, and modification dates will be deterministic. Selected names and directory paths will create known sparse text/path matches, while a file-kind or size-only query will return a deliberately large result set.
+
+### Timing method
+
+Use `ContinuousClock` and report seconds with enough precision to compare repeated runs. Fixture construction is reported separately and excluded from query timings. Each warm phase will run multiple iterations in the same test process; the report will include individual samples plus median (and spread where practical), so a claimed improvement must exceed normal run-to-run variation.
+
+Measure these phases:
+
+1. **Fixture construction wall time** — build the synthetic nodes/topology and `FileTreeStore`; useful context, not a File Browser optimization target.
+2. **Cold index construction** — time a fresh `FileSearchService` with a deterministic no-match text query and no sort. Because the production service intentionally keeps index construction private, also measure the identical warm no-match scan and report the cold-minus-warm delta as the index-construction estimate. Do not add a production benchmark hook merely to time the private helper.
+3. **Warm text search** — repeat a normalized name/kind query against the retained index with a small known result set and no sort.
+4. **Path search** — measure a path-only query whose name/kind check misses, including its first lazy path normalization pass, then repeat it warm to distinguish retained-path lookup from first-pass work.
+5. **Filter-only large-result query** — run a metadata-only query returning most file nodes, initially with no sort, and record the exact result count.
+6. **Sorting** — sort a pre-materialized large result set separately with the normal allocated-size order and deterministic fallback; report exact count and a result fingerprint so an optimization cannot silently change ordering.
+7. **Main-actor result publication** — on `MainActor`, construct and assign the same `FileBrowserDisplayState` shape used by `FileBrowserModel`, recording the time and verifying row lookup/deduplication invariants. If necessary, a test-only `FileSearching` stub will isolate model publication from search work.
+8. **Cancellation** — cancel active cold search/filter/sort work after it has started, measure wall time from cancellation request to task completion, require `CancellationError`, and verify no stale model result is published.
+9. **End-to-end wall time** — measure an actual `FileBrowserModel` entire-scan request from query change through current-result publication for a representative large-result query.
+10. **Peak RSS** — sample/report process resident memory before the fixture, after the fixture, after the retained search index, and at suite peak. Use Darwin process information from the test target only. Report absolute peak and deltas; treat values as process-level context rather than attributing every byte to one phase.
+
+Every report line will use a stable `RADIX_FILE_BROWSER_BENCH_RESULT` prefix so before/after results can be extracted without including benchmark code in the app.
+
+## Baseline and profiling procedure
+
+1. Build and run the opt-in benchmark in the isolated worktree with a dedicated SwiftPM scratch path.
+2. Run at least three full million-node samples when runtime permits; run additional repetitions of lower-variance warm phases within each sample.
+3. Record wall time, phase medians, result counts/fingerprints, cancellation latency, and peak RSS.
+4. Use the phase breakdown and, if needed, Instruments/`sample`-style stack evidence to identify the single dominant actionable bottleneck.
+5. Separate fixture cost from product cost and separate one-time cold cost from repeated interaction cost.
+
+No optimization will be selected from source inspection alone.
+
+## Optimization decision gate
+
+A production change is justified only when all of the following hold:
+
+- one requested File Browser phase is clearly dominant or presents a concrete responsiveness/memory risk;
+- the cost is in production code, not benchmark fixture setup;
+- a small coherent change addresses that cost without a new speculative cache;
+- repeated before/after samples show a meaningful improvement larger than observed noise;
+- result counts, ordering fingerprints, lookup behavior, and cancellation behavior remain equivalent.
+
+Prefer removing repeated traversal, avoidable allocation, or main-actor work over introducing another state owner. Change only the dominant mechanism. If the evidence is mixed or the improvement is marginal, revert the production experiment and keep the benchmark.
+
+## Correctness and cancellation coverage
+
+Add the minimum focused tests needed for the measured path and any chosen optimization. Expected coverage includes:
+
+- text, path, and metadata-only queries preserve AND semantics and exact matches;
+- large-result sorting preserves requested comparator order and deterministic name/ID fallback;
+- display publication preserves input order after deduplication and correct ID lookup;
+- cancellation during the affected long-running phase terminates promptly and cannot publish stale results;
+- existing current-contents and entire-scan query behavior remains unchanged.
+
+Avoid duplicating scenarios already covered by `FileBrowserModelTests`; new tests should specifically protect the optimized boundary or the benchmark's newly exposed cancellation risk.
+
+## Validation and release isolation
+
+Run, in order:
+
+1. focused File Browser tests;
+2. the opt-in million-node benchmark for final after-data;
+3. `swift test` for the complete core suite;
+4. the complete Debug app build required by `AGENTS.md`;
+5. a Release app build;
+6. binary/bundle inspection for `RADIX_BENCH_FILE_BROWSER`, `RADIX_FILE_BROWSER_BENCH_RESULT`, benchmark test class names, and fixture/RSS sampler symbols, requiring no matches in the Release app product;
+7. `git diff --check`, focused diff review, and status checks in both the worktree and canonical checkout.
+
+The final report will distinguish measured baseline, measured after-state, local validation, Release benchmark-code exclusion, and any work not performed. It will not claim release readiness beyond the evidence collected.

--- a/Radix/Services/FileBrowserResults.swift
+++ b/Radix/Services/FileBrowserResults.swift
@@ -83,16 +83,155 @@ enum FileBrowserResults {
         try cancellationCheck()
         guard !sortOrder.isEmpty else { return nodes }
 
-        let preparedNodes = try preparedSortNodes(
+        var preparedNodes = try preparedSortNodes(
             nodes,
+            sortOrder: sortOrder,
             fileTreeStore: fileTreeStore,
             cancellationCheck: cancellationCheck
         )
         try cancellationCheck()
 
-        let sortedNodes = preparedNodes.sorted { lhs, rhs in
+        let sortedNodes = try cancellablySorted(
+            &preparedNodes,
+            sortOrder: sortOrder,
+            cancellationCheck: cancellationCheck
+        )
+        try cancellationCheck()
+        return sortedNodes.map(\.node)
+    }
+
+    private nonisolated static func cancellablySorted(
+        _ nodes: inout [PreparedSortNode],
+        sortOrder: [FileNodeTableComparator],
+        cancellationCheck: @Sendable () throws -> Void
+    ) throws -> [PreparedSortNode] {
+        let chunkSize = 16_384
+        guard nodes.count > chunkSize else {
+            return nodes.sorted { lhs, rhs in
+                lhs.isOrderedBefore(rhs, using: sortOrder)
+            }
+        }
+
+        var source: [PreparedSortNode] = []
+        source.reserveCapacity(nodes.count)
+
+        for start in stride(from: 0, to: nodes.count, by: chunkSize) {
+            try cancellationCheck()
+            let end = min(start + chunkSize, nodes.count)
+            source.append(contentsOf: nodes[start..<end].sorted { lhs, rhs in
+                lhs.isOrderedBefore(rhs, using: sortOrder)
+            })
+        }
+        nodes.removeAll(keepingCapacity: false)
+        try cancellationCheck()
+        var destination = source
+        var runSize = chunkSize
+        while runSize < source.count {
+            let combinedRunSize = runSize * 2
+            for start in stride(from: 0, to: source.count, by: combinedRunSize) {
+                try mergeSortedRuns(
+                    from: source,
+                    into: &destination,
+                    start: start,
+                    middle: min(start + runSize, source.count),
+                    end: min(start + combinedRunSize, source.count),
+                    sortOrder: sortOrder,
+                    cancellationCheck: cancellationCheck
+                )
+            }
+            swap(&source, &destination)
+            runSize = combinedRunSize
+        }
+        return source
+    }
+
+    private nonisolated static func mergeSortedRuns(
+        from source: [PreparedSortNode],
+        into destination: inout [PreparedSortNode],
+        start: Int,
+        middle: Int,
+        end: Int,
+        sortOrder: [FileNodeTableComparator],
+        cancellationCheck: @Sendable () throws -> Void
+    ) throws {
+        var lhsIndex = start
+        var rhsIndex = middle
+
+        for writeIndex in start..<end {
+            if (writeIndex - start).isMultiple(of: 256) {
+                try cancellationCheck()
+            }
+            if lhsIndex == middle {
+                destination[writeIndex] = source[rhsIndex]
+                rhsIndex += 1
+            } else if rhsIndex == end ||
+                        !source[rhsIndex].isOrderedBefore(source[lhsIndex], using: sortOrder) {
+                destination[writeIndex] = source[lhsIndex]
+                lhsIndex += 1
+            } else {
+                destination[writeIndex] = source[rhsIndex]
+                rhsIndex += 1
+            }
+        }
+    }
+
+    private nonisolated static func preparedSortNodes(
+        _ nodes: [FileNodeRecord],
+        sortOrder: [FileNodeTableComparator],
+        fileTreeStore: FileTreeStore?,
+        cancellationCheck: @Sendable () throws -> Void
+    ) throws -> [PreparedSortNode] {
+        let preparesItemKind = sortOrder.contains { $0.field == .itemKind }
+        let preparesDescendantFileCount = sortOrder.contains { $0.field == .descendantFileCount }
+        var preparedNodes: [PreparedSortNode] = []
+        preparedNodes.reserveCapacity(nodes.count)
+
+        for (offset, node) in nodes.enumerated() {
+            if offset.isMultiple(of: 256) {
+                try cancellationCheck()
+            }
+            preparedNodes.append(PreparedSortNode(
+                node: node,
+                itemKind: preparesItemKind ? node.itemKind : nil,
+                descendantFileCount: preparesDescendantFileCount
+                    ? (FileBrowserPackageContents.areHidden(for: node, fileTreeStore: fileTreeStore)
+                        ? 0
+                        : node.descendantFileCount)
+                    : nil
+            ))
+        }
+
+        return preparedNodes
+    }
+
+    private struct PreparedSortNode {
+        let node: FileNodeRecord
+        let itemKind: String?
+        let descendantFileCount: Int?
+
+        nonisolated func compare(_ rhs: PreparedSortNode, using comparator: FileNodeTableComparator) -> ComparisonResult {
+            let result: ComparisonResult = switch comparator.field {
+            case .name:
+                node.name.localizedStandardCompare(rhs.node.name)
+            case .allocatedSize:
+                FileNodeSortComparison.compare(node.allocatedSize, rhs.node.allocatedSize)
+            case .itemKind:
+                itemKind!.localizedStandardCompare(rhs.itemKind!)
+            case .descendantFileCount:
+                FileNodeSortComparison.compare(descendantFileCount!, rhs.descendantFileCount!)
+            case .lastModified:
+                FileNodeSortComparison.compareOptional(node.lastModified, rhs.node.lastModified)
+            }
+
+            return FileNodeSortComparison.applying(comparator.order, to: result)
+        }
+
+        nonisolated func isOrderedBefore(
+            _ rhs: PreparedSortNode,
+            using sortOrder: [FileNodeTableComparator]
+        ) -> Bool {
             for comparator in sortOrder {
-                switch lhs.compare(rhs, using: comparator) {
+                switch compare(rhs, using: comparator) {
                 case .orderedAscending:
                     return true
                 case .orderedDescending:
@@ -104,70 +243,11 @@ enum FileBrowserResults {
                 }
             }
             return FileNodeSortComparison.fallback(
-                lhsName: lhs.name,
-                lhsID: lhs.id,
-                rhsName: rhs.name,
-                rhsID: rhs.id
+                lhsName: node.name,
+                lhsID: node.id,
+                rhsName: rhs.node.name,
+                rhsID: rhs.node.id
             ) == .orderedAscending
-        }
-        try cancellationCheck()
-        return sortedNodes.map(\.node)
-    }
-
-    private nonisolated static func preparedSortNodes(
-        _ nodes: [FileNodeRecord],
-        fileTreeStore: FileTreeStore?,
-        cancellationCheck: @Sendable () throws -> Void
-    ) throws -> [PreparedSortNode] {
-        var preparedNodes: [PreparedSortNode] = []
-        preparedNodes.reserveCapacity(nodes.count)
-
-        for (offset, node) in nodes.enumerated() {
-            if offset.isMultiple(of: 256) {
-                try cancellationCheck()
-            }
-            preparedNodes.append(PreparedSortNode(node: node, fileTreeStore: fileTreeStore))
-        }
-
-        return preparedNodes
-    }
-
-    private struct PreparedSortNode {
-        let node: FileNodeRecord
-        let name: String
-        let id: String
-        let allocatedSize: Int64
-        let itemKind: String
-        let descendantFileCount: Int
-        let lastModified: Date?
-
-        nonisolated init(node: FileNodeRecord, fileTreeStore: FileTreeStore?) {
-            self.node = node
-            self.name = node.name
-            self.id = node.id
-            self.allocatedSize = node.allocatedSize
-            self.itemKind = node.itemKind
-            self.descendantFileCount = FileBrowserPackageContents.areHidden(for: node, fileTreeStore: fileTreeStore)
-                ? 0
-                : node.descendantFileCount
-            self.lastModified = node.lastModified
-        }
-
-        nonisolated func compare(_ rhs: PreparedSortNode, using comparator: FileNodeTableComparator) -> ComparisonResult {
-            let result: ComparisonResult = switch comparator.field {
-            case .name:
-                name.localizedStandardCompare(rhs.name)
-            case .allocatedSize:
-                FileNodeSortComparison.compare(allocatedSize, rhs.allocatedSize)
-            case .itemKind:
-                itemKind.localizedStandardCompare(rhs.itemKind)
-            case .descendantFileCount:
-                FileNodeSortComparison.compare(descendantFileCount, rhs.descendantFileCount)
-            case .lastModified:
-                FileNodeSortComparison.compareOptional(lastModified, rhs.lastModified)
-            }
-
-            return FileNodeSortComparison.applying(comparator.order, to: result)
         }
     }
 }

--- a/RadixCoreTests/FileBrowserBenchmarkTests.swift
+++ b/RadixCoreTests/FileBrowserBenchmarkTests.swift
@@ -320,15 +320,31 @@ final class FileBrowserBenchmarkTests: XCTestCase {
         model.setSearchScope(.entireScan)
 
         let startedAt = ContinuousClock.now
+        let deadline = startedAt.advanced(by: .seconds(60))
+        defer { model.cleanup() }
+
         model.setActiveQuery(query)
-        while model.isSearchingEntireScan {
+        while !model.isSearchingEntireScan, ContinuousClock.now < deadline {
+            await Task.yield()
+        }
+        guard model.isSearchingEntireScan else {
+            throw FileBrowserBenchmarkTimeoutError(
+                message: "Timed out waiting for the end-to-end entire-scan search to start."
+            )
+        }
+
+        while model.isSearchingEntireScan, ContinuousClock.now < deadline {
             try await Task.sleep(for: .milliseconds(1))
+        }
+        guard !model.isSearchingEntireScan else {
+            throw FileBrowserBenchmarkTimeoutError(
+                message: "Timed out waiting for the end-to-end entire-scan search to finish."
+            )
         }
         let seconds = durationSeconds(startedAt.duration(to: .now))
 
         XCTAssertTrue(model.isDisplayingCurrentResults)
         XCTAssertEqual(model.displayedNodes.count, fixture.fileCount)
-        model.cleanup()
         return seconds
     }
 
@@ -665,4 +681,12 @@ private struct CancellationMeasurement {
     let seconds: Double
     let wasCancelled: Bool
     let completedBeforeCancellation: Bool
+}
+
+private struct FileBrowserBenchmarkTimeoutError: LocalizedError {
+    let message: String
+
+    var errorDescription: String? {
+        message
+    }
 }

--- a/RadixCoreTests/FileBrowserBenchmarkTests.swift
+++ b/RadixCoreTests/FileBrowserBenchmarkTests.swift
@@ -1,0 +1,668 @@
+import Combine
+import Darwin
+import Foundation
+import XCTest
+@testable import RadixCore
+
+final class FileBrowserBenchmarkTests: XCTestCase {
+    func testMillionNodeFileBrowserBenchmark() async throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard environment["RADIX_BENCH_FILE_BROWSER"] == "1" else {
+            throw XCTSkip(
+                "Set RADIX_BENCH_FILE_BROWSER=1 to run the million-node File Browser benchmark."
+            )
+        }
+
+        let directoryCount = environment["RADIX_BENCH_FILE_BROWSER_DIRECTORIES"]
+            .flatMap(Int.init)
+            .map { max(1, $0) } ?? 1_000
+        let filesPerDirectory = environment["RADIX_BENCH_FILE_BROWSER_FILES_PER_DIRECTORY"]
+            .flatMap(Int.init)
+            .map { max(1, $0) } ?? 1_000
+        let warmIterationCount = environment["RADIX_BENCH_FILE_BROWSER_WARM_ITERATIONS"]
+            .flatMap(Int.init)
+            .map { max(1, $0) } ?? 3
+
+        let initialPeakRSS = Self.peakResidentBytes()
+        let fixtureMeasurement = Self.measure {
+            Self.makeFixture(
+                directoryCount: directoryCount,
+                filesPerDirectory: filesPerDirectory
+            )
+        }
+        let fixture = fixtureMeasurement.value
+        let fixturePeakRSS = Self.peakResidentBytes()
+
+        XCTAssertEqual(
+            fixture.store.nodeCount,
+            (directoryCount * filesPerDirectory) + directoryCount + 1
+        )
+        Self.report(
+            phase: "fixture",
+            seconds: fixtureMeasurement.seconds,
+            count: fixture.store.nodeCount,
+            peakRSS: fixturePeakRSS,
+            extra: "rss_delta=\(Self.byteDelta(from: initialPeakRSS, to: fixturePeakRSS))"
+        )
+
+        let snapshotID = UUID()
+        let searchService = await FileSearchService()
+        let noMatchQuery = FileBrowserQuery(text: "__radix_no_match__")
+        let coldMeasurement = try await Self.measureAsync {
+            try await searchService.search(
+                snapshotID: snapshotID,
+                treeStore: fixture.store,
+                query: noMatchQuery,
+                sortOrder: []
+            )
+        }
+        XCTAssertTrue(coldMeasurement.value.isEmpty)
+
+        let warmNoMatchSamples = try await Self.measureSearchSamples(
+            count: warmIterationCount,
+            service: searchService,
+            snapshotID: snapshotID,
+            store: fixture.store,
+            query: noMatchQuery,
+            sortOrder: []
+        )
+        let warmNoMatchMedian = Self.median(warmNoMatchSamples.map(\.seconds))
+        let estimatedIndexSeconds = max(coldMeasurement.seconds - warmNoMatchMedian, 0)
+        let indexedPeakRSS = Self.peakResidentBytes()
+        Self.report(
+            phase: "cold_index",
+            seconds: estimatedIndexSeconds,
+            count: fixture.store.nodeCount - 1,
+            peakRSS: indexedPeakRSS,
+            extra: "cold_total=\(Self.format(coldMeasurement.seconds)) " +
+                "warm_scan_median=\(Self.format(warmNoMatchMedian)) " +
+                "rss_delta=\(Self.byteDelta(from: fixturePeakRSS, to: indexedPeakRSS))"
+        )
+
+        let textSamples = try await Self.measureSearchSamples(
+            count: warmIterationCount,
+            service: searchService,
+            snapshotID: snapshotID,
+            store: fixture.store,
+            query: FileBrowserQuery(text: "needle"),
+            sortOrder: []
+        )
+        let expectedNeedleCount = filesPerDirectory > 777
+            ? ((directoryCount - 1) / 100) + 1
+            : 0
+        XCTAssertTrue(textSamples.allSatisfy { $0.resultCount == expectedNeedleCount })
+        Self.reportSamples(
+            phase: "warm_text",
+            samples: textSamples,
+            count: expectedNeedleCount
+        )
+
+        let pathDirectoryOffset = directoryCount / 2
+        let pathQuery = FileBrowserQuery(
+            text: String(format: "/benchmark/directory-%04d/", pathDirectoryOffset)
+        )
+        let firstPathMeasurement = try await Self.measureAsync {
+            try await searchService.search(
+                snapshotID: snapshotID,
+                treeStore: fixture.store,
+                query: pathQuery,
+                sortOrder: []
+            )
+        }
+        XCTAssertEqual(firstPathMeasurement.value.count, filesPerDirectory)
+        let warmPathSamples = try await Self.measureSearchSamples(
+            count: warmIterationCount,
+            service: searchService,
+            snapshotID: snapshotID,
+            store: fixture.store,
+            query: pathQuery,
+            sortOrder: []
+        )
+        XCTAssertTrue(warmPathSamples.allSatisfy { $0.resultCount == filesPerDirectory })
+        Self.report(
+            phase: "path_first",
+            seconds: firstPathMeasurement.seconds,
+            count: filesPerDirectory,
+            peakRSS: Self.peakResidentBytes()
+        )
+        Self.reportSamples(
+            phase: "path_warm",
+            samples: warmPathSamples,
+            count: filesPerDirectory
+        )
+
+        let filterQuery = FileBrowserQuery(itemKind: .file)
+        let filterSamples = try await Self.measureSearchSamples(
+            count: warmIterationCount,
+            service: searchService,
+            snapshotID: snapshotID,
+            store: fixture.store,
+            query: filterQuery,
+            sortOrder: []
+        )
+        XCTAssertTrue(filterSamples.allSatisfy { $0.resultCount == fixture.fileCount })
+        let largeResults = try await searchService.search(
+            snapshotID: snapshotID,
+            treeStore: fixture.store,
+            query: filterQuery,
+            sortOrder: []
+        )
+        Self.reportSamples(
+            phase: "filter_large",
+            samples: filterSamples,
+            count: largeResults.count
+        )
+
+        let sortOrder = [FileNodeTableComparator(field: .allocatedSize, order: .reverse)]
+        let sortingMeasurement = try Self.measure {
+            try FileBrowserResults.sorted(
+                largeResults,
+                sortOrder: sortOrder,
+                fileTreeStore: fixture.store,
+                cancellationCheck: {}
+            )
+        }
+        let sortedResults = sortingMeasurement.value
+        let sortingPeakRSS = Self.peakResidentBytes()
+        XCTAssertEqual(sortedResults.count, fixture.fileCount)
+        Self.assertSorted(
+            sortedResults,
+            using: sortOrder,
+            fileTreeStore: fixture.store
+        )
+        let sortFingerprint = Self.fingerprint(sortedResults)
+        Self.report(
+            phase: "sorting",
+            seconds: sortingMeasurement.seconds,
+            count: sortedResults.count,
+            peakRSS: sortingPeakRSS,
+            extra: "fingerprint=\(sortFingerprint)"
+        )
+
+        let publicationMeasurement = await Self.measurePublication(sortedResults)
+        Self.report(
+            phase: "main_actor_publication",
+            seconds: publicationMeasurement,
+            count: sortedResults.count,
+            peakRSS: Self.peakResidentBytes()
+        )
+
+        let coldCancellation = try await Self.measureColdSearchCancellation(
+            store: fixture.store,
+            query: noMatchQuery
+        )
+        XCTAssertTrue(
+            coldCancellation.wasCancelled || coldCancellation.completedBeforeCancellation,
+            "Cold search returned normally after cancellation was requested."
+        )
+        Self.report(
+            phase: "cancel_cold_search",
+            seconds: coldCancellation.seconds,
+            count: fixture.store.nodeCount - 1,
+            peakRSS: Self.peakResidentBytes(),
+            extra: "cancelled=\(coldCancellation.wasCancelled) " +
+                "completed_before_cancel=\(coldCancellation.completedBeforeCancellation)"
+        )
+
+        let sortCancellation = try await Self.measureSortCancellation(
+            nodes: largeResults,
+            sortOrder: sortOrder,
+            store: fixture.store,
+            baselineSortSeconds: sortingMeasurement.seconds
+        )
+        XCTAssertTrue(
+            sortCancellation.wasCancelled || sortCancellation.completedBeforeCancellation,
+            "Sort returned normally after cancellation was requested."
+        )
+        Self.report(
+            phase: "cancel_sort",
+            seconds: sortCancellation.seconds,
+            count: largeResults.count,
+            peakRSS: Self.peakResidentBytes(),
+            extra: "cancelled=\(sortCancellation.wasCancelled) " +
+                "completed_before_cancel=\(sortCancellation.completedBeforeCancellation)"
+        )
+
+        let endToEndSeconds = try await Self.measureEndToEnd(
+            fixture: fixture,
+            service: searchService,
+            query: filterQuery
+        )
+        Self.report(
+            phase: "end_to_end",
+            seconds: endToEndSeconds,
+            count: fixture.fileCount,
+            peakRSS: Self.peakResidentBytes()
+        )
+
+        Self.report(
+            phase: "suite_peak_rss",
+            seconds: 0,
+            count: fixture.store.nodeCount,
+            peakRSS: Self.peakResidentBytes(),
+            extra: "rss_delta=\(Self.byteDelta(from: initialPeakRSS, to: Self.peakResidentBytes()))"
+        )
+    }
+
+    private static func measureSearchSamples(
+        count: Int,
+        service: FileSearchService,
+        snapshotID: UUID,
+        store: FileTreeStore,
+        query: FileBrowserQuery,
+        sortOrder: [FileNodeTableComparator]
+    ) async throws -> [SearchSample] {
+        var samples: [SearchSample] = []
+        samples.reserveCapacity(count)
+        for _ in 0..<count {
+            let measurement = try await measureAsync {
+                try await service.search(
+                    snapshotID: snapshotID,
+                    treeStore: store,
+                    query: query,
+                    sortOrder: sortOrder
+                )
+            }
+            samples.append(SearchSample(
+                seconds: measurement.seconds,
+                resultCount: measurement.value.count
+            ))
+        }
+        return samples
+    }
+
+    @MainActor
+    private static func measurePublication(_ nodes: [FileNodeRecord]) -> Double {
+        let publisher = FileBrowserPublicationProbe()
+        var publicationCount = 0
+        let cancellable = publisher.objectWillChange.sink {
+            publicationCount += 1
+        }
+
+        let startedAt = ContinuousClock.now
+        publisher.publish(nodes)
+        let seconds = durationSeconds(startedAt.duration(to: .now))
+
+        XCTAssertEqual(publicationCount, 1)
+        XCTAssertEqual(publisher.nodeCount, nodes.count)
+        XCTAssertEqual(publisher.node(id: nodes[0].id)?.id, nodes[0].id)
+        XCTAssertEqual(publisher.node(id: nodes[nodes.count - 1].id)?.id, nodes[nodes.count - 1].id)
+        withExtendedLifetime(cancellable) {}
+        return seconds
+    }
+
+    @MainActor
+    private static func measureEndToEnd(
+        fixture: Fixture,
+        service: FileSearchService,
+        query: FileBrowserQuery
+    ) async throws -> Double {
+        let snapshot = ScanSnapshot(
+            target: ScanTarget(url: fixture.store.root.url),
+            treeStore: fixture.store,
+            startedAt: Date(timeIntervalSinceReferenceDate: 0),
+            finishedAt: Date(timeIntervalSinceReferenceDate: 1),
+            scanWarnings: [],
+            aggregateStats: fixture.store.aggregateStats,
+            isComplete: true
+        )
+        let model = FileBrowserModel(
+            searchService: service,
+            searchDebounceDuration: .zero,
+            currentContentsAsyncThreshold: .max
+        )
+        model.updateContent(
+            nodes: fixture.store.children(of: fixture.store.root.id),
+            contentID: "\(snapshot.id.uuidString)|\(snapshot.root.id)",
+            snapshot: snapshot,
+            fileTreeStore: fixture.store
+        )
+        model.setSearchScope(.entireScan)
+
+        let startedAt = ContinuousClock.now
+        model.setActiveQuery(query)
+        while model.isSearchingEntireScan {
+            try await Task.sleep(for: .milliseconds(1))
+        }
+        let seconds = durationSeconds(startedAt.duration(to: .now))
+
+        XCTAssertTrue(model.isDisplayingCurrentResults)
+        XCTAssertEqual(model.displayedNodes.count, fixture.fileCount)
+        model.cleanup()
+        return seconds
+    }
+
+    private static func measureColdSearchCancellation(
+        store: FileTreeStore,
+        query: FileBrowserQuery
+    ) async throws -> CancellationMeasurement {
+        let service = await FileSearchService()
+        let task = Task {
+            _ = try await service.search(
+                snapshotID: UUID(),
+                treeStore: store,
+                query: query,
+                sortOrder: []
+            )
+            return ContinuousClock.now
+        }
+        await Task.yield()
+        try await Task.sleep(for: .milliseconds(2))
+
+        let cancellationRequestedAt = ContinuousClock.now
+        task.cancel()
+        do {
+            let completedAt = try await task.value
+            return CancellationMeasurement(
+                seconds: durationSeconds(cancellationRequestedAt.duration(to: .now)),
+                wasCancelled: false,
+                completedBeforeCancellation: completedAt <= cancellationRequestedAt
+            )
+        } catch is CancellationError {
+            return CancellationMeasurement(
+                seconds: durationSeconds(cancellationRequestedAt.duration(to: .now)),
+                wasCancelled: true,
+                completedBeforeCancellation: false
+            )
+        }
+    }
+
+    private static func measureSortCancellation(
+        nodes: [FileNodeRecord],
+        sortOrder: [FileNodeTableComparator],
+        store: FileTreeStore,
+        baselineSortSeconds: Double
+    ) async throws -> CancellationMeasurement {
+        let task = Task.detached {
+            _ = try FileBrowserResults.sorted(
+                nodes,
+                sortOrder: sortOrder,
+                fileTreeStore: store,
+                cancellationCheck: {
+                    try Task.checkCancellation()
+                }
+            )
+            return ContinuousClock.now
+        }
+        let delaySeconds = min(max(baselineSortSeconds * 0.5, 0.01), 1.5)
+        try await Task.sleep(for: .seconds(delaySeconds))
+
+        let cancellationRequestedAt = ContinuousClock.now
+        task.cancel()
+        do {
+            let completedAt = try await task.value
+            return CancellationMeasurement(
+                seconds: durationSeconds(cancellationRequestedAt.duration(to: .now)),
+                wasCancelled: false,
+                completedBeforeCancellation: completedAt <= cancellationRequestedAt
+            )
+        } catch is CancellationError {
+            return CancellationMeasurement(
+                seconds: durationSeconds(cancellationRequestedAt.duration(to: .now)),
+                wasCancelled: true,
+                completedBeforeCancellation: false
+            )
+        }
+    }
+
+    private static func makeFixture(
+        directoryCount: Int,
+        filesPerDirectory: Int
+    ) -> Fixture {
+        let fileCount = directoryCount * filesPerDirectory
+        let nodeCount = fileCount + directoryCount + 1
+        let rootIndex = FileTreeNodeIndex(rawValue: 0)
+        let rootID = "/benchmark"
+        var nodes = [FileNodeRecord(
+            id: rootID,
+            url: URL(filePath: rootID, directoryHint: .isDirectory),
+            name: "benchmark",
+            isDirectory: true,
+            isSymbolicLink: false,
+            allocatedSize: Int64(fileCount),
+            logicalSize: Int64(fileCount),
+            descendantFileCount: fileCount,
+            lastModified: nil,
+            isPackage: false,
+            isAccessible: true,
+            isSelfAccessible: true,
+            isSynthetic: false,
+            isAutoSummarized: false
+        )]
+        nodes.reserveCapacity(nodeCount)
+        var childIndicesByIndex = Array(repeating: [FileTreeNodeIndex](), count: nodeCount)
+        var parentIndices = Array<FileTreeNodeIndex?>(repeating: nil, count: nodeCount)
+        var rootChildren: [FileTreeNodeIndex] = []
+        rootChildren.reserveCapacity(directoryCount)
+
+        for directoryOffset in 0..<directoryCount {
+            let directoryID = String(format: "%@/directory-%04d", rootID, directoryOffset)
+            let directoryIndex = FileTreeNodeIndex(rawValue: UInt32(nodes.count))
+            nodes.append(FileNodeRecord(
+                id: directoryID,
+                url: URL(filePath: directoryID, directoryHint: .isDirectory),
+                name: URL(filePath: directoryID).lastPathComponent,
+                isDirectory: true,
+                isSymbolicLink: false,
+                allocatedSize: Int64(filesPerDirectory),
+                logicalSize: Int64(filesPerDirectory),
+                descendantFileCount: filesPerDirectory,
+                lastModified: nil,
+                isPackage: false,
+                isAccessible: true,
+                isSelfAccessible: true,
+                isSynthetic: false,
+                isAutoSummarized: false
+            ))
+            parentIndices[Int(directoryIndex.rawValue)] = rootIndex
+            rootChildren.append(directoryIndex)
+
+            var directoryChildren: [FileTreeNodeIndex] = []
+            directoryChildren.reserveCapacity(filesPerDirectory)
+            for fileOffset in 0..<filesPerDirectory {
+                let fileIndex = FileTreeNodeIndex(rawValue: UInt32(nodes.count))
+                let name = directoryOffset.isMultiple(of: 100) && fileOffset == 777
+                    ? String(format: "needle-%06d.dat", directoryOffset)
+                    : String(format: "item-%04d.dat", fileOffset)
+                let fileID = directoryID + "/" + name
+                let sequence = (directoryOffset * filesPerDirectory) + fileOffset
+                let allocatedSize = Int64(((sequence * 37) % 16_384) + 1)
+                nodes.append(FileNodeRecord(
+                    id: fileID,
+                    url: URL(filePath: fileID),
+                    name: name,
+                    isDirectory: false,
+                    isSymbolicLink: false,
+                    allocatedSize: allocatedSize,
+                    logicalSize: allocatedSize,
+                    descendantFileCount: 1,
+                    lastModified: Date(timeIntervalSinceReferenceDate: Double(sequence % 10_000)),
+                    isPackage: false,
+                    isAccessible: true,
+                    isSelfAccessible: true,
+                    isSynthetic: false,
+                    isAutoSummarized: false
+                ))
+                parentIndices[Int(fileIndex.rawValue)] = directoryIndex
+                directoryChildren.append(fileIndex)
+            }
+            childIndicesByIndex[Int(directoryIndex.rawValue)] = directoryChildren
+        }
+        childIndicesByIndex[0] = rootChildren
+
+        let store = FileTreeStore(
+            verifiedRootIndex: rootIndex,
+            nodes: nodes,
+            childIndicesByIndex: childIndicesByIndex,
+            parentIndices: parentIndices,
+            orderedNodeIndices: nodes.indices.map { FileTreeNodeIndex(rawValue: UInt32($0)) },
+            aggregateStats: ScanAggregateStats(
+                totalAllocatedSize: Int64(fileCount),
+                totalLogicalSize: Int64(fileCount),
+                fileCount: fileCount,
+                directoryCount: directoryCount + 1,
+                accessibleItemCount: nodeCount,
+                inaccessibleItemCount: 0
+            )
+        )
+        return Fixture(store: store, fileCount: fileCount)
+    }
+
+    private static func assertSorted(
+        _ nodes: [FileNodeRecord],
+        using sortOrder: [FileNodeTableComparator],
+        fileTreeStore: FileTreeStore? = nil,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        for offset in 1..<nodes.count {
+            let lhs = nodes[offset - 1]
+            let rhs = nodes[offset]
+            var result = ComparisonResult.orderedSame
+            for comparator in sortOrder {
+                result = comparator.compare(lhs, rhs, fileTreeStore: fileTreeStore)
+                if result != .orderedSame {
+                    break
+                }
+            }
+            if result == .orderedSame {
+                result = FileNodeSortComparison.fallback(
+                    lhsName: lhs.name,
+                    lhsID: lhs.id,
+                    rhsName: rhs.name,
+                    rhsID: rhs.id
+                )
+            }
+            XCTAssertNotEqual(result, .orderedDescending, file: file, line: line)
+        }
+    }
+
+    private static func fingerprint(_ nodes: [FileNodeRecord]) -> String {
+        var hash: UInt64 = 14_695_981_039_346_656_037
+        for node in nodes {
+            for byte in node.id.utf8 {
+                hash ^= UInt64(byte)
+                hash &*= 1_099_511_628_211
+            }
+            hash ^= UInt64(bitPattern: node.allocatedSize)
+            hash &*= 1_099_511_628_211
+        }
+        return String(hash, radix: 16)
+    }
+
+    private static func measure<Value>(_ operation: () throws -> Value) rethrows -> Measurement<Value> {
+        let startedAt = ContinuousClock.now
+        let value = try operation()
+        return Measurement(
+            value: value,
+            seconds: durationSeconds(startedAt.duration(to: .now))
+        )
+    }
+
+    private static func measureAsync<Value>(
+        _ operation: () async throws -> Value
+    ) async rethrows -> Measurement<Value> {
+        let startedAt = ContinuousClock.now
+        let value = try await operation()
+        return Measurement(
+            value: value,
+            seconds: durationSeconds(startedAt.duration(to: .now))
+        )
+    }
+
+    private static func durationSeconds(_ duration: Duration) -> Double {
+        let components = duration.components
+        return Double(components.seconds) +
+            (Double(components.attoseconds) / 1_000_000_000_000_000_000)
+    }
+
+    private static func median(_ values: [Double]) -> Double {
+        let sortedValues = values.sorted()
+        let midpoint = sortedValues.count / 2
+        if sortedValues.count.isMultiple(of: 2) {
+            return (sortedValues[midpoint - 1] + sortedValues[midpoint]) / 2
+        }
+        return sortedValues[midpoint]
+    }
+
+    private static func reportSamples(
+        phase: String,
+        samples: [SearchSample],
+        count: Int
+    ) {
+        let seconds = samples.map(\.seconds)
+        report(
+            phase: phase,
+            seconds: median(seconds),
+            count: count,
+            peakRSS: peakResidentBytes(),
+            extra: "samples=\(seconds.map(format).joined(separator: ","))"
+        )
+    }
+
+    private static func report(
+        phase: String,
+        seconds: Double,
+        count: Int,
+        peakRSS: UInt64,
+        extra: String = ""
+    ) {
+        print(
+            "RADIX_FILE_BROWSER_BENCH_RESULT phase=\(phase) " +
+                "seconds=\(format(seconds)) count=\(count) " +
+                "peak_rss=\(peakRSS) \(extra)"
+        )
+    }
+
+    private static func format(_ value: Double) -> String {
+        String(format: "%.6f", value)
+    }
+
+    private static func peakResidentBytes() -> UInt64 {
+        var usage = rusage()
+        guard getrusage(RUSAGE_SELF, &usage) == 0 else { return 0 }
+        return UInt64(max(usage.ru_maxrss, 0))
+    }
+
+    private static func byteDelta(from start: UInt64, to end: UInt64) -> UInt64 {
+        end >= start ? end - start : 0
+    }
+}
+
+@MainActor
+private final class FileBrowserPublicationProbe: ObservableObject {
+    @Published private var displayState = FileBrowserDisplayState()
+
+    var nodeCount: Int {
+        displayState.nodes.count
+    }
+
+    func node(id: FileNodeRecord.ID) -> FileNodeRecord? {
+        displayState.node(id: id)
+    }
+
+    func publish(_ nodes: [FileNodeRecord]) {
+        displayState = FileBrowserDisplayState(nodes: nodes, context: .empty)
+    }
+}
+
+private struct Fixture: Sendable {
+    let store: FileTreeStore
+    let fileCount: Int
+}
+
+private struct Measurement<Value> {
+    let value: Value
+    let seconds: Double
+}
+
+private struct SearchSample {
+    let seconds: Double
+    let resultCount: Int
+}
+
+private struct CancellationMeasurement {
+    let seconds: Double
+    let wasCancelled: Bool
+    let completedBeforeCancellation: Bool
+}

--- a/RadixCoreTests/FileBrowserModelTests.swift
+++ b/RadixCoreTests/FileBrowserModelTests.swift
@@ -511,6 +511,49 @@ final class FileBrowserModelTests: XCTestCase {
         XCTAssertEqual(probe.checkCount, 3)
     }
 
+    func testLargeSortPreservesOrderAcrossSortedRuns() throws {
+        let nodes = (0..<20_000).map { index in
+            makeTestFileNode(
+                id: "/root/file-\(index).dat",
+                name: "file-\(index).dat",
+                size: Int64(index)
+            )
+        }
+
+        let sortedNodes = try FileBrowserResults.sorted(
+            nodes,
+            sortOrder: [FileNodeTableComparator(field: .allocatedSize, order: .reverse)],
+            cancellationCheck: {}
+        )
+
+        XCTAssertEqual(sortedNodes.map(\.id), nodes.reversed().map(\.id))
+    }
+
+    func testCancellableSortChecksCancellationBetweenLargeRuns() {
+        let nodes = (0..<20_000).map { index in
+            makeTestFileNode(
+                id: "/root/file-\(index).dat",
+                name: "file-\(index).dat",
+                size: Int64(index)
+            )
+        }
+        let preparationCheckCount = (nodes.count + 255) / 256
+        // Entry, preparation, post-preparation, and one check before each sorted run.
+        let firstCheckAfterOneSortedRun = preparationCheckCount + 4
+        let probe = SortCancellationProbe(throwOnCheck: firstCheckAfterOneSortedRun)
+
+        XCTAssertThrowsError(
+            try FileBrowserResults.sorted(
+                nodes,
+                sortOrder: [FileNodeTableComparator(field: .allocatedSize, order: .reverse)],
+                cancellationCheck: probe.check
+            )
+        ) { error in
+            XCTAssertTrue(error is CancellationError)
+        }
+        XCTAssertEqual(probe.checkCount, firstCheckAfterOneSortedRun)
+    }
+
     func testCancellableSortOrderMatchesTableComparators() throws {
         let older = Date(timeIntervalSince1970: 10)
         let newer = Date(timeIntervalSince1970: 20)


### PR DESCRIPTION
## Summary

- add an opt-in, test-target-only benchmark for million-node File Browser workloads
- bound large-result sorting into cancellable 16,384-row runs with reusable merge buffers
- prepare derived sort fields only when active descriptors require them
- add focused ordering and cancellation coverage, plus the pre-edit plan and measured report

Small result sets continue to use the existing direct sort path. No cache or persistent state was added, and no Discard Pile, sidebar scan caching, snapshot scoping, or chart work is included.

## Benchmark results

Release SwiftPM benchmark, 1,001,001-node fixture, three fresh processes per version:

| Phase | Baseline | Optimized | Change |
| --- | ---: | ---: | ---: |
| Allocated-size sort, 1,000,000 results | 3.048 s | 2.793 s | 8.4% faster |
| Active-sort cancellation | 1.348 s | 0.092 s | 93.2% faster |
| Peak RSS at sort completion | 2,034.97 MiB | 1,946.66 MiB | 88.31 MiB lower |
| Main-actor publication | 0.283 s | 0.261 s | no claimed change; spreads overlap |

All full runs returned exactly 1,000,000 results with ordering fingerprint `8f64003a74b8684`. The corrected cancellation harness confirmed every measured cancellation threw `CancellationError` after the request rather than returning normally.

## Validation

- `swift test --filter FileBrowserModelTests`: 40 passed
- `swift test`: 747 passed, 19 expected opt-in skips
- opt-in million-node Release benchmark: passed with complete descriptor and name/ID fallback validation
- Debug app build: passed
- Release app build: passed
- Release bundle, executable, and Swift source list contain no benchmark gate, result prefix, test class, fixture, or publication probe
- `git diff --check`: passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved File Browser sorting for very large result sets.
  * Added cancellation support during lengthy sorting operations.
  * Preserved existing sorting behavior for smaller result sets.

* **Documentation**
  * Added performance plans and benchmark results for million-node File Browser searches.

* **Tests**
  * Added coverage for large-result sorting and cancellation.
  * Added opt-in benchmarks covering search, filtering, sorting, memory usage, and end-to-end updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->