### PR TITLE
perf(charts): improve sunburst responsiveness

### DIFF
--- a/Radix/Services/SunburstChartModel.swift
+++ b/Radix/Services/SunburstChartModel.swift
@@ -38,7 +38,10 @@ final class SunburstChartModel: ObservableObject {
 
     private let layoutService: any SunburstLayouting
     private let layoutRequests = ChartLayoutRequestCoordinator<[SunburstSegment]>()
-    private var selectionOverlayCache = SunburstSelectionOverlayCache(capacity: 8)
+    private var selectionIndex = SunburstSelectionIndex(
+        segmentIndex: SunburstSegmentIndex(segments: [])
+    )
+    private var selectionOverlayCache: SunburstSelectionOverlayCacheEntry?
 
     init(layoutService: any SunburstLayouting = SunburstLayoutService()) {
         self.layoutService = layoutService
@@ -75,37 +78,10 @@ final class SunburstChartModel: ObservableObject {
         from selectedNodeID: String?,
         moving direction: ChartSpatialSelectionDirection
     ) -> SunburstSegment? {
-        let selectableSegments = renderedSegments.filter { segment in
-            guard let nodeID = segment.nodeID else { return false }
-            return !DiskMapFreeSpaceVisualization.isFreeSpaceNodeID(nodeID)
-        }
-        guard let selectedNodeID,
-              let current = selectableSegments.first(where: {
-                  $0.nodeID == selectedNodeID
-              }) else {
-            return firstTopLevelSegment(in: selectableSegments)
-        }
-
-        switch direction {
-        case .left, .right:
-            return adjacentSegment(
-                to: current,
-                moving: direction,
-                among: selectableSegments
-            )
-        case .up:
-            return segment(
-                atSameAngleAs: current,
-                depthOffset: -1,
-                among: selectableSegments
-            )
-        case .down:
-            return segment(
-                atSameAngleAs: current,
-                depthOffset: 1,
-                among: selectableSegments
-            )
-        }
+        selectionIndex.keyboardSelection(
+            from: selectedNodeID,
+            moving: direction
+        )
     }
 
     func keyboardSelectionPoint(
@@ -122,86 +98,28 @@ final class SunburstChartModel: ObservableObject {
         )
     }
 
-    private func firstTopLevelSegment(
-        in segments: [SunburstSegment]
-    ) -> SunburstSegment? {
-        guard let minimumDepth = segments.map(\.depth).min() else { return nil }
-        return ordered(segments.filter { $0.depth == minimumDepth }).first
-    }
-
-    private func adjacentSegment(
-        to current: SunburstSegment,
-        moving direction: ChartSpatialSelectionDirection,
-        among segments: [SunburstSegment]
-    ) -> SunburstSegment? {
-        let ring = ordered(segments.filter { $0.depth == current.depth })
-        guard ring.count > 1,
-              let currentIndex = ring.firstIndex(where: {
-                  $0.nodeID == current.nodeID
-              }) else {
-            return nil
-        }
-
-        switch direction {
-        case .left:
-            return ring[(currentIndex - 1 + ring.count) % ring.count]
-        case .right:
-            return ring[(currentIndex + 1) % ring.count]
-        case .up, .down:
-            return nil
-        }
-    }
-
-    private func segment(
-        atSameAngleAs current: SunburstSegment,
-        depthOffset: Int,
-        among segments: [SunburstSegment]
-    ) -> SunburstSegment? {
-        let targetDepth = current.depth + depthOffset
-        guard targetDepth >= 0 else { return nil }
-        let midpoint = angularMidpoint(of: current)
-        return ordered(segments
-            .filter {
-                $0.depth == targetDepth
-                    && contains(angle: midpoint, in: $0)
-            })
-            .first
-    }
-
-    private func ordered(_ segments: [SunburstSegment]) -> [SunburstSegment] {
-        segments.sorted {
-            if $0.startAngle.radians != $1.startAngle.radians {
-                return $0.startAngle.radians < $1.startAngle.radians
-            }
-            return $0.id < $1.id
-        }
-    }
-
-    private func angularMidpoint(of segment: SunburstSegment) -> Double {
-        (segment.startAngle.radians + segment.endAngle.radians) / 2
-    }
-
-    private func contains(angle: Double, in segment: SunburstSegment) -> Bool {
-        let tolerance = 0.000_000_001
-        return angle >= segment.startAngle.radians - tolerance
-            && angle <= segment.endAngle.radians + tolerance
-    }
-
     func selectionOverlaySegments(
         selectedNodeID: String?,
         selectedAncestorIDs: Set<String>
     ) -> [SunburstSelectionOverlaySegment] {
         let key = SunburstSelectionOverlayCacheKey(
-            renderVersion: renderedLayoutVersion,
             selectedNodeID: selectedNodeID,
             selectedAncestorIDs: selectedAncestorIDs
         )
-        return selectionOverlayCache.segments(for: key) {
-            renderState.selectionOverlaySegments(
-                selectedNodeID: selectedNodeID,
-                selectedAncestorIDs: selectedAncestorIDs
-            )
+        if let selectionOverlayCache,
+           selectionOverlayCache.key == key {
+            return selectionOverlayCache.segments
         }
+
+        let segments = selectionIndex.selectionOverlaySegments(
+            selectedNodeID: selectedNodeID,
+            selectedAncestorIDs: selectedAncestorIDs
+        )
+        selectionOverlayCache = SunburstSelectionOverlayCacheEntry(
+            key: key,
+            segments: segments
+        )
+        return segments
     }
 
     @discardableResult
@@ -253,11 +171,18 @@ final class SunburstChartModel: ObservableObject {
     }
 
     private func apply(_ segments: [SunburstSegment]) {
-        selectionOverlayCache.removeAll()
-        renderState = SunburstChartRenderState(
-            segments: segments,
-            version: renderState.version + 1
+        let segmentIndex = SunburstSegmentIndex(segments: segments)
+        let nextSelectionIndex = SunburstSelectionIndex(
+            segmentIndex: segmentIndex
         )
+        let nextRenderState = SunburstChartRenderState(
+            segments: segments,
+            version: renderState.version + 1,
+            segmentIndex: segmentIndex
+        )
+        renderState = nextRenderState
+        selectionIndex = nextSelectionIndex
+        selectionOverlayCache = nil
     }
 
     private func clearHover() {
@@ -268,53 +193,14 @@ final class SunburstChartModel: ObservableObject {
     }
 }
 
-private struct SunburstSelectionOverlayCacheKey: Hashable {
-    let renderVersion: Int
+private struct SunburstSelectionOverlayCacheKey: Equatable {
     let selectedNodeID: String?
     let selectedAncestorIDs: Set<String>
 }
 
-private struct SunburstSelectionOverlayCache {
-    private let capacity: Int
-    private var segmentsByKey: [SunburstSelectionOverlayCacheKey: [SunburstSelectionOverlaySegment]] = [:]
-    private var keysByRecency: [SunburstSelectionOverlayCacheKey] = []
-
-    init(capacity: Int) {
-        self.capacity = max(capacity, 1)
-    }
-
-    mutating func segments(
-        for key: SunburstSelectionOverlayCacheKey,
-        build: () -> [SunburstSelectionOverlaySegment]
-    ) -> [SunburstSelectionOverlaySegment] {
-        if let segments = segmentsByKey[key] {
-            markRecentlyUsed(key)
-            return segments
-        }
-
-        let segments = build()
-        segmentsByKey[key] = segments
-        markRecentlyUsed(key)
-        trimToCapacity()
-        return segments
-    }
-
-    mutating func removeAll() {
-        segmentsByKey.removeAll()
-        keysByRecency.removeAll()
-    }
-
-    private mutating func markRecentlyUsed(_ key: SunburstSelectionOverlayCacheKey) {
-        keysByRecency.removeAll { $0 == key }
-        keysByRecency.append(key)
-    }
-
-    private mutating func trimToCapacity() {
-        while segmentsByKey.count > capacity, let oldestKey = keysByRecency.first {
-            keysByRecency.removeFirst()
-            segmentsByKey[oldestKey] = nil
-        }
-    }
+private struct SunburstSelectionOverlayCacheEntry {
+    let key: SunburstSelectionOverlayCacheKey
+    let segments: [SunburstSelectionOverlaySegment]
 }
 
 enum SunburstSelectionRole: Equatable, Sendable {
@@ -332,39 +218,110 @@ struct SunburstSelectionOverlaySegment: Identifiable, Equatable, Sendable {
 }
 
 private struct SunburstChartRenderState {
-    var segments: [SunburstSegment]
+    let segments: [SunburstSegment]
     var hoveredSegmentID: SunburstSegment.ID?
-    var version: Int
+    let version: Int
 
-    private var segmentLookup: [SunburstSegment.ID: SunburstSegment]
-    private var segmentByNodeID: [String: SunburstSegment]
-    private var hitTestIndex: SunburstHitTestIndex
+    private let segmentIndex: SunburstSegmentIndex
+    private let hitTestIndex: SunburstHitTestIndex
 
     init(
         segments: [SunburstSegment] = [],
         hoveredSegmentID: SunburstSegment.ID? = nil,
-        version: Int = 0
+        version: Int = 0,
+        segmentIndex: SunburstSegmentIndex? = nil
     ) {
         self.segments = segments
         self.hoveredSegmentID = hoveredSegmentID
         self.version = version
-        segmentLookup = segments.reduce(into: [:]) { lookup, segment in
-            lookup[segment.id] = segment
-        }
-        segmentByNodeID = segments.reduce(into: [:]) { lookup, segment in
-            guard let nodeID = segment.nodeID else { return }
-            lookup[nodeID] = segment
-        }
-        hitTestIndex = SunburstHitTestIndex(segments: segments)
+        let segmentIndex = segmentIndex ?? SunburstSegmentIndex(segments: segments)
+        self.segmentIndex = segmentIndex
+        hitTestIndex = SunburstHitTestIndex(segmentIndex: segmentIndex)
     }
 
     var hoveredSegment: SunburstSegment? {
         guard let hoveredSegmentID else { return nil }
-        return segmentLookup[hoveredSegmentID]
+        return segmentIndex.segment(id: hoveredSegmentID)
     }
 
     func segment(at point: CGPoint, in size: CGSize) -> SunburstSegment? {
         hitTestIndex.segment(at: point, in: size)
+    }
+}
+
+private struct SunburstSelectionIndex {
+    private struct Location {
+        let depth: Int
+        let index: Int
+    }
+
+    private let segmentIndex: SunburstSegmentIndex
+    private let ringsByDepth: [Int: [SunburstSegment]]
+    private let locationByNodeID: [String: Location]
+    private let entrySegment: SunburstSegment?
+
+    init(segmentIndex: SunburstSegmentIndex) {
+        let depths = segmentIndex.depths
+        var ringsByDepth: [Int: [SunburstSegment]] = [:]
+        ringsByDepth.reserveCapacity(depths.count)
+        var locationByNodeID: [String: Location] = [:]
+        locationByNodeID.reserveCapacity(segmentIndex.segmentCount)
+        var entrySegment: SunburstSegment?
+        for depth in depths {
+            let ring = segmentIndex.segments(atDepth: depth)
+                .filter { segment in
+                    guard let nodeID = segment.nodeID else { return false }
+                    return !DiskMapFreeSpaceVisualization.isFreeSpaceNodeID(nodeID)
+                }
+                .sorted(by: Self.precedes)
+            ringsByDepth[depth] = ring
+            for (index, segment) in ring.enumerated() {
+                guard let nodeID = segment.nodeID,
+                      locationByNodeID[nodeID] == nil else {
+                    continue
+                }
+                locationByNodeID[nodeID] = Location(
+                    depth: depth,
+                    index: index
+                )
+            }
+            if entrySegment == nil {
+                entrySegment = ring.first
+            }
+        }
+
+        self.segmentIndex = segmentIndex
+        self.ringsByDepth = ringsByDepth
+        self.locationByNodeID = locationByNodeID
+        self.entrySegment = entrySegment
+    }
+
+    func keyboardSelection(
+        from selectedNodeID: String?,
+        moving direction: ChartSpatialSelectionDirection
+    ) -> SunburstSegment? {
+        guard let selectedNodeID,
+              let location = locationByNodeID[selectedNodeID],
+              let ring = ringsByDepth[location.depth],
+              ring.indices.contains(location.index) else {
+            return entrySegment
+        }
+        let current = ring[location.index]
+
+        switch direction {
+        case .left:
+            guard ring.count > 1 else { return nil }
+            let index = (location.index - 1 + ring.count) % ring.count
+            return ring[index]
+        case .right:
+            guard ring.count > 1 else { return nil }
+            let index = (location.index + 1) % ring.count
+            return ring[index]
+        case .up:
+            return segment(atSameAngleAs: current, depthOffset: -1)
+        case .down:
+            return segment(atSameAngleAs: current, depthOffset: 1)
+        }
     }
 
     func selectionOverlaySegments(
@@ -373,23 +330,26 @@ private struct SunburstChartRenderState {
     ) -> [SunburstSelectionOverlaySegment] {
         guard let selectedNodeID else { return [] }
 
-        var overlaySegments: [SunburstSelectionOverlaySegment] = []
-        overlaySegments.reserveCapacity(selectedAncestorIDs.count)
-
-        for segment in segments {
-            guard let nodeID = segment.nodeID,
-                  nodeID != selectedNodeID,
-                  selectedAncestorIDs.contains(nodeID) else {
+        var ancestors: [(layoutIndex: Int, segment: SunburstSegment)] = []
+        ancestors.reserveCapacity(selectedAncestorIDs.count)
+        for nodeID in selectedAncestorIDs where nodeID != selectedNodeID {
+            guard let indexedSegment = segmentIndex.indexedSegment(nodeID: nodeID) else {
                 continue
             }
+            ancestors.append(indexedSegment)
+        }
+        ancestors.sort { $0.layoutIndex < $1.layoutIndex }
 
+        var overlaySegments: [SunburstSelectionOverlaySegment] = []
+        overlaySegments.reserveCapacity(ancestors.count + 1)
+        for ancestor in ancestors {
             overlaySegments.append(SunburstSelectionOverlaySegment(
-                segment: segment,
+                segment: ancestor.segment,
                 role: .ancestor
             ))
         }
 
-        if let selectedSegment = segmentByNodeID[selectedNodeID] {
+        if let selectedSegment = segmentIndex.segment(nodeID: selectedNodeID) {
             overlaySegments.append(SunburstSelectionOverlaySegment(
                 segment: selectedSegment,
                 role: .selected
@@ -397,5 +357,32 @@ private struct SunburstChartRenderState {
         }
 
         return overlaySegments
+    }
+
+    private func segment(
+        atSameAngleAs current: SunburstSegment,
+        depthOffset: Int
+    ) -> SunburstSegment? {
+        let targetDepth = current.depth + depthOffset
+        guard targetDepth >= 0,
+              let targetRing = ringsByDepth[targetDepth] else {
+            return nil
+        }
+        let midpoint = (current.startAngle.radians + current.endAngle.radians) / 2
+        return targetRing.first { segment in
+            let tolerance = 0.000_000_001
+            return midpoint >= segment.startAngle.radians - tolerance
+                && midpoint <= segment.endAngle.radians + tolerance
+        }
+    }
+
+    private static func precedes(
+        _ lhs: SunburstSegment,
+        _ rhs: SunburstSegment
+    ) -> Bool {
+        if lhs.startAngle.radians != rhs.startAngle.radians {
+            return lhs.startAngle.radians < rhs.startAngle.radians
+        }
+        return lhs.id < rhs.id
     }
 }

--- a/Radix/Services/SunburstGeometry.swift
+++ b/Radix/Services/SunburstGeometry.swift
@@ -205,7 +205,8 @@ nonisolated enum SunburstLayout {
         }
 
         var visible: [GroupEntry] = []
-        var groupedNodes: [FileNodeRecord] = []
+        var groupedCount = 0
+        var onlyGroupedChild: FileNodeRecord?
         var groupedSize: Int64 = 0
 
         for child in children {
@@ -213,7 +214,12 @@ nonisolated enum SunburstLayout {
             let size = max(child.allocatedSize, 1)
             let angle = totalAngle * (Double(size) / max(denominator, 1))
             if angle < minimumAngle {
-                groupedNodes.append(child)
+                groupedCount += 1
+                if groupedCount == 1 {
+                    onlyGroupedChild = child
+                } else {
+                    onlyGroupedChild = nil
+                }
                 groupedSize = addingClamped(groupedSize, size)
             } else {
                 visible.append(
@@ -230,7 +236,7 @@ nonisolated enum SunburstLayout {
             }
         }
 
-        if groupedNodes.count > 1 {
+        if groupedCount > 1 {
             visible.append(
                 GroupEntry(
                     id: "aggregate-\(children.first?.id ?? UUID().uuidString)",
@@ -242,16 +248,16 @@ nonisolated enum SunburstLayout {
                     node: nil
                 )
             )
-        } else if let onlyGrouped = groupedNodes.first {
+        } else if let onlyGroupedChild {
             visible.append(
                 GroupEntry(
-                    id: onlyGrouped.id,
-                    nodeID: onlyGrouped.id,
-                    label: onlyGrouped.name,
-                    totalSize: max(onlyGrouped.allocatedSize, 1),
+                    id: onlyGroupedChild.id,
+                    nodeID: onlyGroupedChild.id,
+                    label: onlyGroupedChild.name,
+                    totalSize: max(onlyGroupedChild.allocatedSize, 1),
                     isAggregate: false,
-                    colorID: onlyGrouped.id,
-                    node: onlyGrouped
+                    colorID: onlyGroupedChild.id,
+                    node: onlyGroupedChild
                 )
             )
         }
@@ -425,20 +431,86 @@ nonisolated enum SunburstCenterHitTester {
     }
 }
 
+nonisolated final class SunburstSegmentIndex: Sendable {
+    private struct NodeEntry: Sendable {
+        let segment: SunburstSegment
+        let layoutIndex: Int
+    }
+
+    let depths: [Int]
+    let segmentCount: Int
+
+    private let segmentsByDepth: [Int: [SunburstSegment]]
+    private let segmentByID: [SunburstSegment.ID: SunburstSegment]
+    private let nodeEntryByID: [String: NodeEntry]
+
+    nonisolated init(segments: [SunburstSegment]) {
+        var segmentsByDepth: [Int: [SunburstSegment]] = [:]
+        var segmentByID: [SunburstSegment.ID: SunburstSegment] = [:]
+        segmentByID.reserveCapacity(segments.count)
+        var nodeEntryByID: [String: NodeEntry] = [:]
+        nodeEntryByID.reserveCapacity(segments.count)
+        for (index, segment) in segments.enumerated() {
+            segmentsByDepth[segment.depth, default: []].append(segment)
+            segmentByID[segment.id] = segment
+            if let nodeID = segment.nodeID {
+                nodeEntryByID[nodeID] = NodeEntry(
+                    segment: segment,
+                    layoutIndex: index
+                )
+            }
+        }
+
+        depths = segmentsByDepth.keys.sorted()
+        segmentCount = segments.count
+        self.segmentsByDepth = segmentsByDepth
+        self.segmentByID = segmentByID
+        self.nodeEntryByID = nodeEntryByID
+    }
+
+    nonisolated func segments(atDepth depth: Int) -> [SunburstSegment] {
+        segmentsByDepth[depth] ?? []
+    }
+
+    nonisolated func segment(id: SunburstSegment.ID) -> SunburstSegment? {
+        segmentByID[id]
+    }
+
+    nonisolated func segment(nodeID: String) -> SunburstSegment? {
+        nodeEntryByID[nodeID]?.segment
+    }
+
+    nonisolated func indexedSegment(
+        nodeID: String
+    ) -> (layoutIndex: Int, segment: SunburstSegment)? {
+        guard let entry = nodeEntryByID[nodeID] else { return nil }
+        return (entry.layoutIndex, entry.segment)
+    }
+}
+
 nonisolated struct SunburstHitTestIndex: Sendable {
     private let rings: [Ring]
 
     nonisolated init(segments: [SunburstSegment]) {
-        var ringSegmentsByDepth: [Int: [SunburstSegment]] = [:]
+        var segmentsByDepth: [Int: [SunburstSegment]] = [:]
         for segment in segments {
-            ringSegmentsByDepth[segment.depth, default: []].append(segment)
+            segmentsByDepth[segment.depth, default: []].append(segment)
         }
 
-        rings = ringSegmentsByDepth
+        rings = segmentsByDepth
             .map { depth, segments in
                 Ring(depth: depth, segments: segments)
             }
             .sorted { $0.depth < $1.depth }
+    }
+
+    nonisolated init(segmentIndex: SunburstSegmentIndex) {
+        rings = segmentIndex.depths.map { depth in
+            Ring(
+                depth: depth,
+                segments: segmentIndex.segments(atDepth: depth)
+            )
+        }
     }
 
     nonisolated func segment(at point: CGPoint, in size: CGSize) -> SunburstSegment? {
@@ -505,8 +577,7 @@ nonisolated struct SunburstHitTestIndex: Sendable {
                 }
             }
 
-            let candidateIndex = max(lowerBound - 1, 0)
-            let candidate = segments[candidateIndex]
+            let candidate = segments[max(lowerBound - 1, 0)]
             guard radians >= candidate.startAngle.radians,
                   radians <= candidate.endAngle.radians else {
                 return nil

--- a/RadixCoreTests/ChartResponsivenessBenchmarkSupport.swift
+++ b/RadixCoreTests/ChartResponsivenessBenchmarkSupport.swift
@@ -82,7 +82,8 @@ enum ChartResponsivenessBenchmarkSupport {
             + (Double(components.attoseconds) / 1_000_000_000_000_000_000)
     }
 
-    static func median(_ values: [Double]) -> Double {
+    static func median(_ values: [Double]) -> Double? {
+        guard !values.isEmpty else { return nil }
         let sortedValues = values.sorted()
         let midpoint = sortedValues.count / 2
         if sortedValues.count.isMultiple(of: 2) {

--- a/RadixCoreTests/ChartResponsivenessBenchmarkSupport.swift
+++ b/RadixCoreTests/ChartResponsivenessBenchmarkSupport.swift
@@ -1,0 +1,127 @@
+import Darwin
+import Foundation
+@testable import RadixCore
+
+enum ChartResponsivenessBenchmarkSupport {
+    static let fnvOffsetBasis: UInt64 = 14_695_981_039_346_656_037
+    private static let fnvPrime: UInt64 = 1_099_511_628_211
+
+    static func node(
+        id: String,
+        name: String,
+        isDirectory: Bool,
+        allocatedSize: Int64,
+        descendantFileCount: Int
+    ) -> FileNodeRecord {
+        FileNodeRecord(
+            id: id,
+            url: URL(
+                filePath: id,
+                directoryHint: isDirectory ? .isDirectory : .notDirectory
+            ),
+            name: name,
+            isDirectory: isDirectory,
+            isSymbolicLink: false,
+            allocatedSize: allocatedSize,
+            logicalSize: allocatedSize,
+            descendantFileCount: descendantFileCount,
+            lastModified: nil,
+            isPackage: false,
+            isAccessible: true,
+            isSelfAccessible: true,
+            isSynthetic: false,
+            isAutoSummarized: false
+        )
+    }
+
+    @inline(__always)
+    static func hash(_ string: String, into hash: inout UInt64) {
+        for byte in string.utf8 {
+            hash ^= UInt64(byte)
+            hash &*= fnvPrime
+        }
+        Self.hash(0xff, into: &hash)
+    }
+
+    @inline(__always)
+    static func hash(_ value: UInt64, into hash: inout UInt64) {
+        var value = value
+        for _ in 0..<MemoryLayout<UInt64>.size {
+            hash ^= value & 0xff
+            hash &*= fnvPrime
+            value >>= 8
+        }
+    }
+
+    static func measure<Value>(
+        _ operation: () throws -> Value
+    ) rethrows -> ChartBenchmarkMeasurement<Value> {
+        let startedAt = ContinuousClock.now
+        let value = try operation()
+        return ChartBenchmarkMeasurement(
+            value: value,
+            seconds: durationSeconds(startedAt.duration(to: .now))
+        )
+    }
+
+    @MainActor
+    static func measureAsync<Value>(
+        _ operation: () async throws -> Value
+    ) async rethrows -> ChartBenchmarkMeasurement<Value> {
+        let startedAt = ContinuousClock.now
+        let value = try await operation()
+        return ChartBenchmarkMeasurement(
+            value: value,
+            seconds: durationSeconds(startedAt.duration(to: .now))
+        )
+    }
+
+    static func durationSeconds(_ duration: Duration) -> Double {
+        let components = duration.components
+        return Double(components.seconds)
+            + (Double(components.attoseconds) / 1_000_000_000_000_000_000)
+    }
+
+    static func median(_ values: [Double]) -> Double {
+        let sortedValues = values.sorted()
+        let midpoint = sortedValues.count / 2
+        if sortedValues.count.isMultiple(of: 2) {
+            return (sortedValues[midpoint - 1] + sortedValues[midpoint]) / 2
+        }
+        return sortedValues[midpoint]
+    }
+
+    static func report(
+        prefix: String,
+        phase: String,
+        seconds: Double,
+        count: Int,
+        peakRSS: UInt64,
+        extra: String = ""
+    ) {
+        print(
+            "\(prefix) phase=\(phase) "
+                + "seconds=\(format(seconds)) count=\(count) "
+                + "peak_rss=\(peakRSS) \(extra)"
+        )
+    }
+
+    static func format(_ value: Double) -> String {
+        String(format: "%.6f", value)
+    }
+
+    static func peakResidentBytes() -> UInt64 {
+        var usage = rusage()
+        guard getrusage(RUSAGE_SELF, &usage) == 0 else { return 0 }
+        return UInt64(max(usage.ru_maxrss, 0))
+    }
+
+    static func byteDelta(from start: UInt64, to end: UInt64) -> UInt64 {
+        end >= start ? end - start : 0
+    }
+}
+
+struct ChartBenchmarkMeasurement<Value> {
+    let value: Value
+    let seconds: Double
+}

--- a/RadixCoreTests/ChartResponsivenessBenchmarkSupportTests.swift
+++ b/RadixCoreTests/ChartResponsivenessBenchmarkSupportTests.swift
@@ -1,0 +1,7 @@
+import XCTest
+
+final class ChartResponsivenessBenchmarkSupportTests: XCTestCase {
+    func testMedianReturnsNilForEmptySamples() {
+        XCTAssertNil(ChartResponsivenessBenchmarkSupport.median([]))
+    }
+}

--- a/RadixCoreTests/SunburstChartModelTests.swift
+++ b/RadixCoreTests/SunburstChartModelTests.swift
@@ -116,6 +116,29 @@ final class SunburstChartModelTests: XCTestCase {
         )
     }
 
+    func testKeyboardSelectionUsesIDToOrderEqualAngles() async {
+        let laterID = makeSegment(
+            id: "b",
+            startAngle: 0,
+            endAngle: 1
+        )
+        let earlierID = makeSegment(
+            id: "a",
+            startAngle: 0,
+            endAngle: 1
+        )
+        let model = await loadedModel(with: [laterID, earlierID])
+
+        XCTAssertEqual(
+            model.keyboardSelection(from: nil, moving: .right)?.nodeID,
+            earlierID.id
+        )
+        XCTAssertEqual(
+            model.keyboardSelection(from: earlierID.id, moving: .right)?.nodeID,
+            laterID.id
+        )
+    }
+
     func testStartingLayoutPublishesPendingState() async {
         let service = ControllableSunburstLayoutService()
         let model = SunburstChartModel(layoutService: service)
@@ -438,10 +461,13 @@ final class SunburstChartModelTests: XCTestCase {
     }
 
     func testSelectionOverlaySegmentsIncludeAncestorsAndSelectedLast() async {
-        let ancestor = makeSegment(id: "ancestor", depth: 0)
+        let firstAncestor = makeSegment(id: "first-ancestor", depth: 0)
+        let secondAncestor = makeSegment(id: "second-ancestor", depth: 1)
         let selected = makeSegment(id: "selected", depth: 1)
         let sibling = makeSegment(id: "sibling", depth: 1)
-        let service = ImmediateSunburstLayoutService(segments: [ancestor, selected, sibling])
+        let service = ImmediateSunburstLayoutService(
+            segments: [secondAncestor, sibling, firstAncestor, selected]
+        )
         let model = SunburstChartModel(layoutService: service)
         let store = makeStore()
 
@@ -455,11 +481,79 @@ final class SunburstChartModelTests: XCTestCase {
         XCTAssertTrue(didApplyLayout)
         let overlaySegments = model.selectionOverlaySegments(
             selectedNodeID: selected.nodeID,
-            selectedAncestorIDs: Set([ancestor.nodeID!, selected.nodeID!, "missing"])
+            selectedAncestorIDs: Set([
+                firstAncestor.nodeID!,
+                selected.nodeID!,
+                secondAncestor.nodeID!,
+                "missing",
+            ])
         )
 
-        XCTAssertEqual(overlaySegments.map(\.segment.id), [ancestor.id, selected.id])
-        XCTAssertEqual(overlaySegments.map(\.role), [.ancestor, .selected])
+        XCTAssertEqual(
+            overlaySegments.map(\.segment.id),
+            [secondAncestor.id, firstAncestor.id, selected.id]
+        )
+        XCTAssertEqual(
+            overlaySegments.map(\.role),
+            [.ancestor, .ancestor, .selected]
+        )
+    }
+
+    func testSelectionOverlayCacheIsInvalidatedByNewLayout() async {
+        let service = ControllableSunburstLayoutService()
+        let model = SunburstChartModel(layoutService: service)
+        let store = makeStore()
+        let firstSelected = makeSegment(id: "selected", depth: 0)
+
+        let firstTask = Task {
+            await model.loadLayout(
+                treeStore: store,
+                rootID: store.rootID,
+                depthLimit: 1,
+                layoutID: "first"
+            )
+        }
+        await service.waitForIssuedRequestCount(1)
+        let didCompleteFirstRequest = await service.completeRequest(
+            id: 0,
+            with: [firstSelected]
+        )
+        XCTAssertTrue(didCompleteFirstRequest)
+        let didApplyFirstLayout = await firstTask.value
+        XCTAssertTrue(didApplyFirstLayout)
+        XCTAssertEqual(
+            model.selectionOverlaySegments(
+                selectedNodeID: firstSelected.nodeID,
+                selectedAncestorIDs: []
+            ).last?.segment.depth,
+            0
+        )
+
+        let secondSelected = makeSegment(id: "selected", depth: 1)
+        let secondTask = Task {
+            await model.loadLayout(
+                treeStore: store,
+                rootID: store.rootID,
+                depthLimit: 2,
+                layoutID: "second"
+            )
+        }
+        await service.waitForIssuedRequestCount(2)
+        let didCompleteSecondRequest = await service.completeRequest(
+            id: 1,
+            with: [secondSelected]
+        )
+        XCTAssertTrue(didCompleteSecondRequest)
+        let didApplySecondLayout = await secondTask.value
+        XCTAssertTrue(didApplySecondLayout)
+
+        XCTAssertEqual(
+            model.selectionOverlaySegments(
+                selectedNodeID: secondSelected.nodeID,
+                selectedAncestorIDs: []
+            ).last?.segment.depth,
+            1
+        )
     }
 
     private func loadedModel(

--- a/RadixCoreTests/SunburstGeometryTests.swift
+++ b/RadixCoreTests/SunburstGeometryTests.swift
@@ -101,6 +101,29 @@ final class SunburstGeometryTests: XCTestCase {
         XCTAssertEqual(aggregate.colorToken.role, .aggregate)
     }
 
+    func testSingleSmallItemRemainsAnIndividualSegment() throws {
+        let large = makeFileNode(id: "/root/large", name: "large", size: 99)
+        let small = makeFileNode(id: "/root/small", name: "small", size: 1)
+        let root = makeDirectoryNode(
+            id: "/root",
+            name: "root",
+            children: [large, small]
+        )
+        let store = makeStore(root: root, children: [large, small])
+
+        let segments = SunburstLayout.segments(
+            in: store,
+            rootID: root.id,
+            depthLimit: 1,
+            minimumAngle: .pi / 2
+        )
+
+        XCTAssertEqual(segments.count, 2)
+        XCTAssertFalse(segments.contains(where: \.isAggregate))
+        XCTAssertEqual(segments.last?.nodeID, small.id)
+        XCTAssertEqual(segments.last?.totalSize, small.allocatedSize)
+    }
+
     func testHitTesterReturnsExpectedSegment() throws {
         let root = makeDirectoryNode(
             id: "/root",

--- a/RadixCoreTests/SunburstResponsivenessBenchmarkTests.swift
+++ b/RadixCoreTests/SunburstResponsivenessBenchmarkTests.swift
@@ -1,0 +1,863 @@
+import CoreGraphics
+import Foundation
+import XCTest
+@testable import RadixCore
+
+private typealias BenchmarkSupport = ChartResponsivenessBenchmarkSupport
+
+@MainActor
+final class SunburstResponsivenessBenchmarkTests: XCTestCase {
+    func testLargeScanSunburstResponsivenessBenchmark() async throws {
+        guard ProcessInfo.processInfo.environment["RADIX_BENCH_SUNBURST"] == "1" else {
+            throw XCTSkip(
+                "Set RADIX_BENCH_SUNBURST=1 to run the large-scan Sunburst benchmark."
+            )
+        }
+
+        let denseFileCount = 1_000_000
+        let branchCount = 120
+        let renderedDepth = 10
+        let sampleCount = 3
+        let hitTestIterationCount = 100_000
+        let overlayIterationCount = 20_000
+        let keyboardIterationCount = 20_000
+        let chartSize = CGSize(width: 1_200, height: 1_200)
+
+        let initialPeakRSS = BenchmarkSupport.peakResidentBytes()
+        let fixtureMeasurement = BenchmarkSupport.measure {
+            Self.makeDenseFixture(fileCount: denseFileCount)
+        }
+        let denseFixture = fixtureMeasurement.value
+        XCTAssertEqual(denseFixture.store.nodeCount, denseFileCount + 2)
+        Self.report(
+            phase: "fixture",
+            seconds: fixtureMeasurement.seconds,
+            count: denseFixture.store.nodeCount,
+            peakRSS: BenchmarkSupport.peakResidentBytes(),
+            extra: "rss_delta=\(BenchmarkSupport.byteDelta(from: initialPeakRSS, to: BenchmarkSupport.peakResidentBytes()))"
+        )
+
+        let denseDiskMapStore = DiskMapTreeStore(denseFixture.store)
+        var largeLayoutSamples: [LayoutSample] = []
+        largeLayoutSamples.reserveCapacity(sampleCount)
+        for _ in 0..<sampleCount {
+            let measurement = try BenchmarkSupport.measure {
+                try SunburstLayout.segments(
+                    in: denseDiskMapStore,
+                    rootID: denseFixture.store.rootID,
+                    depthLimit: 2,
+                    cancellationCheck: {}
+                )
+            }
+            largeLayoutSamples.append(LayoutSample(
+                seconds: measurement.seconds,
+                segmentCount: measurement.value.count,
+                fingerprint: Self.segmentFingerprint(measurement.value)
+            ))
+        }
+        let expectedLargeCount = try XCTUnwrap(largeLayoutSamples.first?.segmentCount)
+        let expectedLargeFingerprint = try XCTUnwrap(largeLayoutSamples.first?.fingerprint)
+        XCTAssertTrue(largeLayoutSamples.allSatisfy {
+            $0.segmentCount == expectedLargeCount
+                && $0.fingerprint == expectedLargeFingerprint
+        })
+        let largeLayoutMedian = BenchmarkSupport.median(largeLayoutSamples.map(\.seconds))
+        Self.report(
+            phase: "layout_large_scan",
+            seconds: largeLayoutMedian,
+            count: expectedLargeCount,
+            peakRSS: BenchmarkSupport.peakResidentBytes(),
+            extra: "samples=\(largeLayoutSamples.map { BenchmarkSupport.format($0.seconds) }.joined(separator: ",")) "
+                + "fingerprint=\(expectedLargeFingerprint)"
+        )
+
+        let denseLayoutMeasurement = try BenchmarkSupport.measure {
+            try SunburstLayout.segments(
+                in: denseDiskMapStore,
+                rootID: denseFixture.denseDirectoryID,
+                depthLimit: 1,
+                cancellationCheck: {}
+            )
+        }
+        let denseSegments = denseLayoutMeasurement.value
+        XCTAssertEqual(denseSegments.count, 1)
+        XCTAssertTrue(try XCTUnwrap(denseSegments.first).isAggregate)
+        let denseFingerprint = Self.segmentFingerprint(denseSegments)
+        Self.report(
+            phase: "layout_dense_root",
+            seconds: denseLayoutMeasurement.seconds,
+            count: denseFileCount,
+            peakRSS: BenchmarkSupport.peakResidentBytes(),
+            extra: "segments=\(denseSegments.count) fingerprint=\(denseFingerprint)"
+        )
+
+        let interactionFixture = Self.makeInteractionFixture(
+            branchCount: branchCount,
+            renderedDepth: renderedDepth
+        )
+        let interactionDiskMapStore = DiskMapTreeStore(interactionFixture.store)
+        let interactionLayoutMeasurement = try BenchmarkSupport.measure {
+            try SunburstLayout.segments(
+                in: interactionDiskMapStore,
+                rootID: interactionFixture.store.rootID,
+                depthLimit: renderedDepth,
+                cancellationCheck: {}
+            )
+        }
+        let interactionSegments = interactionLayoutMeasurement.value
+        XCTAssertEqual(interactionSegments.count, branchCount * renderedDepth)
+        let interactionFingerprint = Self.segmentFingerprint(interactionSegments)
+        Self.report(
+            phase: "layout_interaction_geometry",
+            seconds: interactionLayoutMeasurement.seconds,
+            count: interactionSegments.count,
+            peakRSS: BenchmarkSupport.peakResidentBytes(),
+            extra: "fingerprint=\(interactionFingerprint)"
+        )
+
+        let publicationModel = SunburstChartModel(
+            layoutService: PrecomputedSunburstLayoutService(segments: interactionSegments)
+        )
+        let publicationMeasurement = await BenchmarkSupport.measureAsync {
+            await publicationModel.loadLayout(
+                treeStore: interactionDiskMapStore,
+                rootID: interactionFixture.store.rootID,
+                depthLimit: renderedDepth,
+                layoutID: "interaction-publication"
+            )
+        }
+        XCTAssertTrue(publicationMeasurement.value)
+        XCTAssertEqual(
+            Self.segmentFingerprint(publicationModel.renderedSegments),
+            interactionFingerprint
+        )
+        Self.report(
+            phase: "render_state_publication",
+            seconds: publicationMeasurement.seconds,
+            count: interactionSegments.count,
+            peakRSS: BenchmarkSupport.peakResidentBytes()
+        )
+
+        let hitTestMeasurement = BenchmarkSupport.measure {
+            Self.runHitTests(
+                model: publicationModel,
+                size: chartSize,
+                iterationCount: hitTestIterationCount
+            )
+        }
+        XCTAssertGreaterThan(hitTestMeasurement.value.selectionCount, 0)
+        Self.report(
+            phase: "hit_testing",
+            seconds: hitTestMeasurement.seconds,
+            count: hitTestIterationCount,
+            peakRSS: BenchmarkSupport.peakResidentBytes(),
+            extra: "hits=\(hitTestMeasurement.value.selectionCount) "
+                + "fingerprint=\(hitTestMeasurement.value.fingerprint)"
+        )
+
+        let overlayInputs = Self.makeOverlayInputs(
+            rootID: interactionFixture.store.rootID,
+            branchCount: min(branchCount, 64),
+            renderedDepth: renderedDepth
+        )
+        let coldOverlayMeasurement = BenchmarkSupport.measure {
+            Self.runSelectionOverlays(
+                model: publicationModel,
+                inputs: overlayInputs,
+                iterationCount: overlayIterationCount
+            )
+        }
+        XCTAssertEqual(
+            coldOverlayMeasurement.value.selectionCount,
+            overlayIterationCount * renderedDepth
+        )
+        Self.report(
+            phase: "selection_overlay_alternating",
+            seconds: coldOverlayMeasurement.seconds,
+            count: overlayIterationCount,
+            peakRSS: BenchmarkSupport.peakResidentBytes(),
+            extra: "segments=\(coldOverlayMeasurement.value.selectionCount) "
+                + "fingerprint=\(coldOverlayMeasurement.value.fingerprint)"
+        )
+
+        let cacheHitOverlayMeasurement = try BenchmarkSupport.measure {
+            Self.runSelectionOverlays(
+                model: publicationModel,
+                inputs: [try XCTUnwrap(overlayInputs.first)],
+                iterationCount: overlayIterationCount
+            )
+        }
+        XCTAssertEqual(
+            cacheHitOverlayMeasurement.value.selectionCount,
+            overlayIterationCount * renderedDepth
+        )
+        Self.report(
+            phase: "selection_overlay_same_selection",
+            seconds: cacheHitOverlayMeasurement.seconds,
+            count: overlayIterationCount,
+            peakRSS: BenchmarkSupport.peakResidentBytes(),
+            extra: "segments=\(cacheHitOverlayMeasurement.value.selectionCount) "
+                + "fingerprint=\(cacheHitOverlayMeasurement.value.fingerprint)"
+        )
+
+        let keyboardMeasurement = BenchmarkSupport.measure {
+            Self.runKeyboardSelection(
+                model: publicationModel,
+                iterationCount: keyboardIterationCount
+            )
+        }
+        XCTAssertEqual(keyboardMeasurement.value.selectionCount, keyboardIterationCount)
+        Self.report(
+            phase: "keyboard_selection",
+            seconds: keyboardMeasurement.seconds,
+            count: keyboardIterationCount,
+            peakRSS: BenchmarkSupport.peakResidentBytes(),
+            extra: "selections=\(keyboardMeasurement.value.selectionCount) "
+                + "fingerprint=\(keyboardMeasurement.value.fingerprint)"
+        )
+
+        let cancellationMeasurement = try await Self.measureLayoutCancellation(
+            store: denseDiskMapStore,
+            rootID: denseFixture.denseDirectoryID,
+            baselineLayoutSeconds: denseLayoutMeasurement.seconds
+        )
+        XCTAssertTrue(
+            cancellationMeasurement.wasCancelled
+                || cancellationMeasurement.completedBeforeCancellation,
+            "Large layout returned normally after cancellation was requested."
+        )
+        Self.report(
+            phase: "cancel_layout",
+            seconds: cancellationMeasurement.seconds,
+            count: denseFileCount,
+            peakRSS: BenchmarkSupport.peakResidentBytes(),
+            extra: "cancelled=\(cancellationMeasurement.wasCancelled) "
+                + "completed_before_cancel=\(cancellationMeasurement.completedBeforeCancellation)"
+        )
+
+        let rapidChangeMeasurement = try await Self.measureRapidRootAndDepthChanges(
+            fixture: denseFixture,
+            diskMapStore: denseDiskMapStore
+        )
+        XCTAssertEqual(rapidChangeMeasurement.appliedCount, 1)
+        XCTAssertEqual(rapidChangeMeasurement.completedCount, 1)
+        XCTAssertEqual(
+            rapidChangeMeasurement.cancelledCount,
+            rapidChangeMeasurement.requestCount - 1
+        )
+        XCTAssertEqual(rapidChangeMeasurement.renderedLayoutID, "root-depth-final")
+        XCTAssertEqual(rapidChangeMeasurement.segmentCount, denseSegments.count)
+        XCTAssertEqual(rapidChangeMeasurement.fingerprint, denseFingerprint)
+        Self.report(
+            phase: "rapid_root_depth_changes",
+            seconds: rapidChangeMeasurement.latestRequestSeconds,
+            count: rapidChangeMeasurement.requestCount,
+            peakRSS: BenchmarkSupport.peakResidentBytes(),
+            extra: "total_seconds=\(BenchmarkSupport.format(rapidChangeMeasurement.totalSeconds)) "
+                + "applied=\(rapidChangeMeasurement.appliedCount) "
+                + "cancelled=\(rapidChangeMeasurement.cancelledCount) "
+                + "fingerprint=\(rapidChangeMeasurement.fingerprint)"
+        )
+
+        Self.report(
+            phase: "suite_peak_rss",
+            seconds: 0,
+            count: denseFixture.store.nodeCount,
+            peakRSS: BenchmarkSupport.peakResidentBytes(),
+            extra: "rss_delta=\(BenchmarkSupport.byteDelta(from: initialPeakRSS, to: BenchmarkSupport.peakResidentBytes()))"
+        )
+    }
+
+    private static func measureRapidRootAndDepthChanges(
+        fixture: SunburstDenseBenchmarkFixture,
+        diskMapStore: DiskMapTreeStore
+    ) async throws -> RequestSequenceMeasurement {
+        let requests = [
+            SunburstBenchmarkRequest(
+                rootID: fixture.store.rootID,
+                depthLimit: 2,
+                layoutID: "root-depth-1"
+            ),
+            SunburstBenchmarkRequest(
+                rootID: fixture.denseDirectoryID,
+                depthLimit: 1,
+                layoutID: "root-depth-2"
+            ),
+            SunburstBenchmarkRequest(
+                rootID: fixture.store.rootID,
+                depthLimit: 2,
+                layoutID: "root-depth-3"
+            ),
+            SunburstBenchmarkRequest(
+                rootID: fixture.denseDirectoryID,
+                depthLimit: 1,
+                layoutID: "root-depth-final"
+            ),
+        ]
+        let probe = SunburstBenchmarkLayoutProbe()
+        let service = InstrumentedSunburstLayoutService(
+            probe: probe,
+            suspendedRequestCount: requests.count - 1
+        )
+        let model = SunburstChartModel(layoutService: service)
+        var tasks: [Task<Bool, Never>] = []
+        tasks.reserveCapacity(requests.count)
+        let sequenceStartedAt = ContinuousClock.now
+        var latestRequestStartedAt = sequenceStartedAt
+
+        for (index, request) in requests.enumerated() {
+            if index == requests.count - 1 {
+                latestRequestStartedAt = ContinuousClock.now
+            }
+            tasks.append(Task { @MainActor in
+                await model.loadLayout(
+                    treeStore: diskMapStore,
+                    rootID: request.rootID,
+                    depthLimit: request.depthLimit,
+                    layoutID: request.layoutID
+                )
+            })
+            try await waitForStartedRequestCount(index + 1, probe: probe)
+        }
+
+        let latestDidApply = await tasks[tasks.count - 1].value
+        let latestCompletedAt = ContinuousClock.now
+        var results: [Bool] = []
+        results.reserveCapacity(tasks.count)
+        for task in tasks {
+            results.append(await task.value)
+        }
+        let probeSnapshot = await probe.snapshot()
+
+        XCTAssertTrue(latestDidApply)
+        XCTAssertEqual(probeSnapshot.startedCount, requests.count)
+        return RequestSequenceMeasurement(
+            requestCount: requests.count,
+            appliedCount: results.filter { $0 }.count,
+            completedCount: probeSnapshot.completedCount,
+            cancelledCount: probeSnapshot.cancelledCount,
+            latestRequestSeconds: BenchmarkSupport.durationSeconds(
+                latestRequestStartedAt.duration(to: latestCompletedAt)
+            ),
+            totalSeconds: BenchmarkSupport.durationSeconds(sequenceStartedAt.duration(to: latestCompletedAt)),
+            renderedLayoutID: model.layoutReadiness.renderedLayoutID,
+            segmentCount: model.renderedSegments.count,
+            fingerprint: segmentFingerprint(model.renderedSegments)
+        )
+    }
+
+    private static func waitForStartedRequestCount(
+        _ expectedCount: Int,
+        probe: SunburstBenchmarkLayoutProbe
+    ) async throws {
+        let deadline = ContinuousClock.now.advanced(by: .seconds(30))
+        while await probe.startedCount < expectedCount,
+              ContinuousClock.now < deadline {
+            try await Task.sleep(for: .microseconds(100))
+        }
+        guard await probe.startedCount >= expectedCount else {
+            throw SunburstBenchmarkTimeoutError(
+                message: "Timed out waiting for Sunburst layout request \(expectedCount) to start."
+            )
+        }
+    }
+
+    private static func measureLayoutCancellation(
+        store: DiskMapTreeStore,
+        rootID: String,
+        baselineLayoutSeconds: Double
+    ) async throws -> CancellationMeasurement {
+        let task = Task.detached {
+            _ = try SunburstLayout.segments(
+                in: store,
+                rootID: rootID,
+                depthLimit: 1,
+                cancellationCheck: Task.checkCancellation
+            )
+            return ContinuousClock.now
+        }
+        let delaySeconds = min(max(baselineLayoutSeconds * 0.25, 0.002), 0.05)
+        try await Task.sleep(for: .seconds(delaySeconds))
+
+        let cancellationRequestedAt = ContinuousClock.now
+        task.cancel()
+        do {
+            let completedAt = try await task.value
+            return CancellationMeasurement(
+                seconds: BenchmarkSupport.durationSeconds(cancellationRequestedAt.duration(to: .now)),
+                wasCancelled: false,
+                completedBeforeCancellation: completedAt <= cancellationRequestedAt
+            )
+        } catch is CancellationError {
+            return CancellationMeasurement(
+                seconds: BenchmarkSupport.durationSeconds(cancellationRequestedAt.duration(to: .now)),
+                wasCancelled: true,
+                completedBeforeCancellation: false
+            )
+        }
+    }
+
+    private static func runHitTests(
+        model: SunburstChartModel,
+        size: CGSize,
+        iterationCount: Int
+    ) -> InteractionMeasurement {
+        var state = UInt64(0x9e3779b97f4a7c15)
+        var fingerprint = BenchmarkSupport.fnvOffsetBasis
+        var hitCount = 0
+
+        for _ in 0..<iterationCount {
+            state = state &* 6_364_136_223_846_793_005 &+ 1_442_695_040_888_963_407
+            let xUnit = Double(UInt32(truncatingIfNeeded: state)) / Double(UInt32.max)
+            state = state &* 6_364_136_223_846_793_005 &+ 1_442_695_040_888_963_407
+            let yUnit = Double(UInt32(truncatingIfNeeded: state)) / Double(UInt32.max)
+            let point = CGPoint(
+                x: CGFloat(xUnit) * size.width,
+                y: CGFloat(yUnit) * size.height
+            )
+            if let segment = model.segment(at: point, in: size) {
+                hitCount += 1
+                BenchmarkSupport.hash(segment.id, into: &fingerprint)
+            } else {
+                BenchmarkSupport.hash(UInt64.max, into: &fingerprint)
+            }
+        }
+        return InteractionMeasurement(
+            selectionCount: hitCount,
+            fingerprint: String(fingerprint, radix: 16)
+        )
+    }
+
+    private static func runSelectionOverlays(
+        model: SunburstChartModel,
+        inputs: [OverlayInput],
+        iterationCount: Int
+    ) -> InteractionMeasurement {
+        var fingerprint = BenchmarkSupport.fnvOffsetBasis
+        var segmentCount = 0
+
+        for offset in 0..<iterationCount {
+            let input = inputs[offset % inputs.count]
+            let overlays = model.selectionOverlaySegments(
+                selectedNodeID: input.selectedNodeID,
+                selectedAncestorIDs: input.ancestorIDs
+            )
+            segmentCount += overlays.count
+            for overlay in overlays {
+                BenchmarkSupport.hash(overlay.id, into: &fingerprint)
+                switch overlay.role {
+                case .ancestor:
+                    BenchmarkSupport.hash(0, into: &fingerprint)
+                case .selected:
+                    BenchmarkSupport.hash(1, into: &fingerprint)
+                }
+            }
+        }
+        return InteractionMeasurement(
+            selectionCount: segmentCount,
+            fingerprint: String(fingerprint, radix: 16)
+        )
+    }
+
+    private static func runKeyboardSelection(
+        model: SunburstChartModel,
+        iterationCount: Int
+    ) -> InteractionMeasurement {
+        let directions: [ChartSpatialSelectionDirection] = [.right, .down, .left, .up]
+        var selectedNodeID: String?
+        var selectionCount = 0
+        var fingerprint = BenchmarkSupport.fnvOffsetBasis
+
+        for offset in 0..<iterationCount {
+            let segment = model.keyboardSelection(
+                from: selectedNodeID,
+                moving: directions[offset % directions.count]
+            )
+            selectedNodeID = segment?.nodeID
+            if let selectedNodeID {
+                selectionCount += 1
+                BenchmarkSupport.hash(selectedNodeID, into: &fingerprint)
+            } else {
+                BenchmarkSupport.hash(UInt64.max, into: &fingerprint)
+            }
+        }
+        return InteractionMeasurement(
+            selectionCount: selectionCount,
+            fingerprint: String(fingerprint, radix: 16)
+        )
+    }
+
+    private static func makeDenseFixture(
+        fileCount: Int
+    ) -> SunburstDenseBenchmarkFixture {
+        let rootIndex = FileTreeNodeIndex(rawValue: 0)
+        let denseIndex = FileTreeNodeIndex(rawValue: 1)
+        let rootID = "/sunburst-benchmark"
+        let denseDirectoryID = rootID + "/dense"
+        var nodes = [
+            BenchmarkSupport.node(
+                id: rootID,
+                name: "sunburst-benchmark",
+                isDirectory: true,
+                allocatedSize: Int64(fileCount),
+                descendantFileCount: fileCount
+            ),
+            BenchmarkSupport.node(
+                id: denseDirectoryID,
+                name: "dense",
+                isDirectory: true,
+                allocatedSize: Int64(fileCount),
+                descendantFileCount: fileCount
+            ),
+        ]
+        nodes.reserveCapacity(fileCount + 2)
+        var childIndicesByIndex = Array(
+            repeating: [FileTreeNodeIndex](),
+            count: fileCount + 2
+        )
+        var denseChildren: [FileTreeNodeIndex] = []
+        denseChildren.reserveCapacity(fileCount)
+        var parentIndices = Array<FileTreeNodeIndex?>(
+            repeating: nil,
+            count: fileCount + 2
+        )
+        parentIndices[Int(denseIndex.rawValue)] = rootIndex
+
+        for fileOffset in 0..<fileCount {
+            let fileID = String(format: "%@/item-%07d.dat", denseDirectoryID, fileOffset)
+            let fileIndex = FileTreeNodeIndex(rawValue: UInt32(nodes.count))
+            nodes.append(BenchmarkSupport.node(
+                id: fileID,
+                name: String(format: "item-%07d.dat", fileOffset),
+                isDirectory: false,
+                allocatedSize: 1,
+                descendantFileCount: 1
+            ))
+            denseChildren.append(fileIndex)
+            parentIndices[Int(fileIndex.rawValue)] = denseIndex
+        }
+        childIndicesByIndex[Int(rootIndex.rawValue)] = [denseIndex]
+        childIndicesByIndex[Int(denseIndex.rawValue)] = denseChildren
+
+        let store = FileTreeStore(
+            verifiedRootIndex: rootIndex,
+            nodes: nodes,
+            childIndicesByIndex: childIndicesByIndex,
+            parentIndices: parentIndices,
+            orderedNodeIndices: nodes.indices.map {
+                FileTreeNodeIndex(rawValue: UInt32($0))
+            },
+            aggregateStats: ScanAggregateStats(
+                totalAllocatedSize: Int64(fileCount),
+                totalLogicalSize: Int64(fileCount),
+                fileCount: fileCount,
+                directoryCount: 2,
+                accessibleItemCount: fileCount + 2,
+                inaccessibleItemCount: 0
+            )
+        )
+        return SunburstDenseBenchmarkFixture(
+            store: store,
+            denseDirectoryID: denseDirectoryID
+        )
+    }
+
+    private static func makeInteractionFixture(
+        branchCount: Int,
+        renderedDepth: Int
+    ) -> SunburstInteractionBenchmarkFixture {
+        let rootID = "/sunburst-interaction"
+        let rootIndex = FileTreeNodeIndex(rawValue: 0)
+        let nodeCount = 1 + (branchCount * renderedDepth)
+        var nodes = [BenchmarkSupport.node(
+            id: rootID,
+            name: "sunburst-interaction",
+            isDirectory: true,
+            allocatedSize: Int64(branchCount),
+            descendantFileCount: branchCount
+        )]
+        nodes.reserveCapacity(nodeCount)
+        var childIndicesByIndex = Array(
+            repeating: [FileTreeNodeIndex](),
+            count: nodeCount
+        )
+        var parentIndices = Array<FileTreeNodeIndex?>(
+            repeating: nil,
+            count: nodeCount
+        )
+        var rootChildren: [FileTreeNodeIndex] = []
+        rootChildren.reserveCapacity(branchCount)
+
+        for branchOffset in 0..<branchCount {
+            var parentIndex = rootIndex
+            for depth in 0..<renderedDepth {
+                let id = interactionNodeID(
+                    rootID: rootID,
+                    branchOffset: branchOffset,
+                    depth: depth
+                )
+                let index = FileTreeNodeIndex(rawValue: UInt32(nodes.count))
+                nodes.append(BenchmarkSupport.node(
+                    id: id,
+                    name: depth == 0
+                        ? String(format: "branch-%03d", branchOffset)
+                        : String(format: "level-%02d", depth),
+                    isDirectory: depth + 1 < renderedDepth,
+                    allocatedSize: 1,
+                    descendantFileCount: 1
+                ))
+                parentIndices[Int(index.rawValue)] = parentIndex
+                childIndicesByIndex[Int(parentIndex.rawValue)].append(index)
+                if depth == 0 {
+                    rootChildren.append(index)
+                }
+                parentIndex = index
+            }
+        }
+        childIndicesByIndex[Int(rootIndex.rawValue)] = rootChildren
+
+        let store = FileTreeStore(
+            verifiedRootIndex: rootIndex,
+            nodes: nodes,
+            childIndicesByIndex: childIndicesByIndex,
+            parentIndices: parentIndices,
+            orderedNodeIndices: nodes.indices.map {
+                FileTreeNodeIndex(rawValue: UInt32($0))
+            },
+            aggregateStats: ScanAggregateStats(
+                totalAllocatedSize: Int64(branchCount),
+                totalLogicalSize: Int64(branchCount),
+                fileCount: branchCount,
+                directoryCount: 1 + (branchCount * max(renderedDepth - 1, 0)),
+                accessibleItemCount: nodeCount,
+                inaccessibleItemCount: 0
+            )
+        )
+        return SunburstInteractionBenchmarkFixture(store: store)
+    }
+
+    private static func makeOverlayInputs(
+        rootID: String,
+        branchCount: Int,
+        renderedDepth: Int
+    ) -> [OverlayInput] {
+        (0..<branchCount).map { branchOffset in
+            let ancestorIDs = Set((0..<(renderedDepth - 1)).map { depth in
+                interactionNodeID(
+                    rootID: rootID,
+                    branchOffset: branchOffset,
+                    depth: depth
+                )
+            })
+            return OverlayInput(
+                selectedNodeID: interactionNodeID(
+                    rootID: rootID,
+                    branchOffset: branchOffset,
+                    depth: renderedDepth - 1
+                ),
+                ancestorIDs: ancestorIDs
+            )
+        }
+    }
+
+    private static func interactionNodeID(
+        rootID: String,
+        branchOffset: Int,
+        depth: Int
+    ) -> String {
+        let branchID = String(format: "%@/branch-%03d", rootID, branchOffset)
+        guard depth > 0 else { return branchID }
+        return (1...depth).reduce(branchID) { path, level in
+            path + String(format: "/level-%02d", level)
+        }
+    }
+
+    private static func segmentFingerprint(_ segments: [SunburstSegment]) -> String {
+        var hash = BenchmarkSupport.fnvOffsetBasis
+        for segment in segments {
+            BenchmarkSupport.hash(segment.id, into: &hash)
+            BenchmarkSupport.hash(segment.nodeID ?? "<aggregate>", into: &hash)
+            BenchmarkSupport.hash(segment.label, into: &hash)
+            BenchmarkSupport.hash(segment.startAngle.radians.bitPattern, into: &hash)
+            BenchmarkSupport.hash(segment.endAngle.radians.bitPattern, into: &hash)
+            BenchmarkSupport.hash(Double(segment.innerRadius).bitPattern, into: &hash)
+            BenchmarkSupport.hash(Double(segment.outerRadius).bitPattern, into: &hash)
+            BenchmarkSupport.hash(UInt64(bitPattern: Int64(segment.depth)), into: &hash)
+            BenchmarkSupport.hash(UInt64(bitPattern: segment.totalSize), into: &hash)
+            BenchmarkSupport.hash(UInt64(segment.isAggregate ? 1 : 0), into: &hash)
+            BenchmarkSupport.hash(segment.colorToken.branchID, into: &hash)
+            BenchmarkSupport.hash(segment.colorToken.localID, into: &hash)
+            BenchmarkSupport.hash(UInt64(bitPattern: Int64(segment.colorToken.branchIndex)), into: &hash)
+            BenchmarkSupport.hash(UInt64(bitPattern: Int64(segment.colorToken.branchCount)), into: &hash)
+            BenchmarkSupport.hash(UInt64(bitPattern: Int64(segment.colorToken.siblingIndex)), into: &hash)
+            BenchmarkSupport.hash(UInt64(bitPattern: Int64(segment.colorToken.siblingCount)), into: &hash)
+            BenchmarkSupport.hash(UInt64(bitPattern: Int64(segment.colorToken.depth)), into: &hash)
+            switch segment.colorToken.role {
+            case .normal:
+                BenchmarkSupport.hash(0, into: &hash)
+            case .aggregate:
+                BenchmarkSupport.hash(1, into: &hash)
+            case .freeSpace:
+                BenchmarkSupport.hash(2, into: &hash)
+            }
+        }
+        return String(hash, radix: 16)
+    }
+
+    private static func report(
+        phase: String,
+        seconds: Double,
+        count: Int,
+        peakRSS: UInt64,
+        extra: String = ""
+    ) {
+        BenchmarkSupport.report(
+            prefix: "RADIX_SUNBURST_BENCH_RESULT",
+            phase: phase,
+            seconds: seconds,
+            count: count,
+            peakRSS: peakRSS,
+            extra: extra
+        )
+    }
+}
+
+private actor InstrumentedSunburstLayoutService: SunburstLayouting {
+    let probe: SunburstBenchmarkLayoutProbe
+    let suspendedRequestCount: Int
+
+    init(
+        probe: SunburstBenchmarkLayoutProbe,
+        suspendedRequestCount: Int
+    ) {
+        self.probe = probe
+        self.suspendedRequestCount = suspendedRequestCount
+    }
+
+    func segments(
+        in treeStore: DiskMapTreeStore,
+        rootID: String,
+        depthLimit: Int
+    ) async throws -> [SunburstSegment] {
+        let requestNumber = await probe.recordStarted()
+        do {
+            if requestNumber <= suspendedRequestCount {
+                try await Task.sleep(for: .seconds(5))
+                throw SunburstBenchmarkTimeoutError(
+                    message: "Expected Sunburst request \(requestNumber) to be superseded."
+                )
+            }
+            let segments = try SunburstLayout.segments(
+                in: treeStore,
+                rootID: rootID,
+                depthLimit: depthLimit,
+                cancellationCheck: Task.checkCancellation
+            )
+            await probe.recordCompleted()
+            return segments
+        } catch is CancellationError {
+            await probe.recordCancelled()
+            throw CancellationError()
+        }
+    }
+}
+
+private actor SunburstBenchmarkLayoutProbe {
+    private(set) var startedCount = 0
+    private var completedCount = 0
+    private var cancelledCount = 0
+
+    func recordStarted() -> Int {
+        startedCount += 1
+        return startedCount
+    }
+
+    func recordCompleted() {
+        completedCount += 1
+    }
+
+    func recordCancelled() {
+        cancelledCount += 1
+    }
+
+    func snapshot() -> SunburstBenchmarkLayoutProbeSnapshot {
+        SunburstBenchmarkLayoutProbeSnapshot(
+            startedCount: startedCount,
+            completedCount: completedCount,
+            cancelledCount: cancelledCount
+        )
+    }
+}
+
+private struct PrecomputedSunburstLayoutService: SunburstLayouting {
+    let segments: [SunburstSegment]
+
+    func segments(
+        in treeStore: DiskMapTreeStore,
+        rootID: String,
+        depthLimit: Int
+    ) async throws -> [SunburstSegment] {
+        segments
+    }
+}
+
+private struct SunburstDenseBenchmarkFixture: Sendable {
+    let store: FileTreeStore
+    let denseDirectoryID: String
+}
+
+private struct SunburstInteractionBenchmarkFixture: Sendable {
+    let store: FileTreeStore
+}
+
+private struct SunburstBenchmarkRequest {
+    let rootID: String
+    let depthLimit: Int
+    let layoutID: String
+}
+
+private struct SunburstBenchmarkLayoutProbeSnapshot {
+    let startedCount: Int
+    let completedCount: Int
+    let cancelledCount: Int
+}
+
+private struct OverlayInput {
+    let selectedNodeID: String
+    let ancestorIDs: Set<String>
+}
+
+private struct LayoutSample {
+    let seconds: Double
+    let segmentCount: Int
+    let fingerprint: String
+}
+
+private struct InteractionMeasurement {
+    let selectionCount: Int
+    let fingerprint: String
+}
+
+private struct CancellationMeasurement {
+    let seconds: Double
+    let wasCancelled: Bool
+    let completedBeforeCancellation: Bool
+}
+
+private struct RequestSequenceMeasurement {
+    let requestCount: Int
+    let appliedCount: Int
+    let completedCount: Int
+    let cancelledCount: Int
+    let latestRequestSeconds: Double
+    let totalSeconds: Double
+    let renderedLayoutID: String?
+    let segmentCount: Int
+    let fingerprint: String
+}
+
+private struct SunburstBenchmarkTimeoutError: LocalizedError {
+    let message: String
+
+    var errorDescription: String? { message }
+}

--- a/RadixCoreTests/SunburstResponsivenessBenchmarkTests.swift
+++ b/RadixCoreTests/SunburstResponsivenessBenchmarkTests.swift
@@ -61,7 +61,9 @@ final class SunburstResponsivenessBenchmarkTests: XCTestCase {
             $0.segmentCount == expectedLargeCount
                 && $0.fingerprint == expectedLargeFingerprint
         })
-        let largeLayoutMedian = BenchmarkSupport.median(largeLayoutSamples.map(\.seconds))
+        let largeLayoutMedian = try XCTUnwrap(
+            BenchmarkSupport.median(largeLayoutSamples.map(\.seconds))
+        )
         Self.report(
             phase: "layout_large_scan",
             seconds: largeLayoutMedian,
@@ -585,8 +587,7 @@ final class SunburstResponsivenessBenchmarkTests: XCTestCase {
             repeating: nil,
             count: nodeCount
         )
-        var rootChildren: [FileTreeNodeIndex] = []
-        rootChildren.reserveCapacity(branchCount)
+        childIndicesByIndex[Int(rootIndex.rawValue)].reserveCapacity(branchCount)
 
         for branchOffset in 0..<branchCount {
             var parentIndex = rootIndex
@@ -608,13 +609,9 @@ final class SunburstResponsivenessBenchmarkTests: XCTestCase {
                 ))
                 parentIndices[Int(index.rawValue)] = parentIndex
                 childIndicesByIndex[Int(parentIndex.rawValue)].append(index)
-                if depth == 0 {
-                    rootChildren.append(index)
-                }
                 parentIndex = index
             }
         }
-        childIndicesByIndex[Int(rootIndex.rawValue)] = rootChildren
 
         let store = FileTreeStore(
             verifiedRootIndex: rootIndex,

--- a/RadixCoreTests/TreemapResponsivenessBenchmarkTests.swift
+++ b/RadixCoreTests/TreemapResponsivenessBenchmarkTests.swift
@@ -73,7 +73,9 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
             $0.segmentCount == expectedLargeSegmentCount
                 && $0.fingerprint == expectedLargeFingerprint
         })
-        let largeLayoutMedian = BenchmarkSupport.median(largeLayoutSamples.map(\.seconds))
+        let largeLayoutMedian = try XCTUnwrap(
+            BenchmarkSupport.median(largeLayoutSamples.map(\.seconds))
+        )
         Self.report(
             phase: "layout_large_scan",
             seconds: largeLayoutMedian,
@@ -116,7 +118,9 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
         })
         Self.report(
             phase: "layout_flat_high_fanout",
-            seconds: BenchmarkSupport.median(flatLayoutSamples.map(\.seconds)),
+            seconds: try XCTUnwrap(
+                BenchmarkSupport.median(flatLayoutSamples.map(\.seconds))
+            ),
             count: flatFileCount,
             peakRSS: BenchmarkSupport.peakResidentBytes(),
             extra: "segments=\(expectedFlatSegmentCount) "

--- a/RadixCoreTests/TreemapResponsivenessBenchmarkTests.swift
+++ b/RadixCoreTests/TreemapResponsivenessBenchmarkTests.swift
@@ -1,8 +1,9 @@
 import CoreGraphics
-import Darwin
 import Foundation
 import XCTest
 @testable import RadixCore
+
+private typealias BenchmarkSupport = ChartResponsivenessBenchmarkSupport
 
 @MainActor
 final class TreemapResponsivenessBenchmarkTests: XCTestCase {
@@ -24,8 +25,8 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
 
         let largeLayoutSize = CGSize(width: 1_600, height: 1_000)
         let alternateLayoutSize = CGSize(width: 1_024, height: 1_320)
-        let initialPeakRSS = Self.peakResidentBytes()
-        let fixtureMeasurement = Self.measure {
+        let initialPeakRSS = BenchmarkSupport.peakResidentBytes()
+        let fixtureMeasurement = BenchmarkSupport.measure {
             Self.makeFixture(
                 directoryCount: directoryCount,
                 filesPerDirectory: filesPerDirectory,
@@ -33,7 +34,7 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
             )
         }
         let fixture = fixtureMeasurement.value
-        let fixturePeakRSS = Self.peakResidentBytes()
+        let fixturePeakRSS = BenchmarkSupport.peakResidentBytes()
 
         XCTAssertEqual(
             fixture.store.nodeCount,
@@ -44,14 +45,14 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
             seconds: fixtureMeasurement.seconds,
             count: fixture.store.nodeCount,
             peakRSS: fixturePeakRSS,
-            extra: "rss_delta=\(Self.byteDelta(from: initialPeakRSS, to: fixturePeakRSS))"
+            extra: "rss_delta=\(BenchmarkSupport.byteDelta(from: initialPeakRSS, to: fixturePeakRSS))"
         )
 
         let diskMapStore = DiskMapTreeStore(fixture.store)
         var largeLayoutSamples: [LayoutSample] = []
         largeLayoutSamples.reserveCapacity(sampleCount)
         for _ in 0..<sampleCount {
-            let measurement = try Self.measure {
+            let measurement = try BenchmarkSupport.measure {
                 try TreemapLayout.segments(
                     in: diskMapStore,
                     rootID: fixture.store.rootID,
@@ -72,17 +73,17 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
             $0.segmentCount == expectedLargeSegmentCount
                 && $0.fingerprint == expectedLargeFingerprint
         })
-        let largeLayoutMedian = Self.median(largeLayoutSamples.map(\.seconds))
+        let largeLayoutMedian = BenchmarkSupport.median(largeLayoutSamples.map(\.seconds))
         Self.report(
             phase: "layout_large_scan",
             seconds: largeLayoutMedian,
             count: expectedLargeSegmentCount,
-            peakRSS: Self.peakResidentBytes(),
-            extra: "samples=\(largeLayoutSamples.map { Self.format($0.seconds) }.joined(separator: ",")) "
+            peakRSS: BenchmarkSupport.peakResidentBytes(),
+            extra: "samples=\(largeLayoutSamples.map { BenchmarkSupport.format($0.seconds) }.joined(separator: ",")) "
                 + "fingerprint=\(expectedLargeFingerprint)"
         )
 
-        let denseLayoutMeasurement = try Self.measure {
+        let denseLayoutMeasurement = try BenchmarkSupport.measure {
             try TreemapLayout.segments(
                 in: diskMapStore,
                 rootID: fixture.denseDirectoryID,
@@ -98,7 +99,7 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
             phase: "layout_dense_folder",
             seconds: denseLayoutMeasurement.seconds,
             count: denseSegments.count,
-            peakRSS: Self.peakResidentBytes(),
+            peakRSS: BenchmarkSupport.peakResidentBytes(),
             extra: "fingerprint=\(denseFingerprint)"
         )
 
@@ -115,18 +116,18 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
         })
         Self.report(
             phase: "layout_flat_high_fanout",
-            seconds: Self.median(flatLayoutSamples.map(\.seconds)),
+            seconds: BenchmarkSupport.median(flatLayoutSamples.map(\.seconds)),
             count: flatFileCount,
-            peakRSS: Self.peakResidentBytes(),
+            peakRSS: BenchmarkSupport.peakResidentBytes(),
             extra: "segments=\(expectedFlatSegmentCount) "
-                + "samples=\(flatLayoutSamples.map { Self.format($0.seconds) }.joined(separator: ",")) "
+                + "samples=\(flatLayoutSamples.map { BenchmarkSupport.format($0.seconds) }.joined(separator: ",")) "
                 + "fingerprint=\(expectedFlatFingerprint)"
         )
 
         let publicationModel = TreemapChartModel(
             layoutService: PrecomputedTreemapLayoutService(segments: denseSegments)
         )
-        let publicationMeasurement = await Self.measureAsync {
+        let publicationMeasurement = await BenchmarkSupport.measureAsync {
             await publicationModel.loadLayout(
                 treeStore: diskMapStore,
                 rootID: fixture.denseDirectoryID,
@@ -141,10 +142,10 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
             phase: "render_state_publication",
             seconds: publicationMeasurement.seconds,
             count: denseSegments.count,
-            peakRSS: Self.peakResidentBytes()
+            peakRSS: BenchmarkSupport.peakResidentBytes()
         )
 
-        let hitTestMeasurement = Self.measure {
+        let hitTestMeasurement = BenchmarkSupport.measure {
             Self.runHitTests(
                 model: publicationModel,
                 size: largeLayoutSize,
@@ -156,12 +157,12 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
             phase: "hit_testing",
             seconds: hitTestMeasurement.seconds,
             count: hitTestIterationCount,
-            peakRSS: Self.peakResidentBytes(),
+            peakRSS: BenchmarkSupport.peakResidentBytes(),
             extra: "hits=\(hitTestMeasurement.value.hitCount) "
                 + "fingerprint=\(hitTestMeasurement.value.fingerprint)"
         )
 
-        let wideKeyboardMeasurement = Self.measure {
+        let wideKeyboardMeasurement = BenchmarkSupport.measure {
             Self.runKeyboardSelection(
                 model: publicationModel,
                 size: largeLayoutSize,
@@ -173,12 +174,12 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
             phase: "keyboard_selection_wide",
             seconds: wideKeyboardMeasurement.seconds,
             count: keyboardIterationCount,
-            peakRSS: Self.peakResidentBytes(),
+            peakRSS: BenchmarkSupport.peakResidentBytes(),
             extra: "selections=\(wideKeyboardMeasurement.value.selectionCount) "
                 + "fingerprint=\(wideKeyboardMeasurement.value.fingerprint)"
         )
 
-        let tallKeyboardMeasurement = Self.measure {
+        let tallKeyboardMeasurement = BenchmarkSupport.measure {
             Self.runKeyboardSelection(
                 model: publicationModel,
                 size: alternateLayoutSize,
@@ -190,7 +191,7 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
             phase: "keyboard_selection_tall",
             seconds: tallKeyboardMeasurement.seconds,
             count: keyboardIterationCount,
-            peakRSS: Self.peakResidentBytes(),
+            peakRSS: BenchmarkSupport.peakResidentBytes(),
             extra: "selections=\(tallKeyboardMeasurement.value.selectionCount) "
                 + "fingerprint=\(tallKeyboardMeasurement.value.fingerprint)"
         )
@@ -210,7 +211,7 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
             phase: "cancel_layout",
             seconds: cancellationMeasurement.seconds,
             count: fixture.store.nodeCount,
-            peakRSS: Self.peakResidentBytes(),
+            peakRSS: BenchmarkSupport.peakResidentBytes(),
             extra: "cancelled=\(cancellationMeasurement.wasCancelled) "
                 + "completed_before_cancel=\(cancellationMeasurement.completedBeforeCancellation)"
         )
@@ -227,8 +228,8 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
             phase: "rapid_resize",
             seconds: resizeMeasurement.latestRequestSeconds,
             count: resizeMeasurement.requestCount,
-            peakRSS: Self.peakResidentBytes(),
-            extra: "total_seconds=\(Self.format(resizeMeasurement.totalSeconds)) "
+            peakRSS: BenchmarkSupport.peakResidentBytes(),
+            extra: "total_seconds=\(BenchmarkSupport.format(resizeMeasurement.totalSeconds)) "
                 + "applied=\(resizeMeasurement.appliedCount) "
                 + "cancelled=\(resizeMeasurement.cancelledCount) "
                 + "fingerprint=\(resizeMeasurement.fingerprint)"
@@ -252,8 +253,8 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
             phase: "rapid_navigation",
             seconds: navigationMeasurement.latestRequestSeconds,
             count: navigationMeasurement.requestCount,
-            peakRSS: Self.peakResidentBytes(),
-            extra: "total_seconds=\(Self.format(navigationMeasurement.totalSeconds)) "
+            peakRSS: BenchmarkSupport.peakResidentBytes(),
+            extra: "total_seconds=\(BenchmarkSupport.format(navigationMeasurement.totalSeconds)) "
                 + "applied=\(navigationMeasurement.appliedCount) "
                 + "cancelled=\(navigationMeasurement.cancelledCount) "
                 + "fingerprint=\(navigationMeasurement.fingerprint)"
@@ -263,8 +264,8 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
             phase: "suite_peak_rss",
             seconds: 0,
             count: fixture.store.nodeCount,
-            peakRSS: Self.peakResidentBytes(),
-            extra: "rss_delta=\(Self.byteDelta(from: initialPeakRSS, to: Self.peakResidentBytes()))"
+            peakRSS: BenchmarkSupport.peakResidentBytes(),
+            extra: "rss_delta=\(BenchmarkSupport.byteDelta(from: initialPeakRSS, to: BenchmarkSupport.peakResidentBytes()))"
         )
     }
 
@@ -374,10 +375,10 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
             appliedCount: results.filter { $0 }.count,
             completedCount: probeSnapshot.completedCount,
             cancelledCount: probeSnapshot.cancelledCount,
-            latestRequestSeconds: Self.durationSeconds(
+            latestRequestSeconds: BenchmarkSupport.durationSeconds(
                 latestRequestStartedAt.duration(to: latestCompletedAt)
             ),
-            totalSeconds: Self.durationSeconds(sequenceStartedAt.duration(to: latestCompletedAt)),
+            totalSeconds: BenchmarkSupport.durationSeconds(sequenceStartedAt.duration(to: latestCompletedAt)),
             renderedLayoutID: model.layoutReadiness.renderedLayoutID,
             segmentCount: model.renderedSegments.count,
             fingerprint: Self.segmentFingerprint(model.renderedSegments)
@@ -424,13 +425,13 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
         do {
             let completedAt = try await task.value
             return CancellationMeasurement(
-                seconds: durationSeconds(cancellationRequestedAt.duration(to: .now)),
+                seconds: BenchmarkSupport.durationSeconds(cancellationRequestedAt.duration(to: .now)),
                 wasCancelled: false,
                 completedBeforeCancellation: completedAt <= cancellationRequestedAt
             )
         } catch is CancellationError {
             return CancellationMeasurement(
-                seconds: durationSeconds(cancellationRequestedAt.duration(to: .now)),
+                seconds: BenchmarkSupport.durationSeconds(cancellationRequestedAt.duration(to: .now)),
                 wasCancelled: true,
                 completedBeforeCancellation: false
             )
@@ -443,7 +444,7 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
         iterationCount: Int
     ) -> InteractionMeasurement {
         var state = UInt64(0x9e3779b97f4a7c15)
-        var fingerprint = Self.fnvOffsetBasis
+        var fingerprint = BenchmarkSupport.fnvOffsetBasis
         var hitCount = 0
         for _ in 0..<iterationCount {
             state = state &* 6_364_136_223_846_793_005 &+ 1_442_695_040_888_963_407
@@ -456,9 +457,9 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
             )
             if let segment = model.segment(at: point, in: size) {
                 hitCount += 1
-                Self.hash(segment.id, into: &fingerprint)
+                BenchmarkSupport.hash(segment.id, into: &fingerprint)
             } else {
-                Self.hash(UInt64.max, into: &fingerprint)
+                BenchmarkSupport.hash(UInt64.max, into: &fingerprint)
             }
         }
         return InteractionMeasurement(
@@ -475,7 +476,7 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
         let directions: [ChartSpatialSelectionDirection] = [.right, .down, .left, .up]
         var selectedNodeID: String?
         var selectionCount = 0
-        var fingerprint = Self.fnvOffsetBasis
+        var fingerprint = BenchmarkSupport.fnvOffsetBasis
 
         for offset in 0..<iterationCount {
             let nextNodeID = model.spatialSelectionNodeID(
@@ -486,9 +487,9 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
             selectedNodeID = nextNodeID
             if let nextNodeID {
                 selectionCount += 1
-                Self.hash(nextNodeID, into: &fingerprint)
+                BenchmarkSupport.hash(nextNodeID, into: &fingerprint)
             } else {
-                Self.hash(UInt64.max, into: &fingerprint)
+                BenchmarkSupport.hash(UInt64.max, into: &fingerprint)
             }
         }
         return InteractionMeasurement(
@@ -507,7 +508,7 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
         let rootIndex = FileTreeNodeIndex(rawValue: 0)
         let rootID = "/treemap-benchmark"
         let denseDirectoryID = rootID + "/dense"
-        var nodes = [Self.node(
+        var nodes = [BenchmarkSupport.node(
             id: rootID,
             name: "treemap-benchmark",
             isDirectory: true,
@@ -527,7 +528,7 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
                 directoryOffset
             )
             let directoryIndex = FileTreeNodeIndex(rawValue: UInt32(nodes.count))
-            nodes.append(Self.node(
+            nodes.append(BenchmarkSupport.node(
                 id: directoryID,
                 name: String(format: "directory-%04d", directoryOffset),
                 isDirectory: true,
@@ -546,7 +547,7 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
                     fileOffset
                 )
                 let fileIndex = FileTreeNodeIndex(rawValue: UInt32(nodes.count))
-                nodes.append(Self.node(
+                nodes.append(BenchmarkSupport.node(
                     id: fileID,
                     name: String(format: "item-%05d.dat", fileOffset),
                     isDirectory: false,
@@ -560,7 +561,7 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
         }
 
         let denseDirectoryIndex = FileTreeNodeIndex(rawValue: UInt32(nodes.count))
-        nodes.append(Self.node(
+        nodes.append(BenchmarkSupport.node(
             id: denseDirectoryID,
             name: "dense",
             isDirectory: true,
@@ -573,7 +574,7 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
         for fileOffset in 0..<denseFileCount {
             let fileID = String(format: "%@/tile-%05d.dat", denseDirectoryID, fileOffset)
             let fileIndex = FileTreeNodeIndex(rawValue: UInt32(nodes.count))
-            nodes.append(Self.node(
+            nodes.append(BenchmarkSupport.node(
                 id: fileID,
                 name: String(format: "tile-%05d.dat", fileOffset),
                 isDirectory: false,
@@ -614,7 +615,7 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
     ) throws -> [LayoutSample] {
         let rootID = "/treemap-flat-benchmark"
         let rootIndex = FileTreeNodeIndex(rawValue: 0)
-        var nodes = [Self.node(
+        var nodes = [BenchmarkSupport.node(
             id: rootID,
             name: "treemap-flat-benchmark",
             isDirectory: true,
@@ -632,7 +633,7 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
         for fileOffset in 0..<fileCount {
             let fileID = String(format: "%@/item-%05d.dat", rootID, fileOffset)
             let fileIndex = FileTreeNodeIndex(rawValue: UInt32(nodes.count))
-            nodes.append(Self.node(
+            nodes.append(BenchmarkSupport.node(
                 id: fileID,
                 name: String(format: "item-%05d.dat", fileOffset),
                 isDirectory: false,
@@ -669,7 +670,7 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
         var samples: [LayoutSample] = []
         samples.reserveCapacity(sampleCount)
         for _ in 0..<sampleCount {
-            let measurement = try Self.measure {
+            let measurement = try BenchmarkSupport.measure {
                 try TreemapLayout.segments(
                     in: diskMapStore,
                     rootID: rootID,
@@ -694,124 +695,43 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
         return samples
     }
 
-    private static func node(
-        id: String,
-        name: String,
-        isDirectory: Bool,
-        allocatedSize: Int64,
-        descendantFileCount: Int
-    ) -> FileNodeRecord {
-        FileNodeRecord(
-            id: id,
-            url: URL(filePath: id, directoryHint: isDirectory ? .isDirectory : .notDirectory),
-            name: name,
-            isDirectory: isDirectory,
-            isSymbolicLink: false,
-            allocatedSize: allocatedSize,
-            logicalSize: allocatedSize,
-            descendantFileCount: descendantFileCount,
-            lastModified: nil,
-            isPackage: false,
-            isAccessible: true,
-            isSelfAccessible: true,
-            isSynthetic: false,
-            isAutoSummarized: false
-        )
-    }
-
     private static func segmentFingerprint(_ segments: [TreemapSegment]) -> String {
-        var hash = Self.fnvOffsetBasis
+        var hash = BenchmarkSupport.fnvOffsetBasis
         for segment in segments {
-            Self.hash(segment.id, into: &hash)
-            Self.hash(segment.nodeID ?? "<aggregate>", into: &hash)
-            Self.hash(segment.containerNodeID, into: &hash)
-            Self.hash(segment.label, into: &hash)
-            Self.hash(UInt64(bitPattern: Int64(segment.depth)), into: &hash)
-            Self.hash(UInt64(bitPattern: segment.totalSize), into: &hash)
-            Self.hash(UInt64(segment.isAggregate ? 1 : 0), into: &hash)
-            Self.hash(
+            BenchmarkSupport.hash(segment.id, into: &hash)
+            BenchmarkSupport.hash(segment.nodeID ?? "<aggregate>", into: &hash)
+            BenchmarkSupport.hash(segment.containerNodeID, into: &hash)
+            BenchmarkSupport.hash(segment.label, into: &hash)
+            BenchmarkSupport.hash(UInt64(bitPattern: Int64(segment.depth)), into: &hash)
+            BenchmarkSupport.hash(UInt64(bitPattern: segment.totalSize), into: &hash)
+            BenchmarkSupport.hash(UInt64(segment.isAggregate ? 1 : 0), into: &hash)
+            BenchmarkSupport.hash(
                 UInt64(bitPattern: Int64(segment.groupedItemCount ?? -1)),
                 into: &hash
             )
-            Self.hash(UInt64(segment.isDirectory ? 1 : 0), into: &hash)
-            Self.hash(UInt64(segment.showsContainerHeader ? 1 : 0), into: &hash)
-            Self.hash(Double(segment.rect.minX).bitPattern, into: &hash)
-            Self.hash(Double(segment.rect.minY).bitPattern, into: &hash)
-            Self.hash(Double(segment.rect.width).bitPattern, into: &hash)
-            Self.hash(Double(segment.rect.height).bitPattern, into: &hash)
-            Self.hash(segment.colorToken.branchID, into: &hash)
-            Self.hash(segment.colorToken.localID, into: &hash)
-            Self.hash(UInt64(bitPattern: Int64(segment.colorToken.branchIndex)), into: &hash)
-            Self.hash(UInt64(bitPattern: Int64(segment.colorToken.branchCount)), into: &hash)
-            Self.hash(UInt64(bitPattern: Int64(segment.colorToken.siblingIndex)), into: &hash)
-            Self.hash(UInt64(bitPattern: Int64(segment.colorToken.siblingCount)), into: &hash)
-            Self.hash(UInt64(bitPattern: Int64(segment.colorToken.depth)), into: &hash)
+            BenchmarkSupport.hash(UInt64(segment.isDirectory ? 1 : 0), into: &hash)
+            BenchmarkSupport.hash(UInt64(segment.showsContainerHeader ? 1 : 0), into: &hash)
+            BenchmarkSupport.hash(Double(segment.rect.minX).bitPattern, into: &hash)
+            BenchmarkSupport.hash(Double(segment.rect.minY).bitPattern, into: &hash)
+            BenchmarkSupport.hash(Double(segment.rect.width).bitPattern, into: &hash)
+            BenchmarkSupport.hash(Double(segment.rect.height).bitPattern, into: &hash)
+            BenchmarkSupport.hash(segment.colorToken.branchID, into: &hash)
+            BenchmarkSupport.hash(segment.colorToken.localID, into: &hash)
+            BenchmarkSupport.hash(UInt64(bitPattern: Int64(segment.colorToken.branchIndex)), into: &hash)
+            BenchmarkSupport.hash(UInt64(bitPattern: Int64(segment.colorToken.branchCount)), into: &hash)
+            BenchmarkSupport.hash(UInt64(bitPattern: Int64(segment.colorToken.siblingIndex)), into: &hash)
+            BenchmarkSupport.hash(UInt64(bitPattern: Int64(segment.colorToken.siblingCount)), into: &hash)
+            BenchmarkSupport.hash(UInt64(bitPattern: Int64(segment.colorToken.depth)), into: &hash)
             switch segment.colorToken.role {
             case .normal:
-                Self.hash(0, into: &hash)
+                BenchmarkSupport.hash(0, into: &hash)
             case .aggregate:
-                Self.hash(1, into: &hash)
+                BenchmarkSupport.hash(1, into: &hash)
             case .freeSpace:
-                Self.hash(2, into: &hash)
+                BenchmarkSupport.hash(2, into: &hash)
             }
         }
         return String(hash, radix: 16)
-    }
-
-    private static let fnvOffsetBasis: UInt64 = 14_695_981_039_346_656_037
-    private static let fnvPrime: UInt64 = 1_099_511_628_211
-
-    private static func hash(_ string: String, into hash: inout UInt64) {
-        for byte in string.utf8 {
-            hash ^= UInt64(byte)
-            hash &*= Self.fnvPrime
-        }
-        Self.hash(0xff, into: &hash)
-    }
-
-    private static func hash(_ value: UInt64, into hash: inout UInt64) {
-        var value = value
-        for _ in 0..<MemoryLayout<UInt64>.size {
-            hash ^= value & 0xff
-            hash &*= Self.fnvPrime
-            value >>= 8
-        }
-    }
-
-    private static func measure<Value>(_ operation: () throws -> Value) rethrows
-        -> Measurement<Value> {
-        let startedAt = ContinuousClock.now
-        let value = try operation()
-        return Measurement(
-            value: value,
-            seconds: durationSeconds(startedAt.duration(to: .now))
-        )
-    }
-
-    private static func measureAsync<Value>(
-        _ operation: () async throws -> Value
-    ) async rethrows -> Measurement<Value> {
-        let startedAt = ContinuousClock.now
-        let value = try await operation()
-        return Measurement(
-            value: value,
-            seconds: durationSeconds(startedAt.duration(to: .now))
-        )
-    }
-
-    private static func durationSeconds(_ duration: Duration) -> Double {
-        let components = duration.components
-        return Double(components.seconds)
-            + (Double(components.attoseconds) / 1_000_000_000_000_000_000)
-    }
-
-    private static func median(_ values: [Double]) -> Double {
-        let sortedValues = values.sorted()
-        let midpoint = sortedValues.count / 2
-        if sortedValues.count.isMultiple(of: 2) {
-            return (sortedValues[midpoint - 1] + sortedValues[midpoint]) / 2
-        }
-        return sortedValues[midpoint]
     }
 
     private static func report(
@@ -821,25 +741,14 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
         peakRSS: UInt64,
         extra: String = ""
     ) {
-        print(
-            "RADIX_TREEMAP_BENCH_RESULT phase=\(phase) "
-                + "seconds=\(format(seconds)) count=\(count) "
-                + "peak_rss=\(peakRSS) \(extra)"
+        BenchmarkSupport.report(
+            prefix: "RADIX_TREEMAP_BENCH_RESULT",
+            phase: phase,
+            seconds: seconds,
+            count: count,
+            peakRSS: peakRSS,
+            extra: extra
         )
-    }
-
-    private static func format(_ value: Double) -> String {
-        String(format: "%.6f", value)
-    }
-
-    private static func peakResidentBytes() -> UInt64 {
-        var usage = rusage()
-        guard getrusage(RUSAGE_SELF, &usage) == 0 else { return 0 }
-        return UInt64(max(usage.ru_maxrss, 0))
-    }
-
-    private static func byteDelta(from start: UInt64, to end: UInt64) -> UInt64 {
-        end >= start ? end - start : 0
     }
 }
 
@@ -929,11 +838,6 @@ private struct TreemapBenchmarkLayoutProbeSnapshot {
     let startedCount: Int
     let completedCount: Int
     let cancelledCount: Int
-}
-
-private struct Measurement<Value> {
-    let value: Value
-    let seconds: Double
 }
 
 private struct LayoutSample {


### PR DESCRIPTION
## Summary

- reduce large high-fanout Sunburst layout retention by tracking the grouped count, total size, and sole-child candidate instead of retaining every grouped node
- build immutable per-render Sunburst selection metadata once, replacing full-segment rescans during keyboard navigation and selection-overlay construction
- share the demonstrated ring grouping and segment lookups within Sunburst publication while preserving the lightweight standalone hit-test path
- add an opt-in, test-target-only million-node Sunburst benchmark and extract neutral timing, hashing, reporting, fixture, and RSS helpers shared with the existing Treemap benchmark

## Measured impact

Measurements use the opt-in Debug test benchmark with a deterministic 1,000,002-node fixture and a 1,200-segment interaction layout. Settled values are medians from three final runs unless noted.

| Phase | Baseline | Final | Result |
| --- | ---: | ---: | --- |
| Large-scan layout | 0.4100 s | 0.3775 s | 7.9% faster |
| Dense-root layout | 0.4009 s | 0.3573 s | 10.9% faster |
| 20,000 alternating selection overlays | 4.64 s | 0.609 s | 86.9% faster |
| 20,000 keyboard moves | 9.04 s | 0.151 s | 98.3% faster |
| Latest rapid root/depth request | 0.457 s | 0.374 s | 18.2% faster |
| Suite peak RSS | 1.495 GB | 1.013-1.077 GB | 418-482 MB lower |

Publication intentionally pays a small one-time indexing cost (about 3.46 ms to 3.95 ms) to remove repeated interaction work. The existing direct-segment hit-test representation was retained after a combined representation measured worse; final hit testing remained near baseline. Direct real-layout cancellation remained responsive at roughly 10 ms.

These are synthetic, opt-in test results, not shipped or real-user latency measurements.

## Correctness and cancellation

- full geometry/color fingerprints are unchanged for large, dense, and interaction layouts
- deterministic hit-test, overlay, and keyboard-selection fingerprints are unchanged
- selection overlays retain layout-order ancestors followed by the selected segment
- keyboard entry, ring wrapping, equal-angle ordering, and radial movement semantics are covered by focused tests
- the deterministic rapid-change probe reports `started=4`, `completed=1`, `cancelled=3`, and `applied=1`; only `root-depth-final` publishes
- the standalone hit-test initializer remains lightweight and does not construct unused publication maps

## Benchmark boundary

- Sunburst benchmark requires `RADIX_BENCH_SUNBURST=1`
- Treemap benchmark remains gated by `RADIX_BENCH_TREEMAP=1`
- benchmark code and shared support live only in `RadixCoreTests`
- the rebuilt Release app and Release intermediates contain none of either benchmark's environment/result identifiers, test types, or shared support type

## Validation

- `RADIX_BENCH_SUNBURST=1 swift test --filter SunburstResponsivenessBenchmarkTests/testLargeScanSunburstResponsivenessBenchmark`
- `RADIX_BENCH_TREEMAP=1 swift test --filter TreemapResponsivenessBenchmarkTests/testLargeScanTreemapResponsivenessBenchmark`
- `swift test` — 788 tests, 23 expected skips, 0 failures
- Debug app build with deterministic DerivedData — passed
- Release app build with separate deterministic DerivedData — passed
- Release executable, bundle, and intermediates benchmark-identifier inspection — no matches
- `git diff --check` — passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Sunburst chart keyboard navigation, hit testing, and selection overlays.
  * Added consistent ordering and wraparound behavior for navigation.
  * Preserved single small child segments instead of grouping them.

* **Performance**
  * Improved responsiveness for chart interactions and selection overlays.
  * Added optional Sunburst responsiveness benchmarks covering layout, interaction, memory, and cancellation.

* **Bug Fixes**
  * Refreshed selection overlays after loading a new layout.
  * Improved handling of missing ancestors and equal-angle segments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->