### PR TITLE
refactor(tests): consolidate benchmark support

### DIFF
--- a/RadixCoreTests/BenchmarkSupport.swift
+++ b/RadixCoreTests/BenchmarkSupport.swift
@@ -1,0 +1,122 @@
+import Darwin
+import Foundation
+
+enum BenchmarkSupport {
+    static func measure<Value>(
+        _ operation: () throws -> Value
+    ) rethrows -> BenchmarkMeasurement<Value> {
+        let startedAt = ContinuousClock.now
+        let value = try operation()
+        return BenchmarkMeasurement(
+            value: value,
+            seconds: durationSeconds(startedAt.duration(to: .now))
+        )
+    }
+
+    static func durationSeconds(_ duration: Duration) -> Double {
+        let components = duration.components
+        return Double(components.seconds)
+            + (Double(components.attoseconds) / 1_000_000_000_000_000_000)
+    }
+
+    static func median(_ values: [Double]) -> Double? {
+        guard !values.isEmpty else { return nil }
+        let sortedValues = values.sorted()
+        let midpoint = sortedValues.count / 2
+        if sortedValues.count.isMultiple(of: 2) {
+            return (sortedValues[midpoint - 1] + sortedValues[midpoint]) / 2
+        }
+        return sortedValues[midpoint]
+    }
+
+    static func report(
+        prefix: String,
+        phase: String,
+        seconds: Double,
+        count: Int,
+        peakRSS: UInt64,
+        extra: String = ""
+    ) {
+        print(resultLine(
+            prefix: prefix,
+            phase: phase,
+            seconds: seconds,
+            count: count,
+            peakRSS: peakRSS,
+            extra: extra
+        ))
+    }
+
+    static func resultLine(
+        prefix: String,
+        phase: String,
+        seconds: Double,
+        count: Int,
+        peakRSS: UInt64,
+        extra: String = ""
+    ) -> String {
+        "\(prefix) phase=\(phase) "
+            + "seconds=\(format(seconds)) count=\(count) "
+            + "peak_rss=\(peakRSS) \(extra)"
+    }
+
+    static func format(_ value: Double) -> String {
+        String(format: "%.6f", value)
+    }
+
+    static func peakResidentBytes() -> UInt64 {
+        var usage = rusage()
+        guard getrusage(RUSAGE_SELF, &usage) == 0 else { return 0 }
+        return UInt64(max(usage.ru_maxrss, 0))
+    }
+
+    static func byteDelta(from start: UInt64, to end: UInt64) -> UInt64 {
+        end >= start ? end - start : 0
+    }
+}
+
+struct BenchmarkMeasurement<Value> {
+    let value: Value
+    let seconds: Double
+}
+
+final class BenchmarkMemorySampler: @unchecked Sendable {
+    private let lock = NSLock()
+    private var peakRSS: UInt64
+
+    init(initialRSS: UInt64) {
+        peakRSS = initialRSS
+    }
+
+    func sample() {
+        let currentRSS = Self.currentResidentMemoryBytes()
+        lock.lock()
+        peakRSS = max(peakRSS, currentRSS)
+        lock.unlock()
+    }
+
+    func peak() -> UInt64 {
+        lock.lock()
+        defer { lock.unlock() }
+        return peakRSS
+    }
+
+    static func currentResidentMemoryBytes() -> UInt64 {
+        var info = mach_task_basic_info()
+        var count = mach_msg_type_number_t(
+            MemoryLayout<mach_task_basic_info>.size / MemoryLayout<natural_t>.size
+        )
+        let result = withUnsafeMutablePointer(to: &info) { infoPointer in
+            infoPointer.withMemoryRebound(to: integer_t.self, capacity: Int(count)) { reboundInfo in
+                task_info(
+                    mach_task_self_,
+                    task_flavor_t(MACH_TASK_BASIC_INFO),
+                    reboundInfo,
+                    &count
+                )
+            }
+        }
+        guard result == KERN_SUCCESS else { return 0 }
+        return UInt64(info.resident_size)
+    }
+}

--- a/RadixCoreTests/BenchmarkSupportTests.swift
+++ b/RadixCoreTests/BenchmarkSupportTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+
+final class BenchmarkSupportTests: XCTestCase {
+    func testMedianHandlesEmptyOddAndEvenSamples() {
+        XCTAssertNil(BenchmarkSupport.median([]))
+        XCTAssertEqual(BenchmarkSupport.median([3, 1, 2]), 2)
+        XCTAssertEqual(BenchmarkSupport.median([4, 1, 3, 2]), 2.5)
+    }
+
+    func testDurationSecondsIncludesAttoseconds() {
+        XCTAssertEqual(
+            BenchmarkSupport.durationSeconds(.seconds(1) + .milliseconds(250)),
+            1.25,
+            accuracy: 0.000_001
+        )
+    }
+
+    func testByteDeltaClampsDecreasesToZero() {
+        XCTAssertEqual(BenchmarkSupport.byteDelta(from: 100, to: 125), 25)
+        XCTAssertEqual(BenchmarkSupport.byteDelta(from: 125, to: 100), 0)
+    }
+
+    func testResultLinePreservesBenchmarkOutputFormat() {
+        XCTAssertEqual(
+            BenchmarkSupport.resultLine(
+                prefix: "TEST_RESULT",
+                phase: "fixture",
+                seconds: 1.25,
+                count: 7,
+                peakRSS: 99,
+                extra: "fingerprint=abc"
+            ),
+            "TEST_RESULT phase=fixture seconds=1.250000 count=7 peak_rss=99 fingerprint=abc"
+        )
+        XCTAssertEqual(
+            BenchmarkSupport.resultLine(
+                prefix: "TEST_RESULT",
+                phase: "fixture",
+                seconds: 0,
+                count: 0,
+                peakRSS: 0
+            ),
+            "TEST_RESULT phase=fixture seconds=0.000000 count=0 peak_rss=0 "
+        )
+    }
+}

--- a/RadixCoreTests/ChartResponsivenessBenchmarkSupport.swift
+++ b/RadixCoreTests/ChartResponsivenessBenchmarkSupport.swift
@@ -1,4 +1,3 @@
-import Darwin
 import Foundation
 @testable import RadixCore
 
@@ -53,76 +52,15 @@ enum ChartResponsivenessBenchmarkSupport {
         }
     }
 
-    static func measure<Value>(
-        _ operation: () throws -> Value
-    ) rethrows -> ChartBenchmarkMeasurement<Value> {
-        let startedAt = ContinuousClock.now
-        let value = try operation()
-        return ChartBenchmarkMeasurement(
-            value: value,
-            seconds: durationSeconds(startedAt.duration(to: .now))
-        )
-    }
-
     @MainActor
     static func measureAsync<Value>(
         _ operation: () async throws -> Value
-    ) async rethrows -> ChartBenchmarkMeasurement<Value> {
+    ) async rethrows -> BenchmarkMeasurement<Value> {
         let startedAt = ContinuousClock.now
         let value = try await operation()
-        return ChartBenchmarkMeasurement(
+        return BenchmarkMeasurement(
             value: value,
-            seconds: durationSeconds(startedAt.duration(to: .now))
+            seconds: BenchmarkSupport.durationSeconds(startedAt.duration(to: .now))
         )
     }
-
-    static func durationSeconds(_ duration: Duration) -> Double {
-        let components = duration.components
-        return Double(components.seconds)
-            + (Double(components.attoseconds) / 1_000_000_000_000_000_000)
-    }
-
-    static func median(_ values: [Double]) -> Double? {
-        guard !values.isEmpty else { return nil }
-        let sortedValues = values.sorted()
-        let midpoint = sortedValues.count / 2
-        if sortedValues.count.isMultiple(of: 2) {
-            return (sortedValues[midpoint - 1] + sortedValues[midpoint]) / 2
-        }
-        return sortedValues[midpoint]
-    }
-
-    static func report(
-        prefix: String,
-        phase: String,
-        seconds: Double,
-        count: Int,
-        peakRSS: UInt64,
-        extra: String = ""
-    ) {
-        print(
-            "\(prefix) phase=\(phase) "
-                + "seconds=\(format(seconds)) count=\(count) "
-                + "peak_rss=\(peakRSS) \(extra)"
-        )
-    }
-
-    static func format(_ value: Double) -> String {
-        String(format: "%.6f", value)
-    }
-
-    static func peakResidentBytes() -> UInt64 {
-        var usage = rusage()
-        guard getrusage(RUSAGE_SELF, &usage) == 0 else { return 0 }
-        return UInt64(max(usage.ru_maxrss, 0))
-    }
-
-    static func byteDelta(from start: UInt64, to end: UInt64) -> UInt64 {
-        end >= start ? end - start : 0
-    }
-}
-
-struct ChartBenchmarkMeasurement<Value> {
-    let value: Value
-    let seconds: Double
 }

--- a/RadixCoreTests/ChartResponsivenessBenchmarkSupportTests.swift
+++ b/RadixCoreTests/ChartResponsivenessBenchmarkSupportTests.swift
@@ -1,7 +1,0 @@
-import XCTest
-
-final class ChartResponsivenessBenchmarkSupportTests: XCTestCase {
-    func testMedianReturnsNilForEmptySamples() {
-        XCTAssertNil(ChartResponsivenessBenchmarkSupport.median([]))
-    }
-}

--- a/RadixCoreTests/FileBrowserBenchmarkTests.swift
+++ b/RadixCoreTests/FileBrowserBenchmarkTests.swift
@@ -1,5 +1,4 @@
 import Combine
-import Darwin
 import Foundation
 import XCTest
 @testable import RadixCore
@@ -23,15 +22,15 @@ final class FileBrowserBenchmarkTests: XCTestCase {
             .flatMap(Int.init)
             .map { max(1, $0) } ?? 3
 
-        let initialPeakRSS = Self.peakResidentBytes()
-        let fixtureMeasurement = Self.measure {
+        let initialPeakRSS = BenchmarkSupport.peakResidentBytes()
+        let fixtureMeasurement = BenchmarkSupport.measure {
             Self.makeFixture(
                 directoryCount: directoryCount,
                 filesPerDirectory: filesPerDirectory
             )
         }
         let fixture = fixtureMeasurement.value
-        let fixturePeakRSS = Self.peakResidentBytes()
+        let fixturePeakRSS = BenchmarkSupport.peakResidentBytes()
 
         XCTAssertEqual(
             fixture.store.nodeCount,
@@ -42,7 +41,7 @@ final class FileBrowserBenchmarkTests: XCTestCase {
             seconds: fixtureMeasurement.seconds,
             count: fixture.store.nodeCount,
             peakRSS: fixturePeakRSS,
-            extra: "rss_delta=\(Self.byteDelta(from: initialPeakRSS, to: fixturePeakRSS))"
+            extra: "rss_delta=\(BenchmarkSupport.byteDelta(from: initialPeakRSS, to: fixturePeakRSS))"
         )
 
         let snapshotID = UUID()
@@ -68,15 +67,15 @@ final class FileBrowserBenchmarkTests: XCTestCase {
         )
         let warmNoMatchMedian = Self.median(warmNoMatchSamples.map(\.seconds))
         let estimatedIndexSeconds = max(coldMeasurement.seconds - warmNoMatchMedian, 0)
-        let indexedPeakRSS = Self.peakResidentBytes()
+        let indexedPeakRSS = BenchmarkSupport.peakResidentBytes()
         Self.report(
             phase: "cold_index",
             seconds: estimatedIndexSeconds,
             count: fixture.store.nodeCount - 1,
             peakRSS: indexedPeakRSS,
-            extra: "cold_total=\(Self.format(coldMeasurement.seconds)) " +
-                "warm_scan_median=\(Self.format(warmNoMatchMedian)) " +
-                "rss_delta=\(Self.byteDelta(from: fixturePeakRSS, to: indexedPeakRSS))"
+            extra: "cold_total=\(BenchmarkSupport.format(coldMeasurement.seconds)) " +
+                "warm_scan_median=\(BenchmarkSupport.format(warmNoMatchMedian)) " +
+                "rss_delta=\(BenchmarkSupport.byteDelta(from: fixturePeakRSS, to: indexedPeakRSS))"
         )
 
         let textSamples = try await Self.measureSearchSamples(
@@ -123,7 +122,7 @@ final class FileBrowserBenchmarkTests: XCTestCase {
             phase: "path_first",
             seconds: firstPathMeasurement.seconds,
             count: filesPerDirectory,
-            peakRSS: Self.peakResidentBytes()
+            peakRSS: BenchmarkSupport.peakResidentBytes()
         )
         Self.reportSamples(
             phase: "path_warm",
@@ -154,7 +153,7 @@ final class FileBrowserBenchmarkTests: XCTestCase {
         )
 
         let sortOrder = [FileNodeTableComparator(field: .allocatedSize, order: .reverse)]
-        let sortingMeasurement = Self.measure {
+        let sortingMeasurement = BenchmarkSupport.measure {
             FileBrowserResults.sorted(
                 largeResults,
                 sortOrder: sortOrder,
@@ -162,7 +161,7 @@ final class FileBrowserBenchmarkTests: XCTestCase {
             )
         }
         let sortedResults = sortingMeasurement.value
-        let sortingPeakRSS = Self.peakResidentBytes()
+        let sortingPeakRSS = BenchmarkSupport.peakResidentBytes()
         XCTAssertEqual(sortedResults.count, fixture.fileCount)
         Self.assertSorted(
             sortedResults,
@@ -183,7 +182,7 @@ final class FileBrowserBenchmarkTests: XCTestCase {
             phase: "main_actor_publication",
             seconds: publicationMeasurement,
             count: sortedResults.count,
-            peakRSS: Self.peakResidentBytes()
+            peakRSS: BenchmarkSupport.peakResidentBytes()
         )
 
         let coldCancellation = try await Self.measureColdSearchCancellation(
@@ -198,7 +197,7 @@ final class FileBrowserBenchmarkTests: XCTestCase {
             phase: "cancel_cold_search",
             seconds: coldCancellation.seconds,
             count: fixture.store.nodeCount - 1,
-            peakRSS: Self.peakResidentBytes(),
+            peakRSS: BenchmarkSupport.peakResidentBytes(),
             extra: "cancelled=\(coldCancellation.wasCancelled) " +
                 "completed_before_cancel=\(coldCancellation.completedBeforeCancellation)"
         )
@@ -217,7 +216,7 @@ final class FileBrowserBenchmarkTests: XCTestCase {
             phase: "cancel_sort",
             seconds: sortCancellation.seconds,
             count: largeResults.count,
-            peakRSS: Self.peakResidentBytes(),
+            peakRSS: BenchmarkSupport.peakResidentBytes(),
             extra: "cancelled=\(sortCancellation.wasCancelled) " +
                 "completed_before_cancel=\(sortCancellation.completedBeforeCancellation)"
         )
@@ -231,15 +230,15 @@ final class FileBrowserBenchmarkTests: XCTestCase {
             phase: "end_to_end",
             seconds: endToEndSeconds,
             count: fixture.fileCount,
-            peakRSS: Self.peakResidentBytes()
+            peakRSS: BenchmarkSupport.peakResidentBytes()
         )
 
         Self.report(
             phase: "suite_peak_rss",
             seconds: 0,
             count: fixture.store.nodeCount,
-            peakRSS: Self.peakResidentBytes(),
-            extra: "rss_delta=\(Self.byteDelta(from: initialPeakRSS, to: Self.peakResidentBytes()))"
+            peakRSS: BenchmarkSupport.peakResidentBytes(),
+            extra: "rss_delta=\(BenchmarkSupport.byteDelta(from: initialPeakRSS, to: BenchmarkSupport.peakResidentBytes()))"
         )
     }
 
@@ -280,7 +279,7 @@ final class FileBrowserBenchmarkTests: XCTestCase {
 
         let startedAt = ContinuousClock.now
         publisher.publish(nodes)
-        let seconds = durationSeconds(startedAt.duration(to: .now))
+        let seconds = BenchmarkSupport.durationSeconds(startedAt.duration(to: .now))
 
         XCTAssertEqual(publicationCount, 1)
         XCTAssertEqual(publisher.nodeCount, nodes.count)
@@ -340,7 +339,7 @@ final class FileBrowserBenchmarkTests: XCTestCase {
                 message: "Timed out waiting for the end-to-end entire-scan search to finish."
             )
         }
-        let seconds = durationSeconds(startedAt.duration(to: .now))
+        let seconds = BenchmarkSupport.durationSeconds(startedAt.duration(to: .now))
 
         XCTAssertTrue(model.isDisplayingCurrentResults)
         XCTAssertEqual(model.displayedNodes.count, fixture.fileCount)
@@ -369,13 +368,13 @@ final class FileBrowserBenchmarkTests: XCTestCase {
         do {
             let completedAt = try await task.value
             return CancellationMeasurement(
-                seconds: durationSeconds(cancellationRequestedAt.duration(to: .now)),
+                seconds: BenchmarkSupport.durationSeconds(cancellationRequestedAt.duration(to: .now)),
                 wasCancelled: false,
                 completedBeforeCancellation: completedAt <= cancellationRequestedAt
             )
         } catch is CancellationError {
             return CancellationMeasurement(
-                seconds: durationSeconds(cancellationRequestedAt.duration(to: .now)),
+                seconds: BenchmarkSupport.durationSeconds(cancellationRequestedAt.duration(to: .now)),
                 wasCancelled: true,
                 completedBeforeCancellation: false
             )
@@ -407,13 +406,13 @@ final class FileBrowserBenchmarkTests: XCTestCase {
         do {
             let completedAt = try await task.value
             return CancellationMeasurement(
-                seconds: durationSeconds(cancellationRequestedAt.duration(to: .now)),
+                seconds: BenchmarkSupport.durationSeconds(cancellationRequestedAt.duration(to: .now)),
                 wasCancelled: false,
                 completedBeforeCancellation: completedAt <= cancellationRequestedAt
             )
         } catch is CancellationError {
             return CancellationMeasurement(
-                seconds: durationSeconds(cancellationRequestedAt.duration(to: .now)),
+                seconds: BenchmarkSupport.durationSeconds(cancellationRequestedAt.duration(to: .now)),
                 wasCancelled: true,
                 completedBeforeCancellation: false
             )
@@ -565,39 +564,19 @@ final class FileBrowserBenchmarkTests: XCTestCase {
         return String(hash, radix: 16)
     }
 
-    private static func measure<Value>(_ operation: () throws -> Value) rethrows -> Measurement<Value> {
-        let startedAt = ContinuousClock.now
-        let value = try operation()
-        return Measurement(
-            value: value,
-            seconds: durationSeconds(startedAt.duration(to: .now))
-        )
-    }
-
     private static func measureAsync<Value>(
         _ operation: () async throws -> Value
-    ) async rethrows -> Measurement<Value> {
+    ) async rethrows -> BenchmarkMeasurement<Value> {
         let startedAt = ContinuousClock.now
         let value = try await operation()
-        return Measurement(
+        return BenchmarkMeasurement(
             value: value,
-            seconds: durationSeconds(startedAt.duration(to: .now))
+            seconds: BenchmarkSupport.durationSeconds(startedAt.duration(to: .now))
         )
-    }
-
-    private static func durationSeconds(_ duration: Duration) -> Double {
-        let components = duration.components
-        return Double(components.seconds) +
-            (Double(components.attoseconds) / 1_000_000_000_000_000_000)
     }
 
     private static func median(_ values: [Double]) -> Double {
-        let sortedValues = values.sorted()
-        let midpoint = sortedValues.count / 2
-        if sortedValues.count.isMultiple(of: 2) {
-            return (sortedValues[midpoint - 1] + sortedValues[midpoint]) / 2
-        }
-        return sortedValues[midpoint]
+        BenchmarkSupport.median(values)!
     }
 
     private static func reportSamples(
@@ -610,8 +589,8 @@ final class FileBrowserBenchmarkTests: XCTestCase {
             phase: phase,
             seconds: median(seconds),
             count: count,
-            peakRSS: peakResidentBytes(),
-            extra: "samples=\(seconds.map(format).joined(separator: ","))"
+            peakRSS: BenchmarkSupport.peakResidentBytes(),
+            extra: "samples=\(seconds.map { BenchmarkSupport.format($0) }.joined(separator: ","))"
         )
     }
 
@@ -622,25 +601,14 @@ final class FileBrowserBenchmarkTests: XCTestCase {
         peakRSS: UInt64,
         extra: String = ""
     ) {
-        print(
-            "RADIX_FILE_BROWSER_BENCH_RESULT phase=\(phase) " +
-                "seconds=\(format(seconds)) count=\(count) " +
-                "peak_rss=\(peakRSS) \(extra)"
+        BenchmarkSupport.report(
+            prefix: "RADIX_FILE_BROWSER_BENCH_RESULT",
+            phase: phase,
+            seconds: seconds,
+            count: count,
+            peakRSS: peakRSS,
+            extra: extra
         )
-    }
-
-    private static func format(_ value: Double) -> String {
-        String(format: "%.6f", value)
-    }
-
-    private static func peakResidentBytes() -> UInt64 {
-        var usage = rusage()
-        guard getrusage(RUSAGE_SELF, &usage) == 0 else { return 0 }
-        return UInt64(max(usage.ru_maxrss, 0))
-    }
-
-    private static func byteDelta(from start: UInt64, to end: UInt64) -> UInt64 {
-        end >= start ? end - start : 0
     }
 }
 
@@ -664,11 +632,6 @@ private final class FileBrowserPublicationProbe: ObservableObject {
 private struct Fixture: Sendable {
     let store: FileTreeStore
     let fileCount: Int
-}
-
-private struct Measurement<Value> {
-    let value: Value
-    let seconds: Double
 }
 
 private struct SearchSample {

--- a/RadixCoreTests/FullDiskScanScalingBenchmarkTests.swift
+++ b/RadixCoreTests/FullDiskScanScalingBenchmarkTests.swift
@@ -180,8 +180,8 @@ final class FullDiskScanScalingBenchmarkTests: XCTestCase {
         targetURL: URL,
         options: ScanOptions
     ) async throws -> CompletionMeasurement {
-        let startRSS = MemorySampler.currentResidentMemoryBytes()
-        let sampler = MemorySampler(initialRSS: startRSS)
+        let startRSS = BenchmarkMemorySampler.currentResidentMemoryBytes()
+        let sampler = BenchmarkMemorySampler(initialRSS: startRSS)
         let samplerTask = Task {
             while !Task.isCancelled {
                 sampler.sample()
@@ -214,12 +214,12 @@ final class FullDiskScanScalingBenchmarkTests: XCTestCase {
             }
         }
 
-        let wallSeconds = durationSeconds(startedAt.duration(to: .now))
+        let wallSeconds = BenchmarkSupport.durationSeconds(startedAt.duration(to: .now))
         let cpuAtEnd = ProcessCPUTime.current()
         samplerTask.cancel()
         _ = await samplerTask.result
         sampler.sample()
-        let currentRSS = MemorySampler.currentResidentMemoryBytes()
+        let currentRSS = BenchmarkMemorySampler.currentResidentMemoryBytes()
         let snapshot = try XCTUnwrap(finalSnapshot)
         let representation = representationStats(snapshot.treeStore)
         let ordinaryDiscoveredItems = max(finalMetrics.discoveredItems, 0)
@@ -318,7 +318,7 @@ final class FullDiskScanScalingBenchmarkTests: XCTestCase {
             try? await Task.sleep(for: .milliseconds(1))
         }
         let outcome = await observation.outcome()
-        let latencySeconds = durationSeconds(cancellationStartedAt.duration(to: clock.now))
+        let latencySeconds = BenchmarkSupport.durationSeconds(cancellationStartedAt.duration(to: clock.now))
 
         return CancellationMeasurement(
             delayMilliseconds: delayMilliseconds,
@@ -370,10 +370,6 @@ final class FullDiskScanScalingBenchmarkTests: XCTestCase {
         )
     }
 
-    private static func durationSeconds(_ duration: Duration) -> Double {
-        Double(duration.components.seconds)
-            + Double(duration.components.attoseconds) / 1_000_000_000_000_000_000
-    }
 }
 
 private enum BenchmarkSafetyPolicy {
@@ -573,47 +569,6 @@ private struct ProcessCPUTime {
 
     private static func seconds(_ value: timeval) -> Double {
         Double(value.tv_sec) + Double(value.tv_usec) / 1_000_000
-    }
-}
-
-private final class MemorySampler: @unchecked Sendable {
-    private let lock = NSLock()
-    private var peakRSS: UInt64
-
-    init(initialRSS: UInt64) {
-        peakRSS = initialRSS
-    }
-
-    func sample() {
-        let currentRSS = Self.currentResidentMemoryBytes()
-        lock.lock()
-        peakRSS = max(peakRSS, currentRSS)
-        lock.unlock()
-    }
-
-    func peak() -> UInt64 {
-        lock.lock()
-        defer { lock.unlock() }
-        return peakRSS
-    }
-
-    static func currentResidentMemoryBytes() -> UInt64 {
-        var info = mach_task_basic_info()
-        var count = mach_msg_type_number_t(
-            MemoryLayout<mach_task_basic_info>.size / MemoryLayout<natural_t>.size
-        )
-        let result = withUnsafeMutablePointer(to: &info) { infoPointer in
-            infoPointer.withMemoryRebound(to: integer_t.self, capacity: Int(count)) { reboundInfo in
-                task_info(
-                    mach_task_self_,
-                    task_flavor_t(MACH_TASK_BASIC_INFO),
-                    reboundInfo,
-                    &count
-                )
-            }
-        }
-        guard result == KERN_SUCCESS else { return 0 }
-        return UInt64(info.resident_size)
     }
 }
 

--- a/RadixCoreTests/ProgressAccuracyProbeTests.swift
+++ b/RadixCoreTests/ProgressAccuracyProbeTests.swift
@@ -80,7 +80,7 @@ final class ProgressAccuracyProbeTests: XCTestCase {
             .dropFirst()
             .sink { metrics in
                 samples.append(Sample(
-                    elapsed: Self.seconds(start.duration(to: clock.now)),
+                    elapsed: BenchmarkSupport.durationSeconds(start.duration(to: clock.now)),
                     metrics: metrics
                 ))
             }
@@ -101,7 +101,7 @@ final class ProgressAccuracyProbeTests: XCTestCase {
             try await Task.sleep(for: .milliseconds(10))
         }
 
-        let total = Self.seconds(start.duration(to: clock.now))
+        let total = BenchmarkSupport.durationSeconds(start.duration(to: clock.now))
         progressObservation.cancel()
         let snapshot = try XCTUnwrap(
             coordinator.snapshot,
@@ -145,22 +145,22 @@ final class ProgressAccuracyProbeTests: XCTestCase {
         print(
             """
             RADIX_PROGRESS_ACCURACY_RESULT path=\(targetURL.path)
-            total_seconds=\(Self.format(total))
+            total_seconds=\(BenchmarkSupport.format(total))
             displayed_samples=\(samples.count)
-            time_weighted_mae=\(Self.format(summary.timeWeightedMAE))
-            time_weighted_rmse=\(Self.format(summary.timeWeightedRMSE))
-            signed_bias=\(Self.format(summary.signedBias))
-            max_lead=\(Self.format(summary.maximumLead))
-            max_lag=\(Self.format(summary.maximumLag))
-            milestone_25=\(Self.format(summary.milestone(0.25)))
-            milestone_50=\(Self.format(summary.milestone(0.50)))
-            milestone_75=\(Self.format(summary.milestone(0.75)))
-            milestone_90=\(Self.format(summary.milestone(0.90)))
-            milestone_95=\(Self.format(summary.milestone(0.95)))
-            longest_integer_stall_share=\(Self.format(summary.longestIntegerStallShare))
-            longest_update_gap_share=\(Self.format(summary.longestUpdateGapShare))
-            completion_jump=\(Self.format(summary.completionJump))
-            finalization_elapsed_share=\(Self.format(summary.finalizationElapsedShare))
+            time_weighted_mae=\(BenchmarkSupport.format(summary.timeWeightedMAE))
+            time_weighted_rmse=\(BenchmarkSupport.format(summary.timeWeightedRMSE))
+            signed_bias=\(BenchmarkSupport.format(summary.signedBias))
+            max_lead=\(BenchmarkSupport.format(summary.maximumLead))
+            max_lag=\(BenchmarkSupport.format(summary.maximumLag))
+            milestone_25=\(BenchmarkSupport.format(summary.milestone(0.25)))
+            milestone_50=\(BenchmarkSupport.format(summary.milestone(0.50)))
+            milestone_75=\(BenchmarkSupport.format(summary.milestone(0.75)))
+            milestone_90=\(BenchmarkSupport.format(summary.milestone(0.90)))
+            milestone_95=\(BenchmarkSupport.format(summary.milestone(0.95)))
+            longest_integer_stall_share=\(BenchmarkSupport.format(summary.longestIntegerStallShare))
+            longest_update_gap_share=\(BenchmarkSupport.format(summary.longestUpdateGapShare))
+            completion_jump=\(BenchmarkSupport.format(summary.completionJump))
+            finalization_elapsed_share=\(BenchmarkSupport.format(summary.finalizationElapsedShare))
             monotonic_violations=\(summary.monotonicViolations)
             bounds_violations=\(summary.boundsViolations)
             files=\(snapshot.aggregateStats.fileCount)
@@ -320,7 +320,7 @@ final class ProgressAccuracyProbeTests: XCTestCase {
         let outcome = await observation.terminationOutcome()
         let poolShutdown = workerActivity.hasShutdown
         let workersQuiescent = workerActivity.isQuiescent
-        let shutdownLatency = Self.seconds(cancellationStart.duration(to: clock.now))
+        let shutdownLatency = BenchmarkSupport.durationSeconds(cancellationStart.duration(to: clock.now))
 
         XCTAssertTrue(progressObserved, "Cancellation probe never observed active scan work.")
         XCTAssertTrue(workerActiveAtCancellation, "Cancellation probe did not cancel active summary work.")
@@ -332,7 +332,7 @@ final class ProgressAccuracyProbeTests: XCTestCase {
         print(
             "RADIX_PROGRESS_CANCELLATION_RESULT path=\(targetURL.path) "
                 + "cancel_after_ms=\(cancellationDelayMilliseconds) "
-                + "shutdown_latency_seconds=\(Self.format(shutdownLatency)) "
+                + "shutdown_latency_seconds=\(BenchmarkSupport.format(shutdownLatency)) "
                 + "progress_observed=\(progressObserved) "
                 + "worker_active=\(workerActiveAtCancellation) "
                 + "pool_shutdown=\(poolShutdown) "
@@ -499,15 +499,6 @@ final class ProgressAccuracyProbeTests: XCTestCase {
             let endError = end - heldFraction
             return (endError * endError * endError - startError * startError * startError) / 3
         }
-    }
-
-    private static func seconds(_ duration: Duration) -> Double {
-        Double(duration.components.seconds)
-            + Double(duration.components.attoseconds) / 1_000_000_000_000_000_000
-    }
-
-    private static func format(_ value: Double) -> String {
-        String(format: "%.6f", value)
     }
 
 }

--- a/RadixCoreTests/ScanArchiveBenchmarkTests.swift
+++ b/RadixCoreTests/ScanArchiveBenchmarkTests.swift
@@ -1,5 +1,4 @@
 import CryptoKit
-import Darwin
 import XCTest
 @testable import RadixCore
 
@@ -198,7 +197,7 @@ final class ScanArchiveBenchmarkTests: XCTestCase {
             imported.value.manifest.snapshot.nodeCount
         )
         let phaseSummary = importPhases.measurements().map { phase, duration in
-            "\(phase.rawValue)=\(Self.secondsString(Self.seconds(duration)))"
+            "\(phase.rawValue)=\(Self.secondsString(BenchmarkSupport.durationSeconds(duration)))"
         }.joined(separator: " ")
         print(
             """
@@ -273,7 +272,7 @@ final class ScanArchiveBenchmarkTests: XCTestCase {
             """
         )
         let phaseSummary = comparisonPhases.measurements().map { phase, duration in
-            "\(phase.rawValue)=\(Self.secondsString(Self.seconds(duration)))"
+            "\(phase.rawValue)=\(Self.secondsString(BenchmarkSupport.durationSeconds(duration)))"
         }.joined(separator: " ")
         print("RADIX_COMPARISON_PROFILE_RESULT \(phaseSummary)")
     }
@@ -334,52 +333,11 @@ final class ScanArchiveBenchmarkTests: XCTestCase {
         }
     }
 
-    private final class MemorySampler: @unchecked Sendable {
-        private let lock = NSLock()
-        private var peakRSS: UInt64
-
-        init(initialRSS: UInt64) {
-            self.peakRSS = initialRSS
-        }
-
-        func sample() {
-            let currentRSS = Self.currentResidentMemoryBytes()
-            lock.lock()
-            if currentRSS > peakRSS {
-                peakRSS = currentRSS
-            }
-            lock.unlock()
-        }
-
-        func peak() -> UInt64 {
-            lock.lock()
-            defer { lock.unlock() }
-            return peakRSS
-        }
-
-        static func currentResidentMemoryBytes() -> UInt64 {
-            var info = mach_task_basic_info()
-            var count = mach_msg_type_number_t(MemoryLayout<mach_task_basic_info>.size / MemoryLayout<natural_t>.size)
-            let result = withUnsafeMutablePointer(to: &info) { infoPointer in
-                infoPointer.withMemoryRebound(to: integer_t.self, capacity: Int(count)) { reboundInfo in
-                    task_info(
-                        mach_task_self_,
-                        task_flavor_t(MACH_TASK_BASIC_INFO),
-                        reboundInfo,
-                        &count
-                    )
-                }
-            }
-            guard result == KERN_SUCCESS else { return 0 }
-            return UInt64(info.resident_size)
-        }
-    }
-
     private static func measureMemoryAndTime<Value>(
         _ operation: @escaping () async throws -> Value
     ) async rethrows -> Measurement<Value> {
-        let startRSS = MemorySampler.currentResidentMemoryBytes()
-        let sampler = MemorySampler(initialRSS: startRSS)
+        let startRSS = BenchmarkMemorySampler.currentResidentMemoryBytes()
+        let sampler = BenchmarkMemorySampler(initialRSS: startRSS)
         let samplerTask = Task {
             while !Task.isCancelled {
                 sampler.sample()
@@ -392,10 +350,10 @@ final class ScanArchiveBenchmarkTests: XCTestCase {
         samplerTask.cancel()
         _ = await samplerTask.result
         sampler.sample()
-        let endRSS = MemorySampler.currentResidentMemoryBytes()
+        let endRSS = BenchmarkMemorySampler.currentResidentMemoryBytes()
         return Measurement(
             value: value,
-            elapsedSeconds: Self.seconds(elapsed),
+            elapsedSeconds: BenchmarkSupport.durationSeconds(elapsed),
             startRSS: startRSS,
             endRSS: endRSS,
             peakRSS: max(sampler.peak(), endRSS)
@@ -405,8 +363,8 @@ final class ScanArchiveBenchmarkTests: XCTestCase {
     private static func measureMemoryAndTime<Value>(
         _ operation: @escaping () async -> Value
     ) async -> Measurement<Value> {
-        let startRSS = MemorySampler.currentResidentMemoryBytes()
-        let sampler = MemorySampler(initialRSS: startRSS)
+        let startRSS = BenchmarkMemorySampler.currentResidentMemoryBytes()
+        let sampler = BenchmarkMemorySampler(initialRSS: startRSS)
         let samplerTask = Task {
             while !Task.isCancelled {
                 sampler.sample()
@@ -419,10 +377,10 @@ final class ScanArchiveBenchmarkTests: XCTestCase {
         samplerTask.cancel()
         _ = await samplerTask.result
         sampler.sample()
-        let endRSS = MemorySampler.currentResidentMemoryBytes()
+        let endRSS = BenchmarkMemorySampler.currentResidentMemoryBytes()
         return Measurement(
             value: value,
-            elapsedSeconds: Self.seconds(elapsed),
+            elapsedSeconds: BenchmarkSupport.durationSeconds(elapsed),
             startRSS: startRSS,
             endRSS: endRSS,
             peakRSS: max(sampler.peak(), endRSS)
@@ -984,12 +942,7 @@ final class ScanArchiveBenchmarkTests: XCTestCase {
         value.flatMap(Int.init).map { max(1, $0) } ?? defaultValue
     }
 
-    private static func seconds(_ duration: Duration) -> Double {
-        Double(duration.components.seconds) +
-            (Double(duration.components.attoseconds) / 1_000_000_000_000_000_000)
-    }
-
     private static func secondsString(_ seconds: Double) -> String {
-        String(format: "%.6f", seconds)
+        BenchmarkSupport.format(seconds)
     }
 }

--- a/RadixCoreTests/ScanBenchmarkTests.swift
+++ b/RadixCoreTests/ScanBenchmarkTests.swift
@@ -211,7 +211,7 @@ final class ScanBenchmarkTests: XCTestCase {
 
         let elapsed = startedAt.duration(to: .now)
         let snapshot = try XCTUnwrap(finalSnapshot)
-        let elapsedSeconds = Double(elapsed.components.seconds) + (Double(elapsed.components.attoseconds) / 1_000_000_000_000_000_000)
+        let elapsedSeconds = BenchmarkSupport.durationSeconds(elapsed)
         #if DEBUG
         let profile = autoSummaryProfile?.snapshot()
         let autoSummaryProfileOutput = """
@@ -405,16 +405,16 @@ final class ScanBenchmarkTests: XCTestCase {
             size: CGSize(width: 1_200, height: 800)
         )
         let finishedAt = ContinuousClock.now
-        let filterElapsedSeconds = Self.durationSeconds(
+        let filterElapsedSeconds = BenchmarkSupport.durationSeconds(
             startedAt.duration(to: filterFinishedAt)
         )
-        let sunburstElapsedSeconds = Self.durationSeconds(
+        let sunburstElapsedSeconds = BenchmarkSupport.durationSeconds(
             filterFinishedAt.duration(to: sunburstFinishedAt)
         )
-        let treemapElapsedSeconds = Self.durationSeconds(
+        let treemapElapsedSeconds = BenchmarkSupport.durationSeconds(
             sunburstFinishedAt.duration(to: finishedAt)
         )
-        let endToEndElapsedSeconds = Self.durationSeconds(startedAt.duration(to: finishedAt))
+        let endToEndElapsedSeconds = BenchmarkSupport.durationSeconds(startedAt.duration(to: finishedAt))
 
         let removedNodeCount = removesDirectory ? filesPerDirectory + 1 : 1
         let removedFileCount = removesDirectory ? filesPerDirectory : 1
@@ -511,10 +511,10 @@ final class ScanBenchmarkTests: XCTestCase {
             XCTAssertNil(replacementInput.treeStore.node(id: replacementRemovalID))
 
             if iteration > 0 {
-                filterDurations.append(Self.durationSeconds(
+                filterDurations.append(BenchmarkSupport.durationSeconds(
                     replacementStartedAt.duration(to: replacementFilterFinishedAt)
                 ))
-                endToEndDurations.append(Self.durationSeconds(
+                endToEndDurations.append(BenchmarkSupport.durationSeconds(
                     replacementStartedAt.duration(to: replacementFinishedAt)
                 ))
             }
@@ -1385,12 +1385,7 @@ final class ScanBenchmarkTests: XCTestCase {
     }
 
     private static func elapsedSeconds(since start: ContinuousClock.Instant) -> Double {
-        durationSeconds(start.duration(to: .now))
-    }
-
-    private static func durationSeconds(_ duration: Duration) -> Double {
-        Double(duration.components.seconds) +
-            Double(duration.components.attoseconds) / 1_000_000_000_000_000_000
+        BenchmarkSupport.durationSeconds(start.duration(to: .now))
     }
 
     private static func resultFingerprint(_ store: FileTreeStore) -> String {
@@ -1887,8 +1882,7 @@ final class ScanBenchmarkTests: XCTestCase {
 
         XCTAssertEqual(summary?.descendantFileCount, expectedFileCount)
         let elapsed = startedAt.duration(to: .now)
-        return Double(elapsed.components.seconds) +
-            Double(elapsed.components.attoseconds) / 1_000_000_000_000_000_000
+        return BenchmarkSupport.durationSeconds(elapsed)
     }
 
     private func makeWideBenchmarkDirectory(fileCount: Int) throws -> URL {
@@ -2030,8 +2024,7 @@ final class ScanBenchmarkTests: XCTestCase {
         }
 
         let elapsed = startedAt.duration(to: .now)
-        let elapsedSeconds = Double(elapsed.components.seconds) +
-            (Double(elapsed.components.attoseconds) / 1_000_000_000_000_000_000)
+        let elapsedSeconds = BenchmarkSupport.durationSeconds(elapsed)
         let snapshot = try XCTUnwrap(finalSnapshot)
         XCTAssertEqual(snapshot.aggregateStats.fileCount, fileCount)
         XCTAssertEqual(snapshot.root.descendantFileCount, fileCount)
@@ -2118,8 +2111,7 @@ final class ScanBenchmarkTests: XCTestCase {
         }
 
         let elapsed = startedAt.duration(to: .now)
-        let elapsedSeconds = Double(elapsed.components.seconds) +
-            (Double(elapsed.components.attoseconds) / 1_000_000_000_000_000_000)
+        let elapsedSeconds = BenchmarkSupport.durationSeconds(elapsed)
         let snapshot = try XCTUnwrap(finalSnapshot)
         let packageNodes = snapshot.treeStore.children(of: snapshot.root.id).filter(\.isPackage)
         XCTAssertEqual(snapshot.aggregateStats.fileCount, fileCount)

--- a/RadixCoreTests/SunburstResponsivenessBenchmarkTests.swift
+++ b/RadixCoreTests/SunburstResponsivenessBenchmarkTests.swift
@@ -3,7 +3,7 @@ import Foundation
 import XCTest
 @testable import RadixCore
 
-private typealias BenchmarkSupport = ChartResponsivenessBenchmarkSupport
+private typealias ChartBenchmarkSupport = ChartResponsivenessBenchmarkSupport
 
 @MainActor
 final class SunburstResponsivenessBenchmarkTests: XCTestCase {
@@ -120,7 +120,7 @@ final class SunburstResponsivenessBenchmarkTests: XCTestCase {
         let publicationModel = SunburstChartModel(
             layoutService: PrecomputedSunburstLayoutService(segments: interactionSegments)
         )
-        let publicationMeasurement = await BenchmarkSupport.measureAsync {
+        let publicationMeasurement = await ChartBenchmarkSupport.measureAsync {
             await publicationModel.loadLayout(
                 treeStore: interactionDiskMapStore,
                 rootID: interactionFixture.store.rootID,
@@ -405,7 +405,7 @@ final class SunburstResponsivenessBenchmarkTests: XCTestCase {
         iterationCount: Int
     ) -> InteractionMeasurement {
         var state = UInt64(0x9e3779b97f4a7c15)
-        var fingerprint = BenchmarkSupport.fnvOffsetBasis
+        var fingerprint = ChartBenchmarkSupport.fnvOffsetBasis
         var hitCount = 0
 
         for _ in 0..<iterationCount {
@@ -419,9 +419,9 @@ final class SunburstResponsivenessBenchmarkTests: XCTestCase {
             )
             if let segment = model.segment(at: point, in: size) {
                 hitCount += 1
-                BenchmarkSupport.hash(segment.id, into: &fingerprint)
+                ChartBenchmarkSupport.hash(segment.id, into: &fingerprint)
             } else {
-                BenchmarkSupport.hash(UInt64.max, into: &fingerprint)
+                ChartBenchmarkSupport.hash(UInt64.max, into: &fingerprint)
             }
         }
         return InteractionMeasurement(
@@ -435,7 +435,7 @@ final class SunburstResponsivenessBenchmarkTests: XCTestCase {
         inputs: [OverlayInput],
         iterationCount: Int
     ) -> InteractionMeasurement {
-        var fingerprint = BenchmarkSupport.fnvOffsetBasis
+        var fingerprint = ChartBenchmarkSupport.fnvOffsetBasis
         var segmentCount = 0
 
         for offset in 0..<iterationCount {
@@ -446,12 +446,12 @@ final class SunburstResponsivenessBenchmarkTests: XCTestCase {
             )
             segmentCount += overlays.count
             for overlay in overlays {
-                BenchmarkSupport.hash(overlay.id, into: &fingerprint)
+                ChartBenchmarkSupport.hash(overlay.id, into: &fingerprint)
                 switch overlay.role {
                 case .ancestor:
-                    BenchmarkSupport.hash(0, into: &fingerprint)
+                    ChartBenchmarkSupport.hash(0, into: &fingerprint)
                 case .selected:
-                    BenchmarkSupport.hash(1, into: &fingerprint)
+                    ChartBenchmarkSupport.hash(1, into: &fingerprint)
                 }
             }
         }
@@ -468,7 +468,7 @@ final class SunburstResponsivenessBenchmarkTests: XCTestCase {
         let directions: [ChartSpatialSelectionDirection] = [.right, .down, .left, .up]
         var selectedNodeID: String?
         var selectionCount = 0
-        var fingerprint = BenchmarkSupport.fnvOffsetBasis
+        var fingerprint = ChartBenchmarkSupport.fnvOffsetBasis
 
         for offset in 0..<iterationCount {
             let segment = model.keyboardSelection(
@@ -478,9 +478,9 @@ final class SunburstResponsivenessBenchmarkTests: XCTestCase {
             selectedNodeID = segment?.nodeID
             if let selectedNodeID {
                 selectionCount += 1
-                BenchmarkSupport.hash(selectedNodeID, into: &fingerprint)
+                ChartBenchmarkSupport.hash(selectedNodeID, into: &fingerprint)
             } else {
-                BenchmarkSupport.hash(UInt64.max, into: &fingerprint)
+                ChartBenchmarkSupport.hash(UInt64.max, into: &fingerprint)
             }
         }
         return InteractionMeasurement(
@@ -497,14 +497,14 @@ final class SunburstResponsivenessBenchmarkTests: XCTestCase {
         let rootID = "/sunburst-benchmark"
         let denseDirectoryID = rootID + "/dense"
         var nodes = [
-            BenchmarkSupport.node(
+            ChartBenchmarkSupport.node(
                 id: rootID,
                 name: "sunburst-benchmark",
                 isDirectory: true,
                 allocatedSize: Int64(fileCount),
                 descendantFileCount: fileCount
             ),
-            BenchmarkSupport.node(
+            ChartBenchmarkSupport.node(
                 id: denseDirectoryID,
                 name: "dense",
                 isDirectory: true,
@@ -528,7 +528,7 @@ final class SunburstResponsivenessBenchmarkTests: XCTestCase {
         for fileOffset in 0..<fileCount {
             let fileID = String(format: "%@/item-%07d.dat", denseDirectoryID, fileOffset)
             let fileIndex = FileTreeNodeIndex(rawValue: UInt32(nodes.count))
-            nodes.append(BenchmarkSupport.node(
+            nodes.append(ChartBenchmarkSupport.node(
                 id: fileID,
                 name: String(format: "item-%07d.dat", fileOffset),
                 isDirectory: false,
@@ -571,7 +571,7 @@ final class SunburstResponsivenessBenchmarkTests: XCTestCase {
         let rootID = "/sunburst-interaction"
         let rootIndex = FileTreeNodeIndex(rawValue: 0)
         let nodeCount = 1 + (branchCount * renderedDepth)
-        var nodes = [BenchmarkSupport.node(
+        var nodes = [ChartBenchmarkSupport.node(
             id: rootID,
             name: "sunburst-interaction",
             isDirectory: true,
@@ -598,7 +598,7 @@ final class SunburstResponsivenessBenchmarkTests: XCTestCase {
                     depth: depth
                 )
                 let index = FileTreeNodeIndex(rawValue: UInt32(nodes.count))
-                nodes.append(BenchmarkSupport.node(
+                nodes.append(ChartBenchmarkSupport.node(
                     id: id,
                     name: depth == 0
                         ? String(format: "branch-%03d", branchOffset)
@@ -670,32 +670,32 @@ final class SunburstResponsivenessBenchmarkTests: XCTestCase {
     }
 
     private static func segmentFingerprint(_ segments: [SunburstSegment]) -> String {
-        var hash = BenchmarkSupport.fnvOffsetBasis
+        var hash = ChartBenchmarkSupport.fnvOffsetBasis
         for segment in segments {
-            BenchmarkSupport.hash(segment.id, into: &hash)
-            BenchmarkSupport.hash(segment.nodeID ?? "<aggregate>", into: &hash)
-            BenchmarkSupport.hash(segment.label, into: &hash)
-            BenchmarkSupport.hash(segment.startAngle.radians.bitPattern, into: &hash)
-            BenchmarkSupport.hash(segment.endAngle.radians.bitPattern, into: &hash)
-            BenchmarkSupport.hash(Double(segment.innerRadius).bitPattern, into: &hash)
-            BenchmarkSupport.hash(Double(segment.outerRadius).bitPattern, into: &hash)
-            BenchmarkSupport.hash(UInt64(bitPattern: Int64(segment.depth)), into: &hash)
-            BenchmarkSupport.hash(UInt64(bitPattern: segment.totalSize), into: &hash)
-            BenchmarkSupport.hash(UInt64(segment.isAggregate ? 1 : 0), into: &hash)
-            BenchmarkSupport.hash(segment.colorToken.branchID, into: &hash)
-            BenchmarkSupport.hash(segment.colorToken.localID, into: &hash)
-            BenchmarkSupport.hash(UInt64(bitPattern: Int64(segment.colorToken.branchIndex)), into: &hash)
-            BenchmarkSupport.hash(UInt64(bitPattern: Int64(segment.colorToken.branchCount)), into: &hash)
-            BenchmarkSupport.hash(UInt64(bitPattern: Int64(segment.colorToken.siblingIndex)), into: &hash)
-            BenchmarkSupport.hash(UInt64(bitPattern: Int64(segment.colorToken.siblingCount)), into: &hash)
-            BenchmarkSupport.hash(UInt64(bitPattern: Int64(segment.colorToken.depth)), into: &hash)
+            ChartBenchmarkSupport.hash(segment.id, into: &hash)
+            ChartBenchmarkSupport.hash(segment.nodeID ?? "<aggregate>", into: &hash)
+            ChartBenchmarkSupport.hash(segment.label, into: &hash)
+            ChartBenchmarkSupport.hash(segment.startAngle.radians.bitPattern, into: &hash)
+            ChartBenchmarkSupport.hash(segment.endAngle.radians.bitPattern, into: &hash)
+            ChartBenchmarkSupport.hash(Double(segment.innerRadius).bitPattern, into: &hash)
+            ChartBenchmarkSupport.hash(Double(segment.outerRadius).bitPattern, into: &hash)
+            ChartBenchmarkSupport.hash(UInt64(bitPattern: Int64(segment.depth)), into: &hash)
+            ChartBenchmarkSupport.hash(UInt64(bitPattern: segment.totalSize), into: &hash)
+            ChartBenchmarkSupport.hash(UInt64(segment.isAggregate ? 1 : 0), into: &hash)
+            ChartBenchmarkSupport.hash(segment.colorToken.branchID, into: &hash)
+            ChartBenchmarkSupport.hash(segment.colorToken.localID, into: &hash)
+            ChartBenchmarkSupport.hash(UInt64(bitPattern: Int64(segment.colorToken.branchIndex)), into: &hash)
+            ChartBenchmarkSupport.hash(UInt64(bitPattern: Int64(segment.colorToken.branchCount)), into: &hash)
+            ChartBenchmarkSupport.hash(UInt64(bitPattern: Int64(segment.colorToken.siblingIndex)), into: &hash)
+            ChartBenchmarkSupport.hash(UInt64(bitPattern: Int64(segment.colorToken.siblingCount)), into: &hash)
+            ChartBenchmarkSupport.hash(UInt64(bitPattern: Int64(segment.colorToken.depth)), into: &hash)
             switch segment.colorToken.role {
             case .normal:
-                BenchmarkSupport.hash(0, into: &hash)
+                ChartBenchmarkSupport.hash(0, into: &hash)
             case .aggregate:
-                BenchmarkSupport.hash(1, into: &hash)
+                ChartBenchmarkSupport.hash(1, into: &hash)
             case .freeSpace:
-                BenchmarkSupport.hash(2, into: &hash)
+                ChartBenchmarkSupport.hash(2, into: &hash)
             }
         }
         return String(hash, radix: 16)

--- a/RadixCoreTests/TreemapResponsivenessBenchmarkTests.swift
+++ b/RadixCoreTests/TreemapResponsivenessBenchmarkTests.swift
@@ -3,7 +3,7 @@ import Foundation
 import XCTest
 @testable import RadixCore
 
-private typealias BenchmarkSupport = ChartResponsivenessBenchmarkSupport
+private typealias ChartBenchmarkSupport = ChartResponsivenessBenchmarkSupport
 
 @MainActor
 final class TreemapResponsivenessBenchmarkTests: XCTestCase {
@@ -131,7 +131,7 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
         let publicationModel = TreemapChartModel(
             layoutService: PrecomputedTreemapLayoutService(segments: denseSegments)
         )
-        let publicationMeasurement = await BenchmarkSupport.measureAsync {
+        let publicationMeasurement = await ChartBenchmarkSupport.measureAsync {
             await publicationModel.loadLayout(
                 treeStore: diskMapStore,
                 rootID: fixture.denseDirectoryID,
@@ -448,7 +448,7 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
         iterationCount: Int
     ) -> InteractionMeasurement {
         var state = UInt64(0x9e3779b97f4a7c15)
-        var fingerprint = BenchmarkSupport.fnvOffsetBasis
+        var fingerprint = ChartBenchmarkSupport.fnvOffsetBasis
         var hitCount = 0
         for _ in 0..<iterationCount {
             state = state &* 6_364_136_223_846_793_005 &+ 1_442_695_040_888_963_407
@@ -461,9 +461,9 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
             )
             if let segment = model.segment(at: point, in: size) {
                 hitCount += 1
-                BenchmarkSupport.hash(segment.id, into: &fingerprint)
+                ChartBenchmarkSupport.hash(segment.id, into: &fingerprint)
             } else {
-                BenchmarkSupport.hash(UInt64.max, into: &fingerprint)
+                ChartBenchmarkSupport.hash(UInt64.max, into: &fingerprint)
             }
         }
         return InteractionMeasurement(
@@ -480,7 +480,7 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
         let directions: [ChartSpatialSelectionDirection] = [.right, .down, .left, .up]
         var selectedNodeID: String?
         var selectionCount = 0
-        var fingerprint = BenchmarkSupport.fnvOffsetBasis
+        var fingerprint = ChartBenchmarkSupport.fnvOffsetBasis
 
         for offset in 0..<iterationCount {
             let nextNodeID = model.spatialSelectionNodeID(
@@ -491,9 +491,9 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
             selectedNodeID = nextNodeID
             if let nextNodeID {
                 selectionCount += 1
-                BenchmarkSupport.hash(nextNodeID, into: &fingerprint)
+                ChartBenchmarkSupport.hash(nextNodeID, into: &fingerprint)
             } else {
-                BenchmarkSupport.hash(UInt64.max, into: &fingerprint)
+                ChartBenchmarkSupport.hash(UInt64.max, into: &fingerprint)
             }
         }
         return InteractionMeasurement(
@@ -512,7 +512,7 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
         let rootIndex = FileTreeNodeIndex(rawValue: 0)
         let rootID = "/treemap-benchmark"
         let denseDirectoryID = rootID + "/dense"
-        var nodes = [BenchmarkSupport.node(
+        var nodes = [ChartBenchmarkSupport.node(
             id: rootID,
             name: "treemap-benchmark",
             isDirectory: true,
@@ -532,7 +532,7 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
                 directoryOffset
             )
             let directoryIndex = FileTreeNodeIndex(rawValue: UInt32(nodes.count))
-            nodes.append(BenchmarkSupport.node(
+            nodes.append(ChartBenchmarkSupport.node(
                 id: directoryID,
                 name: String(format: "directory-%04d", directoryOffset),
                 isDirectory: true,
@@ -551,7 +551,7 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
                     fileOffset
                 )
                 let fileIndex = FileTreeNodeIndex(rawValue: UInt32(nodes.count))
-                nodes.append(BenchmarkSupport.node(
+                nodes.append(ChartBenchmarkSupport.node(
                     id: fileID,
                     name: String(format: "item-%05d.dat", fileOffset),
                     isDirectory: false,
@@ -565,7 +565,7 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
         }
 
         let denseDirectoryIndex = FileTreeNodeIndex(rawValue: UInt32(nodes.count))
-        nodes.append(BenchmarkSupport.node(
+        nodes.append(ChartBenchmarkSupport.node(
             id: denseDirectoryID,
             name: "dense",
             isDirectory: true,
@@ -578,7 +578,7 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
         for fileOffset in 0..<denseFileCount {
             let fileID = String(format: "%@/tile-%05d.dat", denseDirectoryID, fileOffset)
             let fileIndex = FileTreeNodeIndex(rawValue: UInt32(nodes.count))
-            nodes.append(BenchmarkSupport.node(
+            nodes.append(ChartBenchmarkSupport.node(
                 id: fileID,
                 name: String(format: "tile-%05d.dat", fileOffset),
                 isDirectory: false,
@@ -619,7 +619,7 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
     ) throws -> [LayoutSample] {
         let rootID = "/treemap-flat-benchmark"
         let rootIndex = FileTreeNodeIndex(rawValue: 0)
-        var nodes = [BenchmarkSupport.node(
+        var nodes = [ChartBenchmarkSupport.node(
             id: rootID,
             name: "treemap-flat-benchmark",
             isDirectory: true,
@@ -637,7 +637,7 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
         for fileOffset in 0..<fileCount {
             let fileID = String(format: "%@/item-%05d.dat", rootID, fileOffset)
             let fileIndex = FileTreeNodeIndex(rawValue: UInt32(nodes.count))
-            nodes.append(BenchmarkSupport.node(
+            nodes.append(ChartBenchmarkSupport.node(
                 id: fileID,
                 name: String(format: "item-%05d.dat", fileOffset),
                 isDirectory: false,
@@ -700,39 +700,39 @@ final class TreemapResponsivenessBenchmarkTests: XCTestCase {
     }
 
     private static func segmentFingerprint(_ segments: [TreemapSegment]) -> String {
-        var hash = BenchmarkSupport.fnvOffsetBasis
+        var hash = ChartBenchmarkSupport.fnvOffsetBasis
         for segment in segments {
-            BenchmarkSupport.hash(segment.id, into: &hash)
-            BenchmarkSupport.hash(segment.nodeID ?? "<aggregate>", into: &hash)
-            BenchmarkSupport.hash(segment.containerNodeID, into: &hash)
-            BenchmarkSupport.hash(segment.label, into: &hash)
-            BenchmarkSupport.hash(UInt64(bitPattern: Int64(segment.depth)), into: &hash)
-            BenchmarkSupport.hash(UInt64(bitPattern: segment.totalSize), into: &hash)
-            BenchmarkSupport.hash(UInt64(segment.isAggregate ? 1 : 0), into: &hash)
-            BenchmarkSupport.hash(
+            ChartBenchmarkSupport.hash(segment.id, into: &hash)
+            ChartBenchmarkSupport.hash(segment.nodeID ?? "<aggregate>", into: &hash)
+            ChartBenchmarkSupport.hash(segment.containerNodeID, into: &hash)
+            ChartBenchmarkSupport.hash(segment.label, into: &hash)
+            ChartBenchmarkSupport.hash(UInt64(bitPattern: Int64(segment.depth)), into: &hash)
+            ChartBenchmarkSupport.hash(UInt64(bitPattern: segment.totalSize), into: &hash)
+            ChartBenchmarkSupport.hash(UInt64(segment.isAggregate ? 1 : 0), into: &hash)
+            ChartBenchmarkSupport.hash(
                 UInt64(bitPattern: Int64(segment.groupedItemCount ?? -1)),
                 into: &hash
             )
-            BenchmarkSupport.hash(UInt64(segment.isDirectory ? 1 : 0), into: &hash)
-            BenchmarkSupport.hash(UInt64(segment.showsContainerHeader ? 1 : 0), into: &hash)
-            BenchmarkSupport.hash(Double(segment.rect.minX).bitPattern, into: &hash)
-            BenchmarkSupport.hash(Double(segment.rect.minY).bitPattern, into: &hash)
-            BenchmarkSupport.hash(Double(segment.rect.width).bitPattern, into: &hash)
-            BenchmarkSupport.hash(Double(segment.rect.height).bitPattern, into: &hash)
-            BenchmarkSupport.hash(segment.colorToken.branchID, into: &hash)
-            BenchmarkSupport.hash(segment.colorToken.localID, into: &hash)
-            BenchmarkSupport.hash(UInt64(bitPattern: Int64(segment.colorToken.branchIndex)), into: &hash)
-            BenchmarkSupport.hash(UInt64(bitPattern: Int64(segment.colorToken.branchCount)), into: &hash)
-            BenchmarkSupport.hash(UInt64(bitPattern: Int64(segment.colorToken.siblingIndex)), into: &hash)
-            BenchmarkSupport.hash(UInt64(bitPattern: Int64(segment.colorToken.siblingCount)), into: &hash)
-            BenchmarkSupport.hash(UInt64(bitPattern: Int64(segment.colorToken.depth)), into: &hash)
+            ChartBenchmarkSupport.hash(UInt64(segment.isDirectory ? 1 : 0), into: &hash)
+            ChartBenchmarkSupport.hash(UInt64(segment.showsContainerHeader ? 1 : 0), into: &hash)
+            ChartBenchmarkSupport.hash(Double(segment.rect.minX).bitPattern, into: &hash)
+            ChartBenchmarkSupport.hash(Double(segment.rect.minY).bitPattern, into: &hash)
+            ChartBenchmarkSupport.hash(Double(segment.rect.width).bitPattern, into: &hash)
+            ChartBenchmarkSupport.hash(Double(segment.rect.height).bitPattern, into: &hash)
+            ChartBenchmarkSupport.hash(segment.colorToken.branchID, into: &hash)
+            ChartBenchmarkSupport.hash(segment.colorToken.localID, into: &hash)
+            ChartBenchmarkSupport.hash(UInt64(bitPattern: Int64(segment.colorToken.branchIndex)), into: &hash)
+            ChartBenchmarkSupport.hash(UInt64(bitPattern: Int64(segment.colorToken.branchCount)), into: &hash)
+            ChartBenchmarkSupport.hash(UInt64(bitPattern: Int64(segment.colorToken.siblingIndex)), into: &hash)
+            ChartBenchmarkSupport.hash(UInt64(bitPattern: Int64(segment.colorToken.siblingCount)), into: &hash)
+            ChartBenchmarkSupport.hash(UInt64(bitPattern: Int64(segment.colorToken.depth)), into: &hash)
             switch segment.colorToken.role {
             case .normal:
-                BenchmarkSupport.hash(0, into: &hash)
+                ChartBenchmarkSupport.hash(0, into: &hash)
             case .aggregate:
-                BenchmarkSupport.hash(1, into: &hash)
+                ChartBenchmarkSupport.hash(1, into: &hash)
             case .freeSpace:
-                BenchmarkSupport.hash(2, into: &hash)
+                ChartBenchmarkSupport.hash(2, into: &hash)
             }
         }
         return String(hash, radix: 16)


### PR DESCRIPTION
## Summary

- Consolidate genuinely shared benchmark timing, formatting, reporting, and RSS utilities in RadixCoreTests.
- Reuse the current-memory sampler across the archive and full-scan benchmarks.
- Keep domain-specific fixtures, inputs, gates, output formats, and fingerprints with their existing benchmarks.
- Leave production sources unchanged and keep the shared support test-target-only.

## Validation

- Full suite: swift test — 796 tests, 24 expected opt-in skips, 0 failures.
- Representative Release opt-in benchmarks passed: File Browser, archive export/import, full-scan scaling, Sunburst, Treemap, real-world scan, and progress accuracy.
- Release app build passed.
- Verified the Release app bundle, executable symbols, and Xcode Swift source list contain no shared benchmark-support code or benchmark gate/result markers.