### PR TITLE
fix(scan): harden incremental rescans

### DIFF
--- a/Radix/Models/FileTreeStore.swift
+++ b/Radix/Models/FileTreeStore.swift
@@ -1711,10 +1711,18 @@ nonisolated struct FileTreeStore: Sendable {
     }
 
     nonisolated func subtreeNodeCount(rootedAt nodeID: String) -> Int {
+        subtreeNodeCount(rootedAt: nodeID, upTo: .max)
+    }
+
+    nonisolated func subtreeNodeCount(
+        rootedAt nodeID: String,
+        upTo limit: Int
+    ) -> Int {
+        guard limit > 0 else { return 0 }
         guard let rootIndex = nodeIndex(id: nodeID) else { return 0 }
         var count = 0
         var stack = [rootIndex]
-        while let nodeIndex = stack.popLast() {
+        while count < limit, let nodeIndex = stack.popLast() {
             count += 1
             stack.append(contentsOf: activeChildren(of: nodeIndex))
         }

--- a/Radix/Models/FileTreeStore.swift
+++ b/Radix/Models/FileTreeStore.swift
@@ -1734,6 +1734,9 @@ nonisolated struct FileTreeStore: Sendable {
             }
             visitedCount += 1
             if let node = node(at: nodeIndex),
+               !node.isDirectory,
+               !node.isSymbolicLink,
+               !node.isSynthetic,
                node.cloneIdentity != nil || node.linkCount > 1 {
                 return true
             }

--- a/Radix/Models/FileTreeStore.swift
+++ b/Radix/Models/FileTreeStore.swift
@@ -1634,6 +1634,27 @@ nonisolated struct FileTreeStore: Sendable {
         return count
     }
 
+    nonisolated func subtreeContainsSharedAllocationMetadata(
+        rootedAt nodeID: String,
+        cancellationCheck: () throws -> Void
+    ) throws -> Bool {
+        guard let rootIndex = nodeIndex(id: nodeID) else { return false }
+        var stack = [rootIndex]
+        var visitedCount = 0
+        while let nodeIndex = stack.popLast() {
+            if visitedCount.isMultiple(of: 256) {
+                try cancellationCheck()
+            }
+            visitedCount += 1
+            if let node = node(at: nodeIndex),
+               node.cloneIdentity != nil || node.linkCount > 1 {
+                return true
+            }
+            stack.append(contentsOf: activeChildren(of: nodeIndex))
+        }
+        return false
+    }
+
     nonisolated func indexedNodeIDs(excludingRoot: Bool = false) -> [String] {
         activeOrderedNodeIndices.compactMap { nodeIndex in
             guard !excludingRoot || nodeIndex != activeRootIndex else { return nil }

--- a/Radix/Models/FileTreeStore.swift
+++ b/Radix/Models/FileTreeStore.swift
@@ -15,12 +15,6 @@ nonisolated struct PreparedFileTreeNodeSet: Sendable {
     fileprivate let indices: Set<FileTreeNodeIndex>
 }
 
-nonisolated struct FileTreeSubtreeContents: Sendable {
-    let root: FileNodeRecord
-    let nodesByID: [String: FileNodeRecord]
-    let childIDsByID: [String: [String]]
-}
-
 nonisolated struct FileTreeChildSpan: Sendable {
     var start: UInt32 = 0
     var count: UInt32 = 0
@@ -340,6 +334,25 @@ nonisolated private struct FileTreeTopologyArena: Sendable {
 }
 
 nonisolated struct FileTreeStore: Sendable {
+    nonisolated struct SubtreeSource: Sendable {
+        let root: FileNodeRecord
+        fileprivate let store: FileTreeStore?
+
+        nonisolated init(node: FileNodeRecord) {
+            self.root = node
+            self.store = nil
+        }
+
+        nonisolated init?(
+            store: FileTreeStore,
+            rootedAt nodeID: String
+        ) {
+            guard let root = store.node(id: nodeID) else { return nil }
+            self.root = root
+            self.store = store
+        }
+    }
+
     private struct NodeMembership: Sendable {
         private var words: [UInt64]
 
@@ -496,16 +509,6 @@ nonisolated struct FileTreeStore: Sendable {
         let orderedNodeIDs: [String]
         let materializedDirectoryIDs: Set<String>
         let didDropReferences: Bool
-    }
-
-    private struct SubtreeReplacementPlan {
-        let targetID: String
-        let oldParentID: String?
-        let oldSubtreeIDs: Set<String>
-        let replacementRootID: String
-        let replacementNodesByID: [String: FileNodeRecord]
-        let replacementChildIDsByID: [String: [String]]
-        let replacementParentIDByID: [String: String]
     }
 
     private struct AggregateStatsAccumulator {
@@ -930,6 +933,90 @@ nonisolated struct FileTreeStore: Sendable {
         self.topologyArena = topologyArena
         self.precomputedAggregateStats = aggregateStats
         self.logicalScope = logicalScope
+    }
+
+    nonisolated static func combining(
+        root: FileNodeRecord,
+        childSubtrees: [SubtreeSource],
+        cancellationCheck: () throws -> Void
+    ) throws -> FileTreeStore {
+        guard !childSubtrees.isEmpty else { return FileTreeStore(root: root) }
+
+        var nodes = [root]
+        var indexByNodeID = [root.id: FileTreeNodeIndex(rawValue: 0)]
+        var parentRawIndices = [UInt32.max]
+        var orderedNodeIndices = [FileTreeNodeIndex(rawValue: 0)]
+        var statsAccumulator = AggregateStatsAccumulator()
+        var sharedAllocationAccumulator = SharedAllocationOwnerAccumulator()
+        var sharedAllocationClaimIndices: [FileTreeNodeIndex] = []
+        statsAccumulator.include(root, hasMaterializedChildren: true)
+        if let claim = SharedAllocationDeduplicator.claim(for: root) {
+            sharedAllocationAccumulator.record(claim)
+            sharedAllocationClaimIndices.append(FileTreeNodeIndex(rawValue: 0))
+        }
+
+        typealias TraversalEntry = (
+            sourceOrdinal: Int,
+            sourceIndex: FileTreeNodeIndex?,
+            parentRawIndex: UInt32
+        )
+        var stack: [TraversalEntry] = []
+        stack.reserveCapacity(childSubtrees.count)
+        for ordinal in childSubtrees.indices.reversed() {
+            let source = childSubtrees[ordinal]
+            let sourceIndex = source.store?.nodeIndex(id: source.root.id)
+            stack.append((ordinal, sourceIndex, 0))
+        }
+
+        while let entry = stack.popLast() {
+            if nodes.count.isMultiple(of: 256) {
+                try cancellationCheck()
+            }
+            let source = childSubtrees[entry.sourceOrdinal]
+            let node: FileNodeRecord
+            let children: ChildIndexCollection
+            if let sourceIndex = entry.sourceIndex, let store = source.store {
+                guard let storedNode = store.node(at: sourceIndex) else { continue }
+                node = storedNode
+                children = store.activeChildren(of: sourceIndex)
+            } else {
+                node = source.root
+                children = .replacement([])
+            }
+
+            let nodeIndex = FileTreeNodeIndex(rawValue: UInt32(nodes.count))
+            guard indexByNodeID.updateValue(nodeIndex, forKey: node.id) == nil else {
+                throw StoreError.replacementIDCollision(node.id)
+            }
+            nodes.append(node)
+            parentRawIndices.append(entry.parentRawIndex)
+            orderedNodeIndices.append(nodeIndex)
+            statsAccumulator.include(node, hasMaterializedChildren: !children.isEmpty)
+            if let claim = SharedAllocationDeduplicator.claim(for: node) {
+                sharedAllocationAccumulator.record(claim)
+                sharedAllocationClaimIndices.append(nodeIndex)
+            }
+
+            for childIndex in children.reversed() {
+                stack.append((entry.sourceOrdinal, childIndex, nodeIndex.rawValue))
+            }
+        }
+
+        let combinedStore = try finalizedCompactedStore(
+            nodes: &nodes,
+            indexByNodeID: indexByNodeID,
+            parentRawIndices: parentRawIndices,
+            orderedNodeIndices: &orderedNodeIndices,
+            affectedNodeIndices: [],
+            statsAccumulator: &statsAccumulator,
+            cancellationCheck: cancellationCheck
+        )
+        return try SharedAllocationDeduplicator.rebalancedStore(
+            combinedStore,
+            sharedAllocationAccumulator: sharedAllocationAccumulator,
+            claimNodeIndices: sharedAllocationClaimIndices,
+            cancellationCheck: cancellationCheck
+        )
     }
 
     nonisolated static func sortedChildren(_ children: [FileNodeRecord]) -> [FileNodeRecord] {
@@ -2064,105 +2151,10 @@ nonisolated struct FileTreeStore: Sendable {
         with replacement: FileTreeStore,
         cancellationCheck: () throws -> Void
     ) throws -> FileTreeStore? {
-        try cancellationCheck()
-        guard nodeIndex(id: targetID) != nil else { return nil }
-        if logicalScope != nil {
-            return try materialized(cancellationCheck: cancellationCheck).replacingSubtree(
-                id: targetID,
-                with: replacement,
-                cancellationCheck: cancellationCheck
-            )
-        }
-
-        let replacementNodesByID = replacement.nodesByID
-        let replacementChildIDsByID = replacement.childIDsByID
-        let replacementParentIDByID = replacement.parentIDByID
-        let existingParentIDs = parentIDByID
-        let existingChildIDs = childIDsByID
-        let oldParentID = existingParentIDs[targetID]
-        let oldSubtreeIDs = Set(try subtreeNodeIDs(
-            rootedAt: targetID,
-            cancellationCheck: cancellationCheck
-        ))
-        try preflightReplacement(
-            nodesByID: replacementNodesByID,
-            removing: oldSubtreeIDs,
+        try replacingSubtrees(
+            [targetID: replacement],
             cancellationCheck: cancellationCheck
         )
-        var updatedNodes = nodesByID
-        var updatedChildIDs = existingChildIDs
-        var updatedParentIDs = existingParentIDs
-
-        for (offset, oldID) in oldSubtreeIDs.enumerated() {
-            if offset.isMultiple(of: 256) {
-                try cancellationCheck()
-            }
-            updatedNodes.removeValue(forKey: oldID)
-            updatedChildIDs.removeValue(forKey: oldID)
-            updatedParentIDs.removeValue(forKey: oldID)
-        }
-
-        for (offset, entry) in replacementNodesByID.enumerated() {
-            if offset.isMultiple(of: 256) {
-                try cancellationCheck()
-            }
-            updatedNodes[entry.key] = entry.value
-        }
-        for (offset, entry) in replacementChildIDsByID.enumerated() {
-            if offset.isMultiple(of: 256) {
-                try cancellationCheck()
-            }
-            updatedChildIDs[entry.key] = entry.value
-        }
-        for (offset, entry) in replacementParentIDByID.enumerated() {
-            if offset.isMultiple(of: 256) {
-                try cancellationCheck()
-            }
-            updatedParentIDs[entry.key] = entry.value
-        }
-
-        let updatedRootID: String
-        if let oldParentID {
-            let previousChildIDs = existingChildIDs[oldParentID] ?? []
-            updatedChildIDs[oldParentID] = previousChildIDs.map { childID in
-                childID == targetID ? replacement.rootID : childID
-            }
-            updatedParentIDs[replacement.rootID] = oldParentID
-            updatedRootID = rootID
-        } else {
-            updatedParentIDs.removeValue(forKey: replacement.rootID)
-            updatedRootID = replacement.rootID
-        }
-
-        var cursor = oldParentID
-        while let currentID = cursor {
-            try cancellationCheck()
-            guard let current = updatedNodes[currentID] else { break }
-            let childRecords = (updatedChildIDs[currentID] ?? []).compactMap { updatedNodes[$0] }
-            let sortedChildRecords = Self.sortedChildren(childRecords)
-            updatedNodes[currentID] = FileNodeRecord.directory(
-                id: current.id,
-                url: current.url,
-                name: current.name,
-                children: sortedChildRecords,
-                lastModified: current.lastModified,
-                fileIdentity: current.fileIdentity,
-                linkCount: current.linkCount,
-                isPackage: current.isPackage,
-                isAccessible: current.isSelfAccessible,
-                childrenAreSorted: true
-            )
-            updatedChildIDs[currentID] = sortedChildRecords.map(\.id)
-            cursor = updatedParentIDs[currentID]
-        }
-
-        let updatedStore = FileTreeStore(
-            rootID: updatedRootID,
-            nodesByID: updatedNodes,
-            childIDsByID: updatedChildIDs,
-            parentIDByID: updatedParentIDs
-        )
-        return try SharedAllocationDeduplicator.rebalancedStore(updatedStore, cancellationCheck: cancellationCheck)
     }
 
     /// Replaces multiple disjoint subtrees as one topology transaction.
@@ -2197,224 +2189,177 @@ nonisolated struct FileTreeStore: Sendable {
             )
         }
 
-        let existingParentIDs = parentIDByID
-        let existingChildIDs = childIDsByID
         let targetIDs = Array(replacements.keys)
-        for targetID in targetIDs {
-            guard nodeIndex(id: targetID) != nil else { return nil }
+        var targetIndices: [FileTreeNodeIndex] = []
+        targetIndices.reserveCapacity(targetIDs.count)
+        var targetOrdinalByIndex: [FileTreeNodeIndex: Int] = [:]
+        targetOrdinalByIndex.reserveCapacity(targetIDs.count)
+        for (ordinal, targetID) in targetIDs.enumerated() {
+            guard let targetIndex = nodeIndex(id: targetID) else { return nil }
+            targetIndices.append(targetIndex)
+            targetOrdinalByIndex[targetIndex] = ordinal
         }
 
-        let targetIDSet = Set(targetIDs)
-        for targetID in targetIDs {
-            var cursor = existingParentIDs[targetID]
-            while let ancestorID = cursor {
+        for (ordinal, targetIndex) in targetIndices.enumerated() {
+            var cursor = topologyArena.parentIndex(of: targetIndex)
+            while let ancestorIndex = cursor {
                 try cancellationCheck()
-                if targetIDSet.contains(ancestorID) {
-                    throw StoreError.overlappingReplacementTargets(ancestorID, targetID)
+                if let ancestorOrdinal = targetOrdinalByIndex[ancestorIndex] {
+                    throw StoreError.overlappingReplacementTargets(
+                        targetIDs[ancestorOrdinal],
+                        targetIDs[ordinal]
+                    )
                 }
-                cursor = existingParentIDs[ancestorID]
+                cursor = topologyArena.parentIndex(of: ancestorIndex)
             }
         }
 
-        var plans: [SubtreeReplacementPlan] = []
-        plans.reserveCapacity(replacements.count)
-        for (offset, targetID) in targetIDs.enumerated() {
-            if offset.isMultiple(of: 64) {
-                try cancellationCheck()
+        let replacementStores = targetIDs.compactMap { replacements[$0] }
+        var removalOwnerByOffset = Array(repeating: UInt32.max, count: nodeRecords.count)
+        var removedNodeCount = 0
+        for (ordinal, targetIndex) in targetIndices.enumerated() {
+            var stack = [targetIndex]
+            while let nodeIndex = stack.popLast() {
+                if removedNodeCount.isMultiple(of: 256) {
+                    try cancellationCheck()
+                }
+                let nodeOffset = Int(nodeIndex.rawValue)
+                precondition(removalOwnerByOffset[nodeOffset] == UInt32.max)
+                removalOwnerByOffset[nodeOffset] = UInt32(ordinal)
+                removedNodeCount += 1
+                stack.append(contentsOf: topologyArena.children(of: nodeIndex))
             }
-            guard let replacement = replacements[targetID] else { continue }
-            plans.append(SubtreeReplacementPlan(
-                targetID: targetID,
-                oldParentID: existingParentIDs[targetID],
-                oldSubtreeIDs: Set(try subtreeNodeIDs(
-                    rootedAt: targetID,
-                    cancellationCheck: cancellationCheck
-                )),
-                replacementRootID: replacement.rootID,
-                replacementNodesByID: replacement.nodesByID,
-                replacementChildIDsByID: replacement.childIDsByID,
-                replacementParentIDByID: replacement.parentIDByID
-            ))
         }
 
-        var replacementOwnerByNodeID: [String: String] = [:]
-        replacementOwnerByNodeID.reserveCapacity(plans.reduce(0) { $0 + $1.replacementNodesByID.count })
-        for plan in plans {
-            try preflightReplacement(
-                nodesByID: plan.replacementNodesByID,
-                removing: plan.oldSubtreeIDs,
-                cancellationCheck: cancellationCheck
-            )
-            for (offset, replacementID) in plan.replacementNodesByID.keys.enumerated() {
+        let replacementNodeCount = replacementStores.reduce(0) { $0 + $1.nodeCount }
+        var replacementNodeIDs = Set<String>()
+        replacementNodeIDs.reserveCapacity(replacementNodeCount)
+        for (ordinal, replacement) in replacementStores.enumerated() {
+            for (offset, replacementIndex) in replacement.indexedNodeIndices().enumerated() {
                 if offset.isMultiple(of: 256) {
                     try cancellationCheck()
                 }
-                if replacementOwnerByNodeID.updateValue(plan.targetID, forKey: replacementID) != nil {
+                guard let replacementNode = replacement.node(at: replacementIndex) else { continue }
+                let replacementID = replacementNode.id
+                if !replacementNodeIDs.insert(replacementID).inserted {
+                    throw StoreError.replacementIDCollision(replacementID)
+                }
+                if let existingIndex = nodeIndex(id: replacementID),
+                   removalOwnerByOffset[Int(existingIndex.rawValue)] != UInt32(ordinal) {
                     throw StoreError.replacementIDCollision(replacementID)
                 }
             }
         }
 
-        let removedIDs = plans.reduce(into: Set<String>()) { result, plan in
-            result.formUnion(plan.oldSubtreeIDs)
-        }
-        var updatedNodes = nodesByID
-        var updatedChildIDs = existingChildIDs
-        var updatedParentIDs = existingParentIDs
-
-        for (offset, removedID) in removedIDs.enumerated() {
-            if offset.isMultiple(of: 256) {
+        var affectedAncestorMembership = NodeMembership(nodeCapacity: nodeRecords.count)
+        for targetIndex in targetIndices {
+            var cursor = topologyArena.parentIndex(of: targetIndex)
+            while let ancestorIndex = cursor {
                 try cancellationCheck()
-            }
-            updatedNodes.removeValue(forKey: removedID)
-            updatedChildIDs.removeValue(forKey: removedID)
-            updatedParentIDs.removeValue(forKey: removedID)
-        }
-
-        for plan in plans {
-            for (offset, entry) in plan.replacementNodesByID.enumerated() {
-                if offset.isMultiple(of: 256) {
-                    try cancellationCheck()
-                }
-                updatedNodes[entry.key] = entry.value
-            }
-            for (offset, entry) in plan.replacementChildIDsByID.enumerated() {
-                if offset.isMultiple(of: 256) {
-                    try cancellationCheck()
-                }
-                updatedChildIDs[entry.key] = entry.value
-            }
-            for (offset, entry) in plan.replacementParentIDByID.enumerated() {
-                if offset.isMultiple(of: 256) {
-                    try cancellationCheck()
-                }
-                updatedParentIDs[entry.key] = entry.value
+                affectedAncestorMembership.insert(ancestorIndex)
+                cursor = topologyArena.parentIndex(of: ancestorIndex)
             }
         }
 
-        let replacementRootIDByTargetID = Dictionary(uniqueKeysWithValues: plans.map {
-            ($0.targetID, $0.replacementRootID)
-        })
-        let affectedParentIDs = Set(plans.compactMap(\.oldParentID))
-        for parentID in affectedParentIDs {
-            try cancellationCheck()
-            let previousChildIDs = existingChildIDs[parentID] ?? []
-            let replacementChildIDs = previousChildIDs.compactMap { childID -> String? in
-                if let replacementRootID = replacementRootIDByTargetID[childID] {
-                    return replacementRootID
-                }
-                return removedIDs.contains(childID) ? nil : childID
-            }
-            if replacementChildIDs.isEmpty {
-                updatedChildIDs.removeValue(forKey: parentID)
-            } else {
-                updatedChildIDs[parentID] = replacementChildIDs
-            }
-        }
+        let finalNodeCount = nodeRecords.count - removedNodeCount + replacementNodeCount
+        var compactedNodes: [FileNodeRecord] = []
+        var compactedIndexByNodeID: [String: FileTreeNodeIndex] = [:]
+        var parentRawIndices: [UInt32] = []
+        var orderedNodeIndices: [FileTreeNodeIndex] = []
+        var affectedCompactedIndices: [FileTreeNodeIndex] = []
+        var replacementRootCompactedIndices: [FileTreeNodeIndex] = []
+        var statsAccumulator = AggregateStatsAccumulator()
+        var sharedAllocationAccumulator = SharedAllocationOwnerAccumulator()
+        var sharedAllocationClaimIndices: [FileTreeNodeIndex] = []
+        compactedNodes.reserveCapacity(finalNodeCount)
+        compactedIndexByNodeID.reserveCapacity(finalNodeCount)
+        parentRawIndices.reserveCapacity(finalNodeCount)
+        orderedNodeIndices.reserveCapacity(finalNodeCount)
 
-        for plan in plans {
-            if let oldParentID = plan.oldParentID {
-                updatedParentIDs[plan.replacementRootID] = oldParentID
-            } else {
-                updatedParentIDs.removeValue(forKey: plan.replacementRootID)
-            }
-        }
-
-        let updatedRootID: String
-        if let rootPlan = plans.first(where: { $0.oldParentID == nil }) {
-            updatedRootID = rootPlan.replacementRootID
-        } else {
-            updatedRootID = rootID
-        }
-
-        var affectedAncestorIDs = Set<String>()
-        for parentID in affectedParentIDs {
-            var cursor: String? = parentID
-            while let currentID = cursor {
-                try cancellationCheck()
-                affectedAncestorIDs.insert(currentID)
-                cursor = updatedParentIDs[currentID]
-            }
-        }
-
-        let orderedNodeIDs = topologyArena.orderedNodeIndices.compactMap { node(at: $0)?.id }
-        for currentID in orderedNodeIDs.reversed() where affectedAncestorIDs.contains(currentID) {
-            try cancellationCheck()
-            guard let current = updatedNodes[currentID] else { continue }
-            let childRecords = (updatedChildIDs[currentID] ?? []).compactMap { updatedNodes[$0] }
-            let sortedChildRecords = Self.sortedChildren(childRecords)
-            updatedNodes[currentID] = FileNodeRecord.directory(
-                id: current.id,
-                url: current.url,
-                name: current.name,
-                children: sortedChildRecords,
-                lastModified: current.lastModified,
-                fileIdentity: current.fileIdentity,
-                linkCount: current.linkCount,
-                isPackage: current.isPackage,
-                isAccessible: current.isSelfAccessible,
-                childrenAreSorted: true
+        typealias TraversalEntry = (
+            sourceOrdinal: Int,
+            sourceIndex: FileTreeNodeIndex,
+            parentRawIndex: UInt32
+        )
+        let baselineSourceOrdinal = -1
+        let rootEntry: TraversalEntry
+        if let rootReplacementOrdinal = targetOrdinalByIndex[topologyArena.rootIndex] {
+            rootEntry = (
+                rootReplacementOrdinal,
+                replacementStores[rootReplacementOrdinal].activeRootIndex,
+                UInt32.max
             )
-            if sortedChildRecords.isEmpty {
-                updatedChildIDs.removeValue(forKey: currentID)
-            } else {
-                updatedChildIDs[currentID] = sortedChildRecords.map(\.id)
+        } else {
+            rootEntry = (baselineSourceOrdinal, topologyArena.rootIndex, UInt32.max)
+        }
+        var traversalStack = [rootEntry]
+
+        while let entry = traversalStack.popLast() {
+            if compactedNodes.count.isMultiple(of: 256) {
+                try cancellationCheck()
+            }
+            let sourceStore = entry.sourceOrdinal == baselineSourceOrdinal
+                ? self
+                : replacementStores[entry.sourceOrdinal]
+            guard let node = sourceStore.node(at: entry.sourceIndex) else { continue }
+            let sourceChildren = sourceStore.activeChildren(of: entry.sourceIndex)
+            let compactedIndex = FileTreeNodeIndex(rawValue: UInt32(compactedNodes.count))
+            precondition(
+                compactedIndexByNodeID.updateValue(compactedIndex, forKey: node.id) == nil
+            )
+            compactedNodes.append(node)
+            parentRawIndices.append(entry.parentRawIndex)
+            orderedNodeIndices.append(compactedIndex)
+            statsAccumulator.include(node, hasMaterializedChildren: !sourceChildren.isEmpty)
+            if let claim = SharedAllocationDeduplicator.claim(for: node) {
+                sharedAllocationAccumulator.record(claim)
+                sharedAllocationClaimIndices.append(compactedIndex)
+            }
+
+            let isReplacementRoot = entry.sourceOrdinal != baselineSourceOrdinal
+                && entry.sourceIndex == sourceStore.activeRootIndex
+            if isReplacementRoot {
+                replacementRootCompactedIndices.append(compactedIndex)
+            } else if entry.sourceOrdinal == baselineSourceOrdinal
+                && affectedAncestorMembership.contains(entry.sourceIndex) {
+                affectedCompactedIndices.append(compactedIndex)
+            }
+
+            for childIndex in sourceChildren.reversed() {
+                if entry.sourceOrdinal == baselineSourceOrdinal,
+                   let replacementOrdinal = targetOrdinalByIndex[childIndex] {
+                    traversalStack.append((
+                        replacementOrdinal,
+                        replacementStores[replacementOrdinal].activeRootIndex,
+                        compactedIndex.rawValue
+                    ))
+                } else {
+                    traversalStack.append((
+                        entry.sourceOrdinal,
+                        childIndex,
+                        compactedIndex.rawValue
+                    ))
+                }
             }
         }
 
-        let aggregateStats = try Self.aggregateStats(
-            rootID: updatedRootID,
-            nodesByID: updatedNodes,
-            childIDsByID: updatedChildIDs,
+        precondition(compactedNodes.count == finalNodeCount)
+        let compactedStore = try Self.finalizedCompactedStore(
+            nodes: &compactedNodes,
+            indexByNodeID: compactedIndexByNodeID,
+            parentRawIndices: parentRawIndices,
+            orderedNodeIndices: &orderedNodeIndices,
+            affectedNodeIndices: affectedCompactedIndices,
+            changedNodeIndices: replacementRootCompactedIndices,
+            statsAccumulator: &statsAccumulator,
             cancellationCheck: cancellationCheck
         )
-        let updatedStore = FileTreeStore(
-            verifiedRootID: updatedRootID,
-            nodesByID: updatedNodes,
-            childIDsByID: updatedChildIDs,
-            parentIDByID: updatedParentIDs,
-            aggregateStats: aggregateStats
+        return try SharedAllocationDeduplicator.rebalancedStore(
+            compactedStore,
+            sharedAllocationAccumulator: sharedAllocationAccumulator,
+            claimNodeIndices: sharedAllocationClaimIndices,
+            cancellationCheck: cancellationCheck
         )
-        return try SharedAllocationDeduplicator.rebalancedStore(updatedStore, cancellationCheck: cancellationCheck)
-    }
-
-    private nonisolated func preflightReplacement(
-        nodesByID replacementNodesByID: [String: FileNodeRecord],
-        removing oldSubtreeIDs: Set<String>,
-        cancellationCheck: () throws -> Void
-    ) throws {
-        for (offset, replacementID) in replacementNodesByID.keys.enumerated() {
-            if offset.isMultiple(of: 256) {
-                try cancellationCheck()
-            }
-            if nodeIndex(id: replacementID) != nil && !oldSubtreeIDs.contains(replacementID) {
-                throw StoreError.replacementIDCollision(replacementID)
-            }
-        }
-    }
-
-    private nonisolated static func aggregateStats(
-        rootID: String,
-        nodesByID: [String: FileNodeRecord],
-        childIDsByID: [String: [String]],
-        cancellationCheck: () throws -> Void
-    ) throws -> ScanAggregateStats {
-        guard let root = nodesByID[rootID] else {
-            preconditionFailure("Verified FileTreeStore root is missing.")
-        }
-
-        var accumulator = AggregateStatsAccumulator()
-        for (offset, node) in nodesByID.values.enumerated() {
-            if offset.isMultiple(of: 256) {
-                try cancellationCheck()
-            }
-            accumulator.include(
-                node,
-                hasMaterializedChildren: childIDsByID[node.id]?.isEmpty == false
-            )
-        }
-
-        return accumulator.stats(root: root)
     }
 
     /// Returns an independently mutable compact store for the visible scope.
@@ -2604,6 +2549,7 @@ nonisolated struct FileTreeStore: Sendable {
     private nonisolated static func finalizeCompactedSubtree(
         nodes: inout [FileNodeRecord],
         affectedNodeIndices: [FileTreeNodeIndex],
+        changedNodeIndices: [FileTreeNodeIndex] = [],
         childSpans: [FileTreeChildSpan],
         childIndices: inout [FileTreeNodeIndex],
         orderedNodeIndices: inout [FileTreeNodeIndex],
@@ -2612,7 +2558,8 @@ nonisolated struct FileTreeStore: Sendable {
     ) throws {
         var didReorderChildren = false
         if !affectedNodeIndices.isEmpty {
-            let affectedNodeIndexSet = Set(affectedNodeIndices)
+            var affectedNodeIndexSet = Set(affectedNodeIndices)
+            affectedNodeIndexSet.formUnion(changedNodeIndices)
             for nodeIndex in affectedNodeIndices.reversed() {
                 try cancellationCheck()
                 let nodeOffset = Int(nodeIndex.rawValue)
@@ -2657,6 +2604,85 @@ nonisolated struct FileTreeStore: Sendable {
             )
         }
         try cancellationCheck()
+    }
+
+    private nonisolated static func finalizedCompactedStore(
+        nodes: inout [FileNodeRecord],
+        indexByNodeID: [String: FileTreeNodeIndex]? = nil,
+        parentRawIndices: [UInt32],
+        orderedNodeIndices: inout [FileTreeNodeIndex],
+        affectedNodeIndices: [FileTreeNodeIndex],
+        changedNodeIndices: [FileTreeNodeIndex] = [],
+        statsAccumulator: inout AggregateStatsAccumulator,
+        cancellationCheck: () throws -> Void
+    ) throws -> FileTreeStore {
+        var childSpans = Array(repeating: FileTreeChildSpan(), count: nodes.count)
+        for (offset, parentRawIndex) in parentRawIndices.enumerated() {
+            if offset.isMultiple(of: 256) {
+                try cancellationCheck()
+            }
+            if parentRawIndex != UInt32.max {
+                childSpans[Int(parentRawIndex)].count += 1
+            }
+        }
+
+        var childCount = 0
+        for offset in childSpans.indices {
+            if offset.isMultiple(of: 256) {
+                try cancellationCheck()
+            }
+            childSpans[offset].start = UInt32(childCount)
+            childCount += Int(childSpans[offset].count)
+        }
+
+        var nextChildRawOffset = childSpans.map(\.start)
+        var childIndices = Array(
+            repeating: FileTreeNodeIndex(rawValue: 0),
+            count: childCount
+        )
+        for (offset, parentRawIndex) in parentRawIndices.enumerated()
+        where parentRawIndex != UInt32.max {
+            if offset.isMultiple(of: 256) {
+                try cancellationCheck()
+            }
+            let parentOffset = Int(parentRawIndex)
+            childIndices[Int(nextChildRawOffset[parentOffset])] = FileTreeNodeIndex(
+                rawValue: UInt32(offset)
+            )
+            nextChildRawOffset[parentOffset] += 1
+        }
+
+        try finalizeCompactedSubtree(
+            nodes: &nodes,
+            affectedNodeIndices: affectedNodeIndices,
+            changedNodeIndices: changedNodeIndices,
+            childSpans: childSpans,
+            childIndices: &childIndices,
+            orderedNodeIndices: &orderedNodeIndices,
+            statsAccumulator: &statsAccumulator,
+            cancellationCheck: cancellationCheck
+        )
+        if let indexByNodeID {
+            return FileTreeStore(
+                verifiedRootIndex: FileTreeNodeIndex(rawValue: 0),
+                nodes: nodes,
+                indexByNodeID: indexByNodeID,
+                parentRawIndices: parentRawIndices,
+                childSpans: childSpans,
+                childIndices: childIndices,
+                orderedNodeIndices: orderedNodeIndices,
+                aggregateStats: statsAccumulator.stats(root: nodes[0])
+            )
+        }
+        return FileTreeStore(
+            verifiedRootIndex: FileTreeNodeIndex(rawValue: 0),
+            nodes: nodes,
+            parentRawIndices: parentRawIndices,
+            childSpans: childSpans,
+            childIndices: childIndices,
+            orderedNodeIndices: orderedNodeIndices,
+            aggregateStats: statsAccumulator.stats(root: nodes[0])
+        )
     }
 
     private nonisolated func compactedSubtree(
@@ -2731,56 +2757,13 @@ nonisolated struct FileTreeStore: Sendable {
             }
         }
 
-        var childSpans = Array(repeating: FileTreeChildSpan(), count: scopedNodes.count)
-        for (scopedOffset, parentRawIndex) in parentRawIndices.enumerated() {
-            if scopedOffset.isMultiple(of: 256) {
-                try cancellationCheck()
-            }
-            if parentRawIndex != UInt32.max {
-                childSpans[Int(parentRawIndex)].count += 1
-            }
-        }
-
-        var childCount = 0
-        for scopedOffset in childSpans.indices {
-            if scopedOffset.isMultiple(of: 256) {
-                try cancellationCheck()
-            }
-            childSpans[scopedOffset].start = UInt32(childCount)
-            childCount += Int(childSpans[scopedOffset].count)
-        }
-
-        var nextChildRawOffset = childSpans.map(\.start)
-        var childIndices = Array(repeating: FileTreeNodeIndex(rawValue: 0), count: childCount)
-        for (scopedOffset, parentRawIndex) in parentRawIndices.enumerated()
-        where parentRawIndex != UInt32.max {
-            if scopedOffset.isMultiple(of: 256) {
-                try cancellationCheck()
-            }
-            let parentOffset = Int(parentRawIndex)
-            let childRawOffset = nextChildRawOffset[parentOffset]
-            childIndices[Int(childRawOffset)] = FileTreeNodeIndex(rawValue: UInt32(scopedOffset))
-            nextChildRawOffset[parentOffset] += 1
-        }
-
-        let scopedRootIndex = FileTreeNodeIndex(rawValue: 0)
-        try Self.finalizeCompactedSubtree(
+        let scopedStore = try Self.finalizedCompactedStore(
             nodes: &scopedNodes,
-            affectedNodeIndices: affectedScopedIndices,
-            childSpans: childSpans,
-            childIndices: &childIndices,
+            parentRawIndices: parentRawIndices,
             orderedNodeIndices: &orderedNodeIndices,
+            affectedNodeIndices: affectedScopedIndices,
             statsAccumulator: &statsAccumulator,
             cancellationCheck: cancellationCheck
-        )
-        let scopedStore = FileTreeStore(
-            verifiedRootIndex: scopedRootIndex,
-            nodes: scopedNodes,
-            parentRawIndices: parentRawIndices,
-            childSpans: childSpans,
-            childIndices: childIndices,
-            orderedNodeIndices: orderedNodeIndices,
-            aggregateStats: statsAccumulator.stats(root: scopedNodes[0])
         )
         return try SharedAllocationDeduplicator.rebalancedStore(
             scopedStore,
@@ -2788,76 +2771,6 @@ nonisolated struct FileTreeStore: Sendable {
             claimNodeIndices: sharedAllocationClaimIndices,
             cancellationCheck: cancellationCheck
         )
-    }
-
-    nonisolated func subtreeContents(rootedAt targetID: String) -> FileTreeSubtreeContents? {
-        try? subtreeContents(rootedAt: targetID, cancellationCheck: {})
-    }
-
-    nonisolated func subtreeContents(
-        rootedAt targetID: String,
-        cancellationCheck: () throws -> Void
-    ) throws -> FileTreeSubtreeContents? {
-        try cancellationCheck()
-        guard let targetIndex = nodeIndex(id: targetID) else { return nil }
-
-        var scopedNodes: [String: FileNodeRecord] = [:]
-        var scopedChildIDs: [String: [String]] = [:]
-        var stack = [targetIndex]
-
-        while let currentIndex = stack.popLast() {
-            try cancellationCheck()
-            guard let record = node(at: currentIndex) else { continue }
-            let currentID = record.id
-            scopedNodes[currentID] = record
-
-            let childIndices = activeChildren(of: currentIndex)
-            guard !childIndices.isEmpty else { continue }
-
-            var scopedChildren: [String] = []
-            scopedChildren.reserveCapacity(childIndices.count)
-            for (offset, childIndex) in childIndices.enumerated() {
-                if offset.isMultiple(of: 256) {
-                    try cancellationCheck()
-                }
-                guard let childID = self.node(at: childIndex)?.id else { continue }
-                scopedChildren.append(childID)
-                stack.append(childIndex)
-            }
-
-            if !scopedChildren.isEmpty {
-                scopedChildIDs[currentID] = scopedChildren
-            }
-        }
-
-        guard let root = scopedNodes[targetID] else { return nil }
-        return FileTreeSubtreeContents(
-            root: root,
-            nodesByID: scopedNodes,
-            childIDsByID: scopedChildIDs
-        )
-    }
-
-    nonisolated func subtreeNodeIDs(rootedAt id: String) -> [String] {
-        (try? subtreeNodeIDs(rootedAt: id, cancellationCheck: {})) ?? []
-    }
-
-    private nonisolated func subtreeNodeIDs(
-        rootedAt id: String,
-        cancellationCheck: () throws -> Void
-    ) throws -> [String] {
-        guard let rootIndex = nodeIndex(id: id) else { return [] }
-        var result: [String] = []
-        var stack = [rootIndex]
-
-        while let currentIndex = stack.popLast() {
-            try cancellationCheck()
-            guard let currentID = node(at: currentIndex)?.id else { continue }
-            result.append(currentID)
-            stack.append(contentsOf: activeChildren(of: currentIndex))
-        }
-
-        return result
     }
 
     private nonisolated static func sanitizedTopology(

--- a/Radix/Services/FileSystemEventHistory.swift
+++ b/Radix/Services/FileSystemEventHistory.swift
@@ -319,6 +319,8 @@ nonisolated extension FileSystemEventFlags {
         copy(kFSEventStreamEventFlagItemIsFile, to: .itemIsFile)
         copy(kFSEventStreamEventFlagItemIsDir, to: .itemIsDirectory)
         copy(kFSEventStreamEventFlagItemIsSymlink, to: .itemIsSymbolicLink)
+        copy(kFSEventStreamEventFlagItemIsHardlink, to: .itemIsHardLink)
+        copy(kFSEventStreamEventFlagItemIsLastHardlink, to: .itemIsLastHardLink)
         copy(kFSEventStreamEventFlagItemCloned, to: .itemCloned)
         self = mappedFlags
     }

--- a/Radix/Services/IncrementalRescanPlanner.swift
+++ b/Radix/Services/IncrementalRescanPlanner.swift
@@ -151,7 +151,11 @@ nonisolated struct IncrementalRescanPlanner: Sendable {
             }
         }
         for subtreeID in rescanSubtreeIDs {
-            incrementalWorkItemCount += treeStore.subtreeNodeCount(rootedAt: subtreeID)
+            let remainingWorkItemCount = fullScanWorkThreshold - incrementalWorkItemCount
+            incrementalWorkItemCount += treeStore.subtreeNodeCount(
+                rootedAt: subtreeID,
+                upTo: remainingWorkItemCount
+            )
             if incrementalWorkItemCount >= fullScanWorkThreshold {
                 return .fullScan(reason: .incrementalWorkTooBroad)
             }

--- a/Radix/Services/IncrementalRescanPlanner.swift
+++ b/Radix/Services/IncrementalRescanPlanner.swift
@@ -37,19 +37,6 @@ nonisolated struct IncrementalRescanPlanner: Sendable {
             if eventPath == targetPath {
                 return .fullScan(reason: .changedScanRoot)
             }
-            if !event.flags.intersection([.itemIsHardLink, .itemIsLastHardLink]).isEmpty {
-                return .fullScan(reason: .sharedAllocationTopologyChanged)
-            }
-            if !event.flags.intersection([.itemModified, .itemRemoved]).isEmpty,
-               let existingNode = treeStore.node(id: eventPath) {
-                if existingNode.cloneIdentity != nil {
-                    return .fullScan(reason: .cloneTopologyChanged)
-                }
-                if existingNode.linkCount > 1 {
-                    return .fullScan(reason: .sharedAllocationTopologyChanged)
-                }
-            }
-
             let knownIsDirectory: Bool?
             if event.flags.contains(.itemIsDirectory) {
                 knownIsDirectory = true
@@ -64,6 +51,24 @@ nonisolated struct IncrementalRescanPlanner: Sendable {
                    isDirectory: knownIsDirectory
                ) == true {
                 continue
+            }
+            if event.flags.contains(.itemCloned) {
+                return .fullScan(reason: .cloneTopologyChanged)
+            }
+            if !event.flags.intersection([.itemIsHardLink, .itemIsLastHardLink]).isEmpty {
+                return .fullScan(reason: .sharedAllocationTopologyChanged)
+            }
+            if let existingNode = treeStore.node(id: eventPath) {
+                if !event.flags.intersection([.itemModified, .itemRemoved]).isEmpty,
+                   existingNode.cloneIdentity != nil {
+                    return .fullScan(reason: .cloneTopologyChanged)
+                }
+                if !existingNode.isDirectory,
+                   !existingNode.isSymbolicLink,
+                   !existingNode.isSynthetic,
+                   existingNode.linkCount > 1 {
+                    return .fullScan(reason: .sharedAllocationTopologyChanged)
+                }
             }
 
             var candidatePath = initialCandidatePath(
@@ -190,7 +195,6 @@ nonisolated struct IncrementalRescanPlanner: Sendable {
         if !flags.intersection([.volumeMounted, .volumeUnmounted]).isEmpty {
             return .nestedVolumeChanged
         }
-        if flags.contains(.itemCloned) { return .cloneTopologyChanged }
         return nil
     }
 

--- a/Radix/Services/IncrementalRescanPlanner.swift
+++ b/Radix/Services/IncrementalRescanPlanner.swift
@@ -37,9 +37,17 @@ nonisolated struct IncrementalRescanPlanner: Sendable {
             if eventPath == targetPath {
                 return .fullScan(reason: .changedScanRoot)
             }
+            if !event.flags.intersection([.itemIsHardLink, .itemIsLastHardLink]).isEmpty {
+                return .fullScan(reason: .sharedAllocationTopologyChanged)
+            }
             if !event.flags.intersection([.itemModified, .itemRemoved]).isEmpty,
-               treeStore.node(id: eventPath)?.cloneIdentity != nil {
-                return .fullScan(reason: .cloneTopologyChanged)
+               let existingNode = treeStore.node(id: eventPath) {
+                if existingNode.cloneIdentity != nil {
+                    return .fullScan(reason: .cloneTopologyChanged)
+                }
+                if existingNode.linkCount > 1 {
+                    return .fullScan(reason: .sharedAllocationTopologyChanged)
+                }
             }
 
             let knownIsDirectory: Bool?

--- a/Radix/Services/IncrementalRescanPlanner.swift
+++ b/Radix/Services/IncrementalRescanPlanner.swift
@@ -8,7 +8,7 @@ import Foundation
 /// Converts advisory filesystem events into conservative directory relists and
 /// subtree rescans that can be spliced into a prior `FileTreeStore`.
 nonisolated struct IncrementalRescanPlanner: Sendable {
-    private static let broadRelistDirectoryThreshold = 32
+    private static let minimumBroadWorkItemCount = 32
 
     private enum UpdateKind {
         case relistDirectory
@@ -134,21 +134,21 @@ nonisolated struct IncrementalRescanPlanner: Sendable {
                 continue
             }
         }
-        let updateRootCount = relistDirectoryIDs.count + rescanSubtreeIDs.count
-        if updateRootCount >= Self.broadRelistDirectoryThreshold {
-            let fullScanWorkThreshold = max(treeStore.nodeCount / 2, 1)
-            var incrementalWorkItemCount = 0
-            for directoryID in relistDirectoryIDs {
-                incrementalWorkItemCount += treeStore.childCount(of: directoryID) + 1
-                if incrementalWorkItemCount >= fullScanWorkThreshold {
-                    return .fullScan(reason: .incrementalWorkTooBroad)
-                }
+        let fullScanWorkThreshold = max(
+            treeStore.nodeCount / 2,
+            Self.minimumBroadWorkItemCount
+        )
+        var incrementalWorkItemCount = 0
+        for directoryID in relistDirectoryIDs {
+            incrementalWorkItemCount += treeStore.childCount(of: directoryID) + 1
+            if incrementalWorkItemCount >= fullScanWorkThreshold {
+                return .fullScan(reason: .incrementalWorkTooBroad)
             }
-            for subtreeID in rescanSubtreeIDs {
-                incrementalWorkItemCount += treeStore.subtreeNodeCount(rootedAt: subtreeID)
-                if incrementalWorkItemCount >= fullScanWorkThreshold {
-                    return .fullScan(reason: .incrementalWorkTooBroad)
-                }
+        }
+        for subtreeID in rescanSubtreeIDs {
+            incrementalWorkItemCount += treeStore.subtreeNodeCount(rootedAt: subtreeID)
+            if incrementalWorkItemCount >= fullScanWorkThreshold {
+                return .fullScan(reason: .incrementalWorkTooBroad)
             }
         }
         return .update(

--- a/Radix/Services/IncrementalScanService.swift
+++ b/Radix/Services/IncrementalScanService.swift
@@ -25,7 +25,6 @@ nonisolated final class IncrementalScanService: ScanEventStreaming, @unchecked S
         case incompleteMetadata
         case duplicateEntry
         case identityChanged
-        case replacementCollision
     }
 
     private struct ShallowReplacement: Sendable {
@@ -419,18 +418,18 @@ nonisolated final class IncrementalScanService: ScanEventStreaming, @unchecked S
         baseline: ScanSnapshot,
         classificationWorkerLimit: Int
     ) async throws -> ShallowReplacement {
-        guard let originalSubtree = baseline.treeStore.subtreeContents(rootedAt: directoryID),
-              originalSubtree.root.isDirectory,
-              !originalSubtree.root.isSymbolicLink else {
+        guard let originalRoot = baseline.treeStore.node(id: directoryID),
+              originalRoot.isDirectory,
+              !originalRoot.isSymbolicLink else {
             throw ShallowRelistError.invalidDirectory
         }
         if ScanEngine.requiresDeepScanForAutoSummary(
-            at: originalSubtree.root.url,
+            at: originalRoot.url,
             scanTarget: target,
             options: options
         ) {
             let replacement = try await scannedReplacement(
-                at: originalSubtree.root.url,
+                at: originalRoot.url,
                 scanTarget: target,
                 options: options
             )
@@ -441,22 +440,21 @@ nonisolated final class IncrementalScanService: ScanEventStreaming, @unchecked S
             )
         }
         let listing = try await engine.shallowDirectoryListing(
-            at: originalSubtree.root.url,
+            at: originalRoot.url,
             scanTarget: target,
             options: options,
             classificationWorkerLimit: classificationWorkerLimit
         )
         guard listing.directoryMetadata.fileIdentity != nil,
-              listing.directoryMetadata.fileIdentity == originalSubtree.root.fileIdentity else {
+              listing.directoryMetadata.fileIdentity == originalRoot.fileIdentity else {
             throw ShallowRelistError.identityChanged
         }
 
-        var nodesByID = originalSubtree.nodesByID
-        var childIDsByID = originalSubtree.childIDsByID
-        let originalChildIDs = originalSubtree.childIDsByID[directoryID] ?? []
         var currentChildIDs = Set<String>()
         currentChildIDs.reserveCapacity(listing.entries.count)
         var preservedSubtreeIDs = Set<String>()
+        var childSubtrees: [FileTreeStore.SubtreeSource] = []
+        childSubtrees.reserveCapacity(listing.entries.count)
         var replacementWarnings: [ScanWarning] = []
 
         for entry in listing.entries {
@@ -471,62 +469,55 @@ nonisolated final class IncrementalScanService: ScanEventStreaming, @unchecked S
             }
 
             if canPreserveDirectory(
-                baselineNode: originalSubtree.nodesByID[childID],
+                baselineNode: baseline.treeStore.node(id: childID),
                 metadata: metadata
             ) {
+                guard let subtree = FileTreeStore.SubtreeSource(
+                    store: baseline.treeStore,
+                    rootedAt: childID
+                ) else {
+                    throw ShallowRelistError.incompleteMetadata
+                }
+                childSubtrees.append(subtree)
                 preservedSubtreeIDs.insert(childID)
                 continue
             }
 
-            removeSubtree(
-                rootedAt: childID,
-                originalChildIDsByID: originalSubtree.childIDsByID,
-                nodesByID: &nodesByID,
-                childIDsByID: &childIDsByID
-            )
             if metadata.isDirectory, !metadata.isSymbolicLink {
                 let childSnapshot = try await scannedReplacement(
                     at: entry.url,
                     scanTarget: target,
                     options: options
                 )
-                for (replacementID, node) in childSnapshot.treeStore.nodesByID {
-                    guard nodesByID[replacementID] == nil else {
-                        throw ShallowRelistError.replacementCollision
-                    }
-                    nodesByID[replacementID] = node
+                guard childSnapshot.treeStore.rootID == childID,
+                      let subtree = FileTreeStore.SubtreeSource(
+                          store: childSnapshot.treeStore,
+                          rootedAt: childID
+                      ) else {
+                    throw ShallowRelistError.incompleteMetadata
                 }
-                for (replacementID, childIDs) in childSnapshot.treeStore.childIDsByID {
-                    childIDsByID[replacementID] = childIDs
-                }
+                childSubtrees.append(subtree)
                 replacementWarnings.append(contentsOf: childSnapshot.scanWarnings)
             } else {
-                nodesByID[childID] = engine.makeFileNode(
+                let child = engine.makeFileNode(
                     url: entry.url,
                     metadata: metadata
                 )
+                childSubtrees.append(FileTreeStore.SubtreeSource(node: child))
             }
         }
 
-        for removedChildID in originalChildIDs where !currentChildIDs.contains(removedChildID) {
-            removeSubtree(
-                rootedAt: removedChildID,
-                originalChildIDsByID: originalSubtree.childIDsByID,
-                nodesByID: &nodesByID,
-                childIDsByID: &childIDsByID
-            )
+        childSubtrees.sort {
+            FileTreeStore.areInDisplayOrder($0.root, $1.root)
         }
-
-        let children = FileTreeStore.sortedChildren(
-            currentChildIDs.compactMap { nodesByID[$0] }
-        )
+        let children = childSubtrees.map(\.root)
         guard children.count == currentChildIDs.count else {
             throw ShallowRelistError.incompleteMetadata
         }
-        nodesByID[directoryID] = FileNodeRecord.directory(
+        let replacementRoot = FileNodeRecord.directory(
             id: directoryID,
-            url: originalSubtree.root.url,
-            name: originalSubtree.root.name,
+            url: originalRoot.url,
+            name: originalRoot.name,
             children: children,
             lastModified: listing.directoryMetadata.lastModified,
             fileIdentity: listing.directoryMetadata.fileIdentity,
@@ -535,11 +526,6 @@ nonisolated final class IncrementalScanService: ScanEventStreaming, @unchecked S
             isAccessible: listing.directoryMetadata.isReadable,
             childrenAreSorted: true
         )
-        if children.isEmpty {
-            childIDsByID.removeValue(forKey: directoryID)
-        } else {
-            childIDsByID[directoryID] = children.map(\.id)
-        }
         replacementWarnings.append(contentsOf: baseline.scanWarnings.filter { warning in
             preservedSubtreeIDs.contains { subtreeID in
                 Self.path(warning.path, isContainedIn: subtreeID)
@@ -547,10 +533,10 @@ nonisolated final class IncrementalScanService: ScanEventStreaming, @unchecked S
         })
         return ShallowReplacement(
             directoryID: directoryID,
-            treeStore: FileTreeStore(
-                rootID: directoryID,
-                nodesByID: nodesByID,
-                childIDsByID: childIDsByID
+            treeStore: try FileTreeStore.combining(
+                root: replacementRoot,
+                childSubtrees: childSubtrees,
+                cancellationCheck: { try Task.checkCancellation() }
             ),
             warnings: replacementWarnings
         )
@@ -598,20 +584,6 @@ nonisolated final class IncrementalScanService: ScanEventStreaming, @unchecked S
             return false
         }
         return true
-    }
-
-    private nonisolated func removeSubtree(
-        rootedAt nodeID: String,
-        originalChildIDsByID: [String: [String]],
-        nodesByID: inout [String: FileNodeRecord],
-        childIDsByID: inout [String: [String]]
-    ) {
-        var stack = [nodeID]
-        while let removedID = stack.popLast() {
-            stack.append(contentsOf: originalChildIDsByID[removedID] ?? [])
-            nodesByID.removeValue(forKey: removedID)
-            childIDsByID.removeValue(forKey: removedID)
-        }
     }
 
     private nonisolated static func path(_ path: String, isContainedIn rootPath: String) -> Bool {

--- a/Radix/Services/IncrementalScanService.swift
+++ b/Radix/Services/IncrementalScanService.swift
@@ -72,23 +72,40 @@ nonisolated final class IncrementalScanService: ScanEventStreaming, @unchecked S
         options: ScanOptions,
         executionMode: ScanExecutionMode
     ) -> AsyncThrowingStream<ScanProgressEvent, Error> {
-        let checkpoint: ScanIncrementalCheckpoint?
-        do {
-            checkpoint = try eventHistoryProvider.currentCheckpoint(for: target.url)
-        } catch {
-            checkpoint = nil
-            Self.logger.info(
-                "Incremental checkpoint unavailable: \(error, privacy: .private)"
-            )
-        }
-        return bridge(
-            engine.scan(target: target, options: options),
-            executionMode: executionMode
-        ) { snapshot in
-            self.snapshot(
-                snapshot,
-                checkpoint: checkpoint
-            )
+        AsyncThrowingStream { continuation in
+            let task = Task.detached(priority: .userInitiated) {
+                continuation.yield(.executionMode(executionMode))
+
+                let checkpoint: ScanIncrementalCheckpoint?
+                do {
+                    checkpoint = try self.eventHistoryProvider.currentCheckpoint(for: target.url)
+                } catch {
+                    checkpoint = nil
+                    Self.logger.info(
+                        "Incremental checkpoint unavailable: \(error, privacy: .private)"
+                    )
+                }
+
+                do {
+                    try Task.checkCancellation()
+                    for try await event in self.engine.scan(target: target, options: options) {
+                        if case .finished(let snapshot) = event {
+                            continuation.yield(.finished(self.snapshot(
+                                snapshot,
+                                checkpoint: checkpoint
+                            )))
+                        } else {
+                            continuation.yield(event)
+                        }
+                    }
+                    continuation.finish()
+                } catch is CancellationError {
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { @Sendable _ in task.cancel() }
         }
     }
 
@@ -625,33 +642,6 @@ nonisolated final class IncrementalScanService: ScanEventStreaming, @unchecked S
             continuation.yield(event)
         }
         continuation.finish()
-    }
-
-    private nonisolated func bridge(
-        _ stream: AsyncThrowingStream<ScanProgressEvent, Error>,
-        executionMode: ScanExecutionMode,
-        finishedTransform: @escaping @Sendable (ScanSnapshot) -> ScanSnapshot
-    ) -> AsyncThrowingStream<ScanProgressEvent, Error> {
-        AsyncThrowingStream { continuation in
-            let task = Task(priority: .userInitiated) {
-                do {
-                    continuation.yield(.executionMode(executionMode))
-                    for try await event in stream {
-                        if case .finished(let snapshot) = event {
-                            continuation.yield(.finished(finishedTransform(snapshot)))
-                        } else {
-                            continuation.yield(event)
-                        }
-                    }
-                    continuation.finish()
-                } catch is CancellationError {
-                    continuation.finish()
-                } catch {
-                    continuation.finish(throwing: error)
-                }
-            }
-            continuation.onTermination = { @Sendable _ in task.cancel() }
-        }
     }
 
     private nonisolated func incrementalRescanEligibility(

--- a/Radix/Services/ScanCoordinator.swift
+++ b/Radix/Services/ScanCoordinator.swift
@@ -518,8 +518,61 @@ final class ScanCoordinator: ObservableObject {
             )
         } catch is CancellationError {
             completeFolderRescanAsCancelled(id: rescanID)
+        } catch ScanSnapshotTransformError.sharedAllocationRequiresFullScan {
+            await continueFolderRescanAsFullScan(
+                baseline: baseline,
+                rescanID: rescanID
+            )
         } catch {
             failFolderRescan(error, nodeName: node.name, rescanID: rescanID)
+        }
+    }
+
+    private func continueFolderRescanAsFullScan(
+        baseline: ScanSnapshot,
+        rescanID: UUID
+    ) async {
+        guard activeScanID == rescanID,
+              let options = baseline.scanOptions else {
+            completeFolderRescanAsCancelled(id: rescanID)
+            return
+        }
+
+        progress.executionMode = .fullFallback(.sharedAllocationTopologyChanged)
+        scanMetrics = ScanMetrics()
+        resetProgressThrottling()
+        do {
+            var fullSnapshot: ScanSnapshot?
+            for try await event in scanService.scan(
+                target: baseline.target,
+                options: options
+            ) {
+                guard activeScanID == rescanID else { return }
+                switch event {
+                case .progress(let metrics):
+                    handleProgress(metrics, operationID: rescanID)
+                case .finished(let snapshot):
+                    fullSnapshot = snapshot
+                case .executionMode, .warning:
+                    break
+                }
+            }
+
+            try Task.checkCancellation()
+            guard activeScanID == rescanID,
+                  let fullSnapshot else {
+                completeFolderRescanAsCancelled(id: rescanID)
+                return
+            }
+            finishScan(with: fullSnapshot, scanID: rescanID)
+        } catch is CancellationError {
+            completeFolderRescanAsCancelled(id: rescanID)
+        } catch {
+            failFolderRescan(
+                error,
+                nodeName: baseline.root.name,
+                rescanID: rescanID
+            )
         }
     }
 
@@ -675,6 +728,7 @@ final class ScanCoordinator: ObservableObject {
 
         activeScanID = nil
         scanTask = nil
+        folderRescanState = nil
         phase = .displaying
         publishCompletionNotice(for: progress.executionMode)
         onScanFinished?(snapshot)

--- a/Radix/Services/ScanCoordinator.swift
+++ b/Radix/Services/ScanCoordinator.swift
@@ -539,6 +539,7 @@ final class ScanCoordinator: ObservableObject {
         }
 
         progress.executionMode = .fullFallback(.sharedAllocationTopologyChanged)
+        folderRescanState = FolderRescanState(nodeName: baseline.target.displayName)
         scanMetrics = ScanMetrics()
         resetProgressThrottling()
         do {

--- a/Radix/Services/ScanIncrementalModels.swift
+++ b/Radix/Services/ScanIncrementalModels.swift
@@ -49,6 +49,8 @@ nonisolated struct FileSystemEventFlags: OptionSet, Codable, Hashable, Sendable 
     static let itemIsDirectory = Self(rawValue: 1 << 13)
     static let itemIsSymbolicLink = Self(rawValue: 1 << 14)
     static let itemCloned = Self(rawValue: 1 << 15)
+    static let itemIsHardLink = Self(rawValue: 1 << 16)
+    static let itemIsLastHardLink = Self(rawValue: 1 << 17)
 }
 
 nonisolated struct FileSystemEventRecord: Codable, Hashable, Sendable {
@@ -100,6 +102,7 @@ nonisolated enum IncrementalRescanFallbackReason: String, Codable, Hashable, Sen
     case noMaterializedAncestor
     case autoSummarizedBoundary
     case incrementalWorkTooBroad
+    case sharedAllocationTopologyChanged
     case directoryRelistFailed
     case changedSubtreeUnavailable
     case subtreeRescanFailed
@@ -146,7 +149,8 @@ nonisolated extension IncrementalRescanFallbackReason {
              .readOnlyBaseline,
              .noMaterializedAncestor,
              .autoSummarizedBoundary,
-             .cloneTopologyChanged:
+             .cloneTopologyChanged,
+             .sharedAllocationTopologyChanged:
             return .previousScanUnavailable
         case .directoryRelistFailed,
              .changedSubtreeUnavailable,

--- a/Radix/Services/ScanSnapshotTransformService.swift
+++ b/Radix/Services/ScanSnapshotTransformService.swift
@@ -11,6 +11,25 @@ nonisolated enum ScanSnapshotTransformError: Error, Sendable {
     case sharedAllocationRequiresFullScan
 }
 
+private nonisolated enum SubtreeRescanAllocationValidator {
+    static func validate(
+        baseline: FileTreeStore,
+        targetID: String,
+        replacement: FileTreeStore,
+        cancellationCheck: () throws -> Void
+    ) throws {
+        if try baseline.subtreeContainsSharedAllocationMetadata(
+            rootedAt: targetID,
+            cancellationCheck: cancellationCheck
+        ) || replacement.subtreeContainsSharedAllocationMetadata(
+            rootedAt: replacement.rootID,
+            cancellationCheck: cancellationCheck
+        ) {
+            throw ScanSnapshotTransformError.sharedAllocationRequiresFullScan
+        }
+    }
+}
+
 protocol ScanSnapshotTransforming: Sendable {
     func replacingNode(
         in snapshot: ScanSnapshot,
@@ -59,15 +78,12 @@ extension ScanSnapshotTransforming {
         volumeCapacity: VolumeCapacitySnapshot?,
         reconcilesVolumeCapacity: Bool
     ) async throws -> ScanSnapshot? {
-        if try snapshot.treeStore.subtreeContainsSharedAllocationMetadata(
-            rootedAt: targetID,
+        try SubtreeRescanAllocationValidator.validate(
+            baseline: snapshot.treeStore,
+            targetID: targetID,
+            replacement: replacement,
             cancellationCheck: { try Task.checkCancellation() }
-        ) || replacement.subtreeContainsSharedAllocationMetadata(
-            rootedAt: replacement.rootID,
-            cancellationCheck: { try Task.checkCancellation() }
-        ) {
-            throw ScanSnapshotTransformError.sharedAllocationRequiresFullScan
-        }
+        )
         return try await replacingNode(
             in: snapshot,
             id: targetID,
@@ -153,15 +169,12 @@ actor ScanSnapshotTransformService {
         volumeCapacity: VolumeCapacitySnapshot?,
         reconcilesVolumeCapacity: Bool
     ) async throws -> ScanSnapshot? {
-        if try snapshot.treeStore.subtreeContainsSharedAllocationMetadata(
-            rootedAt: targetID,
+        try SubtreeRescanAllocationValidator.validate(
+            baseline: snapshot.treeStore,
+            targetID: targetID,
+            replacement: replacement,
             cancellationCheck: { try Task.checkCancellation() }
-        ) || replacement.subtreeContainsSharedAllocationMetadata(
-            rootedAt: replacement.rootID,
-            cancellationCheck: { try Task.checkCancellation() }
-        ) {
-            throw ScanSnapshotTransformError.sharedAllocationRequiresFullScan
-        }
+        )
         return try snapshot.replacingNode(
             id: targetID,
             with: replacement,

--- a/Radix/Services/ScanSnapshotTransformService.swift
+++ b/Radix/Services/ScanSnapshotTransformService.swift
@@ -7,6 +7,10 @@
 
 import Foundation
 
+nonisolated enum ScanSnapshotTransformError: Error, Sendable {
+    case sharedAllocationRequiresFullScan
+}
+
 protocol ScanSnapshotTransforming: Sendable {
     func replacingNode(
         in snapshot: ScanSnapshot,
@@ -55,7 +59,16 @@ extension ScanSnapshotTransforming {
         volumeCapacity: VolumeCapacitySnapshot?,
         reconcilesVolumeCapacity: Bool
     ) async throws -> ScanSnapshot? {
-        try await replacingNode(
+        if try snapshot.treeStore.subtreeContainsSharedAllocationMetadata(
+            rootedAt: targetID,
+            cancellationCheck: { try Task.checkCancellation() }
+        ) || replacement.subtreeContainsSharedAllocationMetadata(
+            rootedAt: replacement.rootID,
+            cancellationCheck: { try Task.checkCancellation() }
+        ) {
+            throw ScanSnapshotTransformError.sharedAllocationRequiresFullScan
+        }
+        return try await replacingNode(
             in: snapshot,
             id: targetID,
             with: replacement,
@@ -108,7 +121,7 @@ actor ScanSnapshotTransformService {
         with replacement: FileTreeStore,
         additionalWarnings: [ScanWarning] = []
     ) async throws -> ScanSnapshot? {
-        try snapshot.replacingNode(
+        return try snapshot.replacingNode(
             id: targetID,
             with: replacement,
             additionalWarnings: additionalWarnings,
@@ -140,7 +153,16 @@ actor ScanSnapshotTransformService {
         volumeCapacity: VolumeCapacitySnapshot?,
         reconcilesVolumeCapacity: Bool
     ) async throws -> ScanSnapshot? {
-        try snapshot.replacingNode(
+        if try snapshot.treeStore.subtreeContainsSharedAllocationMetadata(
+            rootedAt: targetID,
+            cancellationCheck: { try Task.checkCancellation() }
+        ) || replacement.subtreeContainsSharedAllocationMetadata(
+            rootedAt: replacement.rootID,
+            cancellationCheck: { try Task.checkCancellation() }
+        ) {
+            throw ScanSnapshotTransformError.sharedAllocationRequiresFullScan
+        }
+        return try snapshot.replacingNode(
             id: targetID,
             with: replacement,
             additionalWarnings: additionalWarnings,

--- a/RadixCoreTests/FileTreeStoreTests.swift
+++ b/RadixCoreTests/FileTreeStoreTests.swift
@@ -1077,6 +1077,22 @@ final class FileTreeStoreTests: XCTestCase {
         ))
     }
 
+    func testSubtreeNodeCountStopsAtLimit() {
+        let files = (0..<10).map { index in
+            makeFileNode(
+                id: "/root/file-\(index).dat",
+                name: "file-\(index).dat",
+                size: 1
+            )
+        }
+        let root = makeDirectoryNode(id: "/root", name: "root", children: files)
+        let store = FileTreeStore(root: root, childrenByID: [root.id: files])
+
+        XCTAssertEqual(store.subtreeNodeCount(rootedAt: root.id, upTo: 4), 4)
+        XCTAssertEqual(store.subtreeNodeCount(rootedAt: root.id, upTo: 0), 0)
+        XCTAssertEqual(store.subtreeNodeCount(rootedAt: "/missing", upTo: 4), 0)
+    }
+
     func testReplacingRootCanChangeRootID() throws {
         let oldChild = makeFileNode(id: "/root/old.txt", name: "old.txt", size: 4)
         let oldRoot = makeDirectoryNode(id: "/root", name: "root", children: [oldChild])

--- a/RadixCoreTests/FileTreeStoreTests.swift
+++ b/RadixCoreTests/FileTreeStoreTests.swift
@@ -1054,6 +1054,29 @@ final class FileTreeStoreTests: XCTestCase {
         XCTAssertEqual(store.node(id: sibling.id)?.name, sibling.name)
     }
 
+    func testSharedAllocationMetadataIgnoresDirectoryLinkCounts() throws {
+        let ordinaryFile = makeFileNode(
+            id: "/root/ordinary.dat",
+            name: "ordinary.dat",
+            size: 4
+        )
+        let root = makeTestDirectoryNode(
+            id: "/root",
+            name: "root",
+            children: [ordinaryFile],
+            linkCount: 42
+        )
+        let store = FileTreeStore(
+            root: root,
+            childrenByID: [root.id: [ordinaryFile]]
+        )
+
+        XCTAssertFalse(try store.subtreeContainsSharedAllocationMetadata(
+            rootedAt: root.id,
+            cancellationCheck: {}
+        ))
+    }
+
     func testReplacingRootCanChangeRootID() throws {
         let oldChild = makeFileNode(id: "/root/old.txt", name: "old.txt", size: 4)
         let oldRoot = makeDirectoryNode(id: "/root", name: "root", children: [oldChild])

--- a/RadixCoreTests/FileTreeStoreTests.swift
+++ b/RadixCoreTests/FileTreeStoreTests.swift
@@ -1119,6 +1119,33 @@ final class FileTreeStoreTests: XCTestCase {
         XCTAssertEqual(updated.aggregateStats.directoryCount, 3)
     }
 
+    func testReplacingSubtreesCanChangeRootID() throws {
+        let oldChild = makeFileNode(id: "/root/old.txt", name: "old.txt", size: 5)
+        let root = makeDirectoryNode(id: "/root", name: "root", children: [oldChild])
+        let store = FileTreeStore(root: root, childrenByID: [root.id: [oldChild]])
+        let newChild = makeFileNode(id: "/replacement/new.txt", name: "new.txt", size: 9)
+        let replacementRoot = makeDirectoryNode(
+            id: "/replacement",
+            name: "replacement",
+            children: [newChild]
+        )
+
+        let updated = try XCTUnwrap(try store.replacingSubtrees(
+            [
+                root.id: FileTreeStore(
+                    root: replacementRoot,
+                    childrenByID: [replacementRoot.id: [newChild]]
+                ),
+            ],
+            cancellationCheck: {}
+        ))
+
+        XCTAssertEqual(updated.rootID, replacementRoot.id)
+        XCTAssertEqual(updated.root.allocatedSize, 9)
+        XCTAssertEqual(updated.children(of: replacementRoot.id), [newChild])
+        XCTAssertNil(updated.node(id: root.id))
+    }
+
     func testReplacingSubtreesRejectsOverlappingTargets() throws {
         let leaf = makeFileNode(id: "/root/folder/leaf.txt", name: "leaf.txt", size: 4)
         let folder = makeDirectoryNode(id: "/root/folder", name: "folder", children: [leaf])
@@ -1158,6 +1185,24 @@ final class FileTreeStoreTests: XCTestCase {
             XCTAssertTrue(error.localizedDescription.contains(sharedID))
         }
         XCTAssertEqual(store.root.allocatedSize, 2)
+    }
+
+    func testReplacingSubtreesRejectsIDRemovedByAnotherTarget() throws {
+        let oldA = makeFileNode(id: "/root/A", name: "A", size: 1)
+        let oldB = makeFileNode(id: "/root/B", name: "B", size: 1)
+        let root = makeDirectoryNode(id: "/root", name: "root", children: [oldA, oldB])
+        let store = FileTreeStore(root: root, childrenByID: [root.id: [oldA, oldB]])
+        let replacementB = makeFileNode(id: "/root/replacement-B", name: "replacement-B", size: 2)
+
+        XCTAssertThrowsError(try store.replacingSubtrees(
+            [
+                oldA.id: FileTreeStore(root: oldB),
+                oldB.id: FileTreeStore(root: replacementB),
+            ],
+            cancellationCheck: {}
+        )) { error in
+            XCTAssertTrue(error.localizedDescription.contains(oldB.id))
+        }
     }
 
     func testReplacingSubtreesRebalancesHardLinksAcrossReplacementBoundaries() throws {

--- a/RadixCoreTests/IncrementalRescanPlannerTests.swift
+++ b/RadixCoreTests/IncrementalRescanPlannerTests.swift
@@ -129,6 +129,32 @@ final class IncrementalRescanPlannerTests: XCTestCase {
         XCTAssertEqual(plan, .fullScan(reason: .incrementalWorkTooBroad))
     }
 
+    func testSingleBroadSubtreeFallsBackToFullScan() {
+        let changedFiles = (0..<40).map { index in
+            file("/scan/changed/file-\(index).dat")
+        }
+        let changed = directory("/scan/changed", children: changedFiles)
+        let paddingFiles = (0..<20).map { index in
+            file("/scan/padding-\(index).dat")
+        }
+        let rootChildren = [changed] + paddingFiles
+        let root = directory("/scan", children: rootChildren)
+        let store = FileTreeStore(root: root, childrenByID: [
+            root.id: rootChildren,
+            changed.id: changedFiles,
+        ])
+
+        let plan = IncrementalRescanPlanner().plan(
+            history: history([
+                event(changed.id, flags: [.mustScanSubdirectories, .itemIsDirectory]),
+            ]),
+            target: ScanTarget(url: URL(filePath: "/scan", directoryHint: .isDirectory)),
+            treeStore: store
+        )
+
+        XCTAssertEqual(plan, .fullScan(reason: .incrementalWorkTooBroad))
+    }
+
     func testNestedEventsCoalesceToTopLevelChangedSubtree() {
         let fixture = makeFixture()
         let plan = IncrementalRescanPlanner().plan(

--- a/RadixCoreTests/IncrementalRescanPlannerTests.swift
+++ b/RadixCoreTests/IncrementalRescanPlannerTests.swift
@@ -264,6 +264,7 @@ final class IncrementalRescanPlannerTests: XCTestCase {
 
         let cases: [(FileSystemEventFlags, IncrementalRescanFallbackReason)] = [
             ([.itemModified, .itemIsFile], .sharedAllocationTopologyChanged),
+            ([.itemMetadataModified, .itemIsFile], .sharedAllocationTopologyChanged),
             ([.itemCreated, .itemIsFile, .itemIsHardLink], .sharedAllocationTopologyChanged),
             ([.itemRemoved, .itemIsFile, .itemIsLastHardLink], .sharedAllocationTopologyChanged),
         ]
@@ -279,6 +280,25 @@ final class IncrementalRescanPlannerTests: XCTestCase {
 
             XCTAssertEqual(plan, .fullScan(reason: expectedReason))
         }
+    }
+
+    func testDirectoryLinkCountDoesNotRequireSharedAllocationFallback() {
+        let folder = directory("/scan/folder", children: [], linkCount: 12)
+        let root = directory("/scan", children: [folder])
+        let store = FileTreeStore(root: root, childrenByID: [root.id: [folder]])
+
+        let plan = IncrementalRescanPlanner().plan(
+            history: history([
+                event(folder.id, flags: [.itemModified, .itemIsDirectory]),
+            ]),
+            target: ScanTarget(url: URL(filePath: "/scan", directoryHint: .isDirectory)),
+            treeStore: store
+        )
+
+        XCTAssertEqual(plan, .update(
+            relistDirectoryIDs: [],
+            rescanSubtreeIDs: [folder.id]
+        ))
     }
 
     func testEventInsidePackageUsesMaterializedPackageLeaf() {
@@ -319,6 +339,27 @@ final class IncrementalRescanPlannerTests: XCTestCase {
         let plan = IncrementalRescanPlanner().plan(
             history: history([
                 event("/scan/folder/debug.log", flags: [.itemModified, .itemIsFile]),
+            ]),
+            target: ScanTarget(url: URL(filePath: "/scan", directoryHint: .isDirectory)),
+            treeStore: fixture.store,
+            exclusionMatcher: matcher
+        )
+
+        XCTAssertEqual(plan, .noChanges)
+    }
+
+    func testExcludedSharedAllocationEventDoesNotTriggerFullScan() {
+        let fixture = makeFixture()
+        let matcher = ScanExclusionMatcher(
+            patterns: ["*.log"],
+            rootPath: "/scan"
+        )
+        let plan = IncrementalRescanPlanner().plan(
+            history: history([
+                event(
+                    "/scan/folder/debug.log",
+                    flags: [.itemModified, .itemIsFile, .itemCloned, .itemIsHardLink]
+                ),
             ]),
             target: ScanTarget(url: URL(filePath: "/scan", directoryHint: .isDirectory)),
             treeStore: fixture.store,
@@ -393,13 +434,18 @@ final class IncrementalRescanPlannerTests: XCTestCase {
         return (store, folder, package, autoSummary)
     }
 
-    private func directory(_ path: String, children: [FileNodeRecord]) -> FileNodeRecord {
+    private func directory(
+        _ path: String,
+        children: [FileNodeRecord],
+        linkCount: UInt64 = 1
+    ) -> FileNodeRecord {
         FileNodeRecord.directory(
             id: path,
             url: URL(filePath: path, directoryHint: .isDirectory),
             name: URL(filePath: path).lastPathComponent,
             children: children,
             lastModified: nil,
+            linkCount: linkCount,
             isPackage: false,
             isAccessible: true
         )

--- a/RadixCoreTests/IncrementalRescanPlannerTests.swift
+++ b/RadixCoreTests/IncrementalRescanPlannerTests.swift
@@ -221,6 +221,40 @@ final class IncrementalRescanPlannerTests: XCTestCase {
         }
     }
 
+    func testHardLinkEventsRequireFullScan() {
+        let identity = FileIdentity(device: 1, inode: 42)
+        let hardLink = file(
+            "/scan/folder/shared.bin",
+            fileIdentity: identity,
+            linkCount: 2
+        )
+        let folder = directory("/scan/folder", children: [hardLink])
+        let root = directory("/scan", children: [folder])
+        let store = FileTreeStore(root: root, childrenByID: [
+            root.id: [folder],
+            folder.id: [hardLink],
+        ])
+        let target = ScanTarget(url: URL(filePath: "/scan", directoryHint: .isDirectory))
+
+        let cases: [(FileSystemEventFlags, IncrementalRescanFallbackReason)] = [
+            ([.itemModified, .itemIsFile], .sharedAllocationTopologyChanged),
+            ([.itemCreated, .itemIsFile, .itemIsHardLink], .sharedAllocationTopologyChanged),
+            ([.itemRemoved, .itemIsFile, .itemIsLastHardLink], .sharedAllocationTopologyChanged),
+        ]
+        for (flags, expectedReason) in cases {
+            let eventPath = flags.contains(.itemCreated)
+                ? "/scan/folder/new-link.bin"
+                : hardLink.id
+            let plan = IncrementalRescanPlanner().plan(
+                history: history([event(eventPath, flags: flags)]),
+                target: target,
+                treeStore: store
+            )
+
+            XCTAssertEqual(plan, .fullScan(reason: expectedReason))
+        }
+    }
+
     func testEventInsidePackageUsesMaterializedPackageLeaf() {
         let fixture = makeFixture()
         let plan = IncrementalRescanPlanner().plan(
@@ -347,6 +381,8 @@ final class IncrementalRescanPlannerTests: XCTestCase {
 
     private func file(
         _ path: String,
+        fileIdentity: FileIdentity? = nil,
+        linkCount: UInt64 = 1,
         cloneIdentity: CloneIdentity? = nil
     ) -> FileNodeRecord {
         FileNodeRecord(
@@ -359,6 +395,8 @@ final class IncrementalRescanPlannerTests: XCTestCase {
             logicalSize: 1,
             descendantFileCount: 1,
             lastModified: nil,
+            fileIdentity: fileIdentity,
+            linkCount: linkCount,
             cloneIdentity: cloneIdentity,
             isPackage: false,
             isAccessible: true,

--- a/RadixCoreTests/IncrementalScanServiceTests.swift
+++ b/RadixCoreTests/IncrementalScanServiceTests.swift
@@ -17,6 +17,20 @@ final class IncrementalScanServiceTests: XCTestCase {
         )
     }
 
+    func testFSEventFlagMappingPreservesHardLinkEvents() {
+        let rawFlags = FSEventStreamEventFlags(
+            kFSEventStreamEventFlagItemCreated |
+                kFSEventStreamEventFlagItemIsFile |
+                kFSEventStreamEventFlagItemIsHardlink |
+                kFSEventStreamEventFlagItemIsLastHardlink
+        )
+
+        XCTAssertEqual(
+            FileSystemEventFlags(fseventRawValue: rawFlags),
+            [.itemCreated, .itemIsFile, .itemIsHardLink, .itemIsLastHardLink]
+        )
+    }
+
     func testDarwinHistoryProviderCapturesCheckpointForLocalDirectory() throws {
         let rootURL = try makeIncrementalTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: rootURL) }

--- a/RadixCoreTests/IncrementalScanServiceTests.swift
+++ b/RadixCoreTests/IncrementalScanServiceTests.swift
@@ -113,6 +113,26 @@ final class IncrementalScanServiceTests: XCTestCase {
         XCTAssertEqual(result.snapshot.incrementalCheckpoint?.eventID, 10)
     }
 
+    @MainActor
+    func testFullScanCapturesCheckpointOffMainThread() async throws {
+        let rootURL = try makeIncrementalTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+        let history = IncrementalHistoryStub(
+            checkpoints: [checkpoint(10)],
+            events: []
+        )
+        let service = IncrementalScanService(eventHistoryProvider: history)
+
+        _ = try await incrementalScanResult(
+            from: service.scan(
+                target: ScanTarget(url: rootURL),
+                options: ScanOptions()
+            )
+        )
+
+        XCTAssertEqual(history.checkpointMainThreadObservations, [false])
+    }
+
     func testMissingCheckpointReportsFullFallbackReason() async throws {
         let rootURL = try makeIncrementalTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: rootURL) }
@@ -684,6 +704,7 @@ private final class IncrementalHistoryStub: FileSystemEventHistoryProviding, @un
     private let events: [FileSystemEventRecord]
     private let beforeReturningHistory: @Sendable () throws -> Void
     private var historyRequests = 0
+    private var checkpointThreadObservations: [Bool] = []
 
     init(
         checkpoints: [ScanIncrementalCheckpoint],
@@ -701,10 +722,17 @@ private final class IncrementalHistoryStub: FileSystemEventHistoryProviding, @un
         return historyRequests
     }
 
+    var checkpointMainThreadObservations: [Bool] {
+        lock.lock()
+        defer { lock.unlock() }
+        return checkpointThreadObservations
+    }
+
     func currentCheckpoint(for targetURL: URL) throws -> ScanIncrementalCheckpoint {
         _ = targetURL
         lock.lock()
         defer { lock.unlock() }
+        checkpointThreadObservations.append(Thread.isMainThread)
         guard !checkpoints.isEmpty else {
             throw FileSystemEventHistoryError.eventIDUnavailable(targetURL.path)
         }

--- a/RadixCoreTests/ScanCoordinatorTests.swift
+++ b/RadixCoreTests/ScanCoordinatorTests.swift
@@ -408,6 +408,102 @@ final class ScanCoordinatorTests: XCTestCase {
     }
 
     @MainActor
+    func testFolderRescanFallsBackToFullScanForCloneMetadata() async throws {
+        let service = ControlledScanService()
+        let coordinator = ScanCoordinator(
+            scanService: service,
+            progressThrottleDuration: .zero
+        )
+        let rootTarget = makeCoordinatorTarget("/scan/shared")
+        let folderTarget = makeCoordinatorTarget("/scan/shared/Changed")
+        let cloneIdentity = CloneIdentity(device: 1, cloneID: 42)
+        let changedClone = makeTestFileNode(
+            id: folderTarget.id + "/shared.dat",
+            name: "shared.dat",
+            size: 20,
+            cloneIdentity: cloneIdentity,
+            mayShareDataBlocks: true
+        )
+        let siblingClone = makeTestFileNode(
+            id: rootTarget.id + "/shared.dat",
+            name: "shared.dat",
+            size: 0,
+            unduplicatedAllocatedSize: 20,
+            cloneIdentity: cloneIdentity,
+            mayShareDataBlocks: true
+        )
+        let folder = makeTestDirectoryNode(
+            id: folderTarget.id,
+            name: "Changed",
+            children: [changedClone]
+        )
+        let root = makeTestDirectoryNode(
+            id: rootTarget.id,
+            name: "shared",
+            children: [folder, siblingClone]
+        )
+        let baselineStore = FileTreeStore(root: root, childrenByID: [
+            root.id: [folder, siblingClone],
+            folder.id: [changedClone],
+        ])
+        let options = ScanOptions()
+        let baseline = makeCoordinatorSnapshot(
+            target: rootTarget,
+            root: root,
+            store: baselineStore,
+            scanOptions: options
+        )
+        coordinator.restoreCompletedSnapshot(baseline)
+
+        XCTAssertTrue(coordinator.rescanFolder(id: folder.id))
+
+        let replacementFile = makeTestFileNode(
+            id: changedClone.id,
+            name: changedClone.name,
+            size: 40,
+            cloneIdentity: cloneIdentity,
+            mayShareDataBlocks: true
+        )
+        let replacementRoot = makeTestDirectoryNode(
+            id: folder.id,
+            name: folder.name,
+            children: [replacementFile]
+        )
+        service.yield(.finished(makeCoordinatorSnapshot(
+            target: folderTarget,
+            root: replacementRoot,
+            store: FileTreeStore(
+                root: replacementRoot,
+                childrenByID: [replacementRoot.id: [replacementFile]]
+            )
+        )), scanIndex: 0)
+        service.finish(scanIndex: 0)
+
+        try await waitUntil("shared folder rescan starts full fallback") {
+            service.requests.count == 2
+                && coordinator.progress.executionMode
+                    == .fullFallback(.sharedAllocationTopologyChanged)
+        }
+        let fallbackRequest = try XCTUnwrap(service.requests.dropFirst().first)
+        XCTAssertEqual(fallbackRequest.target, rootTarget)
+        XCTAssertEqual(fallbackRequest.options, options)
+
+        let fullSnapshot = makeCoordinatorSnapshot(
+            target: rootTarget,
+            scanOptions: options
+        )
+        service.yield(.finished(fullSnapshot), scanIndex: 1)
+        service.finish(scanIndex: 1)
+
+        try await waitUntil("shared folder full fallback finishes") {
+            coordinator.scanCompletionNotice
+                == .fullFallback(.sharedAllocationTopologyChanged)
+        }
+        XCTAssertEqual(coordinator.snapshot?.id, fullSnapshot.id)
+        XCTAssertNil(coordinator.folderRescanState)
+    }
+
+    @MainActor
     func testFolderRescanRefreshesWholeVolumeCapacityAccounting() async throws {
         let service = ControlledScanService()
         let refreshedCapacity = VolumeCapacitySnapshot(

--- a/RadixCoreTests/ScanCoordinatorTests.swift
+++ b/RadixCoreTests/ScanCoordinatorTests.swift
@@ -487,6 +487,10 @@ final class ScanCoordinatorTests: XCTestCase {
         let fallbackRequest = try XCTUnwrap(service.requests.dropFirst().first)
         XCTAssertEqual(fallbackRequest.target, rootTarget)
         XCTAssertEqual(fallbackRequest.options, options)
+        XCTAssertEqual(
+            coordinator.folderRescanState,
+            FolderRescanState(nodeName: rootTarget.displayName)
+        )
 
         let fullSnapshot = makeCoordinatorSnapshot(
             target: rootTarget,


### PR DESCRIPTION
## Summary

- guard incremental and focused rescans when hard-link or clone changes can invalidate scan-wide allocation ownership
- capture full-scan checkpoints off the main actor and preserve atomic full-scan fallback behavior
- replace dictionary-heavy shallow relists and subtree splices with compact arena traversal while preserving totals, ordering, collisions, and shared-allocation rebalancing
- evaluate broad incremental work for every plan and stop counting once the full-scan threshold is reached

## Review fixes

- distinguish ordinary directory link counts from file hard links so focused rescans do not fall back unnecessarily
- handle inode-metadata changes for existing hard links and ignore clone/hard-link events in excluded paths
- bound large-subtree work estimation at the point where the fallback decision is already known

## Validation

- `swift test --scratch-path .build/.swiftpm` — 818 passed, 24 opt-in/environmental tests skipped, 0 failures
- focused scanner/planner/tree/coordinator suite — 139 passed, 0 failures
- Debug and Release 10k-node incremental benchmarks matched full-scan results; incremental updates remained faster for root, one-directory, and ten-directory mutations, while the 100-directory case correctly chose full fallback
- `xcodebuild -project Radix.xcodeproj -scheme Radix -configuration Debug -destination 'platform=macOS' -derivedDataPath .build/xcode-derived-data build` — succeeded


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved detection of hard links, cloned files, and related filesystem changes.
  * Added safer incremental rescan handling for complex file-sharing changes.
  * Improved preservation and reuse of unchanged file-tree content during partial rescans.
* **Bug Fixes**
  * Folder rescans now automatically fall back to a complete scan when partial updates could produce inaccurate results.
  * Preserved relevant filesystem event details during scanning.
* **Reliability**
  * Improved cancellation handling, checkpoint reporting, snapshot updates, and recovery from interrupted or incomplete scans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->