### PR TITLE
fix(scanner): enforce filesystem identity boundaries

### DIFF
--- a/Radix/Services/AtomicDirectoryParallelSummary.swift
+++ b/Radix/Services/AtomicDirectoryParallelSummary.swift
@@ -480,6 +480,13 @@ extension AtomicDirectorySummarizer {
                 partial.recordWarning(for: childURL, error: error)
                 continue
             }
+            if let boundaryError = item.volumeBoundaryPolicy.descentBoundaryError(
+                for: childURL,
+                childDeviceID: childIdentity.fileSystemDeviceID
+            ) {
+                partial.recordWarning(for: childURL, error: boundaryError)
+                continue
+            }
             pendingItems.append(
                 AtomicSummaryWorkItem(
                     url: childURL,
@@ -487,7 +494,8 @@ extension AtomicDirectorySummarizer {
                         ? true
                         : item.treatPackagesAsDirectories,
                     ownerNodeID: item.ownerNodeID,
-                    expectedIdentity: childIdentity
+                    expectedIdentity: childIdentity,
+                    volumeBoundaryPolicy: item.volumeBoundaryPolicy
                 )
             )
         }
@@ -506,6 +514,7 @@ extension AtomicDirectorySummarizer {
         ownerNodeID: String,
         exclusionMatcher: ScanExclusionMatcher,
         metadataLoader: ScanMetadataLoader,
+        volumeBoundaryPolicy: ScanEngine.ScanVolumeBoundaryPolicy = .unrestricted,
         cancellationCheck: @escaping CancellationCheck,
         metrics: ScanMetrics,
         continuation: AsyncThrowingStream<ScanProgressEvent, Error>.Continuation,
@@ -537,7 +546,8 @@ extension AtomicDirectorySummarizer {
                 url: url,
                 treatPackagesAsDirectories: treatPackagesAsDirectories,
                 ownerNodeID: ownerNodeID,
-                expectedIdentity: expectedRootIdentity
+                expectedIdentity: expectedRootIdentity,
+                volumeBoundaryPolicy: volumeBoundaryPolicy
             )
         ]
         let queue = AtomicSummaryWorkQueue(items: initialItems)
@@ -804,6 +814,14 @@ extension AtomicDirectorySummarizer {
                 continue
             }
 
+            if let boundaryError = item.volumeBoundaryPolicy.descentBoundaryError(
+                for: childURL,
+                childDeviceID: childMetadata.fileIdentity?.fileSystemDeviceID
+            ) {
+                partial.recordWarning(for: childURL, error: boundaryError)
+                continue
+            }
+
             pendingItems.append(
                 AtomicSummaryWorkItem(
                     url: childURL,
@@ -811,7 +829,8 @@ extension AtomicDirectorySummarizer {
                     ownerNodeID: item.ownerNodeID,
                     expectedIdentity: childMetadata.fileIdentity?.isFileSystemIdentity == true
                         ? childMetadata.fileIdentity
-                        : nil
+                        : nil,
+                    volumeBoundaryPolicy: item.volumeBoundaryPolicy
                 )
             )
         }

--- a/Radix/Services/AtomicDirectoryParallelSummary.swift
+++ b/Radix/Services/AtomicDirectoryParallelSummary.swift
@@ -13,23 +13,6 @@ nonisolated private struct AtomicSummaryCancellation: Error {
 
 nonisolated struct AtomicSummaryRootFallbackRequired: Error {}
 
-nonisolated private final class AtomicSummaryWarningCollector: @unchecked Sendable {
-    private let lock = NSLock()
-    private var warnings: [ScanWarning] = []
-
-    func record(for url: URL, error: Error) {
-        lock.lock()
-        warnings.append(ScanWarningFactory.makeWarning(for: url, error: error))
-        lock.unlock()
-    }
-
-    func collectedWarnings() -> [ScanWarning] {
-        lock.lock()
-        defer { lock.unlock() }
-        return warnings
-    }
-}
-
 nonisolated private final class AtomicSummaryWorkQueue: @unchecked Sendable {
     private let condition = NSCondition()
     private var pendingItems: [AtomicSummaryWorkItem]
@@ -223,7 +206,7 @@ extension AtomicDirectorySummarizer {
         includeHiddenFiles: Bool,
         exclusionMatcher: ScanExclusionMatcher,
         metadataLoader: ScanMetadataLoader,
-        cancellationCheck: CancellationCheck,
+        cancellationCheck: @escaping CancellationCheck,
         progressReporter: AtomicSummaryProgressReporter,
         forcesFoundationTraversal: Bool
     ) throws -> AtomicSummaryWorkResult {
@@ -332,51 +315,112 @@ extension AtomicDirectorySummarizer {
         includeHiddenFiles: Bool,
         exclusionMatcher: ScanExclusionMatcher,
         metadataLoader: ScanMetadataLoader,
-        cancellationCheck: CancellationCheck,
+        cancellationCheck: @escaping CancellationCheck,
         progressReporter: AtomicSummaryProgressReporter
     ) throws -> AtomicSummaryWorkResult {
+        var visitedItemCount = 0
+        let result = try processFoundationWorkItem(
+            item,
+            includeHiddenFiles: includeHiddenFiles,
+            exclusionMatcher: exclusionMatcher,
+            metadataLoader: metadataLoader,
+            cancellationCheck: cancellationCheck,
+            progressReporter: progressReporter,
+            progressVisitedItemCount: visitedItemCount
+        )
+        visitedItemCount = ScanIntegerMath.addingClamped(
+            visitedItemCount,
+            result.partial.visitedItemCount
+        )
+        progressReporter.finish(currentURL: item.url, visitedItemCount: visitedItemCount)
+        return result
+    }
+
+    /// Shared classification policy for the rare path-based compatibility
+    /// backend. Results remain local until the post-enumeration identity check.
+    nonisolated static func processFoundationWorkItem(
+        _ item: AtomicSummaryWorkItem,
+        includeHiddenFiles: Bool,
+        exclusionMatcher: ScanExclusionMatcher,
+        metadataLoader: ScanMetadataLoader,
+        cancellationCheck: @escaping CancellationCheck,
+        progressReporter: AtomicSummaryProgressReporter,
+        progressVisitedItemCount: Int,
+        directoryContents: ScanEngine.DirectoryContentsProvider = ScanEngine.defaultDirectoryContents
+    ) throws -> AtomicSummaryWorkResult {
         try cancellationCheck()
+        func warningResult(
+            for url: URL,
+            error: Error,
+            visitedItemCount: Int = 0
+        ) -> AtomicSummaryWorkResult {
+            var partial = AtomicDirectorySummaryPartial()
+            partial.visitedItemCount = visitedItemCount
+            partial.recordWarning(for: url, error: error)
+            return AtomicSummaryWorkResult(partial: partial, pendingItems: [])
+        }
+
+        do {
+            try metadataLoader.validateFileSystemIdentity(item.expectedIdentity, at: item.url)
+        } catch {
+            return warningResult(for: item.url, error: error)
+        }
 
         var options: FileManager.DirectoryEnumerationOptions = [.skipsSubdirectoryDescendants]
         if !includeHiddenFiles {
             options.insert(.skipsHiddenFiles)
         }
 
-        let warningCollector = AtomicSummaryWarningCollector()
-        guard let enumerator = FileManager.default.enumerator(
-            at: item.url,
-            includingPropertiesForKeys: ScanMetadataLoader.atomicSummaryResourceKeys,
-            options: options,
-            errorHandler: { childURL, error in
-                warningCollector.record(for: childURL, error: error)
-                return true
-            }
-        ) else {
-            var partial = AtomicDirectorySummaryPartial()
-            partial.recordWarning(
-                for: item.url,
-                error: NSError(
-                    domain: NSCocoaErrorDomain,
-                    code: NSFileReadUnknownError,
-                    userInfo: [NSURLErrorKey: item.url]
-                )
+        let enumerationResult: ScanEngine.DirectoryEnumerationResult
+        do {
+            enumerationResult = try directoryContents(
+                item.url,
+                ScanMetadataLoader.atomicSummaryResourceKeys,
+                options,
+                cancellationCheck
             )
-            progressReporter.finish(currentURL: item.url, visitedItemCount: 0)
-            return AtomicSummaryWorkResult(partial: partial, pendingItems: [])
+        } catch {
+            try cancellationCheck()
+            return warningResult(for: item.url, error: error)
+        }
+
+        do {
+            try metadataLoader.validateFileSystemIdentity(item.expectedIdentity, at: item.url)
+        } catch {
+            let visitedItemCount = enumerationResult.urls.count
+            let currentProgressVisitedItemCount = ScanIntegerMath.addingClamped(
+                progressVisitedItemCount,
+                visitedItemCount
+            )
+            if let currentURL = enumerationResult.urls.last {
+                progressReporter.emit(
+                    currentURL: currentURL,
+                    visitedItemCount: currentProgressVisitedItemCount
+                )
+            }
+            return warningResult(
+                for: item.url,
+                error: error,
+                visitedItemCount: visitedItemCount
+            )
         }
 
         var partial = AtomicDirectorySummaryPartial()
         var pendingItems: [AtomicSummaryWorkItem] = []
-        var visitedItemCount = 0
-        while let nextObject = enumerator.nextObject() {
+        for childURL in enumerationResult.urls {
             try cancellationCheck()
-            guard let childURL = nextObject as? URL else { continue }
-            visitedItemCount += 1
-            partial.visitedItemCount += 1
-            if visitedItemCount == 1 || visitedItemCount.isMultiple(of: 64) {
+            partial.visitedItemCount = ScanIntegerMath.addingClamped(
+                partial.visitedItemCount,
+                1
+            )
+            let currentProgressVisitedItemCount = ScanIntegerMath.addingClamped(
+                progressVisitedItemCount,
+                partial.visitedItemCount
+            )
+            if currentProgressVisitedItemCount == 1 || currentProgressVisitedItemCount.isMultiple(of: 64) {
                 progressReporter.emit(
                     currentURL: childURL,
-                    visitedItemCount: visitedItemCount
+                    visitedItemCount: currentProgressVisitedItemCount
                 )
             }
 
@@ -429,23 +473,28 @@ extension AtomicDirectorySummarizer {
                 continue
             }
 
+            let childIdentity: FileIdentity
+            do {
+                childIdentity = try metadataLoader.fileSystemIdentity(at: childURL)
+            } catch {
+                partial.recordWarning(for: childURL, error: error)
+                continue
+            }
             pendingItems.append(
                 AtomicSummaryWorkItem(
                     url: childURL,
                     treatPackagesAsDirectories: childMetadata.isPackage
                         ? true
                         : item.treatPackagesAsDirectories,
-                    ownerNodeID: item.ownerNodeID
+                    ownerNodeID: item.ownerNodeID,
+                    expectedIdentity: childIdentity
                 )
             )
         }
 
-        let localizedWarnings = warningCollector.collectedWarnings()
-        if !localizedWarnings.isEmpty {
-            partial.isAccessible = false
-            partial.warnings.append(contentsOf: localizedWarnings)
+        for failure in enumerationResult.localizedFailures {
+            partial.recordWarning(for: failure.url, error: failure.error)
         }
-        progressReporter.finish(currentURL: item.url, visitedItemCount: visitedItemCount)
         return AtomicSummaryWorkResult(partial: partial, pendingItems: pendingItems)
     }
 
@@ -461,7 +510,8 @@ extension AtomicDirectorySummarizer {
         metrics: ScanMetrics,
         continuation: AsyncThrowingStream<ScanProgressEvent, Error>.Continuation,
         resumeState: AtomicDirectoryProbeResumeState? = nil,
-        forcesFoundationTraversal: Bool = false
+        forcesFoundationTraversal: Bool = false,
+        expectedRootIdentity: FileIdentity? = nil
     ) async throws -> AtomicDirectorySummary? {
         try cancellationCheck()
         #if DEBUG
@@ -486,7 +536,8 @@ extension AtomicDirectorySummarizer {
             AtomicSummaryWorkItem(
                 url: url,
                 treatPackagesAsDirectories: treatPackagesAsDirectories,
-                ownerNodeID: ownerNodeID
+                ownerNodeID: ownerNodeID,
+                expectedIdentity: expectedRootIdentity
             )
         ]
         let queue = AtomicSummaryWorkQueue(items: initialItems)
@@ -554,7 +605,7 @@ extension AtomicDirectorySummarizer {
         accumulator: AtomicSummaryAccumulator,
         queue: AtomicSummaryWorkQueue,
         metadataLoader: ScanMetadataLoader,
-        cancellationCheck: CancellationCheck,
+        cancellationCheck: @escaping CancellationCheck,
         progressReporter: AtomicSummaryProgressReporter,
         workerVisitedItemCount: inout Int,
         forcesFoundationTraversal: Bool
@@ -757,7 +808,10 @@ extension AtomicDirectorySummarizer {
                 AtomicSummaryWorkItem(
                     url: childURL,
                     treatPackagesAsDirectories: childMetadata.isPackage ? true : item.treatPackagesAsDirectories,
-                    ownerNodeID: item.ownerNodeID
+                    ownerNodeID: item.ownerNodeID,
+                    expectedIdentity: childMetadata.fileIdentity?.isFileSystemIdentity == true
+                        ? childMetadata.fileIdentity
+                        : nil
                 )
             )
         }
@@ -773,99 +827,26 @@ extension AtomicDirectorySummarizer {
         accumulator: AtomicSummaryAccumulator,
         queue: AtomicSummaryWorkQueue,
         metadataLoader: ScanMetadataLoader,
-        cancellationCheck: CancellationCheck,
+        cancellationCheck: @escaping CancellationCheck,
         progressReporter: AtomicSummaryProgressReporter,
         workerVisitedItemCount: inout Int
     ) throws {
-        try cancellationCheck()
-
-        var options: FileManager.DirectoryEnumerationOptions = [.skipsSubdirectoryDescendants]
-        if !includeHiddenFiles {
-            options.insert(.skipsHiddenFiles)
+        let result = try processFoundationWorkItem(
+            item,
+            includeHiddenFiles: includeHiddenFiles,
+            exclusionMatcher: exclusionMatcher,
+            metadataLoader: metadataLoader,
+            cancellationCheck: cancellationCheck,
+            progressReporter: progressReporter,
+            progressVisitedItemCount: workerVisitedItemCount
+        )
+        workerVisitedItemCount = ScanIntegerMath.addingClamped(
+            workerVisitedItemCount,
+            result.partial.visitedItemCount
+        )
+        accumulator.merge(result.partial)
+        for pendingItem in result.pendingItems {
+            queue.enqueue(pendingItem)
         }
-
-        guard let enumerator = FileManager.default.enumerator(
-            at: item.url,
-            includingPropertiesForKeys: ScanMetadataLoader.atomicSummaryResourceKeys,
-            options: options,
-            errorHandler: { childURL, error in
-                accumulator.recordWarning(for: childURL, error: error)
-                return true
-            }
-        ) else {
-            accumulator.recordWarning(
-                for: item.url,
-                error: NSError(
-                    domain: NSCocoaErrorDomain,
-                    code: NSFileReadUnknownError,
-                    userInfo: [NSURLErrorKey: item.url]
-                )
-            )
-            return
-        }
-
-        var partial = AtomicDirectorySummaryPartial()
-        while let nextObject = enumerator.nextObject() {
-            try cancellationCheck()
-            guard let childURL = nextObject as? URL else { continue }
-            workerVisitedItemCount += 1
-            partial.visitedItemCount += 1
-            if workerVisitedItemCount == 1 || workerVisitedItemCount.isMultiple(of: 64) {
-                progressReporter.emit(
-                    currentURL: childURL,
-                    visitedItemCount: workerVisitedItemCount
-                )
-            }
-
-            let hintedIsDirectory = childURL.hasDirectoryPath
-            let childPath = childURL.path
-            guard !exclusionMatcher.excludesKnownNormalizedPath(
-                childPath,
-                isDirectory: hintedIsDirectory
-            ) else {
-                continue
-            }
-
-            let childMetadata: NodeMetadata
-            do {
-                let values = try childURL.resourceValues(forKeys: ScanMetadataLoader.atomicSummaryResourceKeySet)
-                childMetadata = metadataLoader.atomicSummaryMetadata(for: childURL, prefetchedResourceValues: values)
-            } catch {
-                partial.recordWarning(for: childURL, error: error)
-                continue
-            }
-
-            guard childMetadata.isDirectory == hintedIsDirectory ||
-                    !exclusionMatcher.excludesKnownNormalizedPath(
-                        childPath,
-                        isDirectory: childMetadata.isDirectory
-                    ) else {
-                continue
-            }
-            guard !childMetadata.isDataless else { continue }
-
-            partial.updateAccessibility(childMetadata.isReadable)
-
-            guard childMetadata.isDirectory else {
-                partial.accumulateFile(childMetadata, url: childURL, ownerNodeID: item.ownerNodeID)
-                continue
-            }
-
-            let isTraversablePackageSymlink = childMetadata.isSymbolicLink
-                && childMetadata.isPackage
-                && !item.treatPackagesAsDirectories
-            guard !childMetadata.isSymbolicLink || isTraversablePackageSymlink else {
-                continue
-            }
-
-            queue.enqueue(
-                AtomicSummaryWorkItem(
-                    url: childURL,
-                    treatPackagesAsDirectories: childMetadata.isPackage ? true : item.treatPackagesAsDirectories,
-                    ownerNodeID: item.ownerNodeID
-                )
-            )
-        }
-        accumulator.merge(partial)
     }
 }

--- a/Radix/Services/AtomicDirectorySummarizer.swift
+++ b/Radix/Services/AtomicDirectorySummarizer.swift
@@ -15,6 +15,7 @@ nonisolated struct AtomicDirectorySummarizer: Sendable {
     let metadataLoader: ScanMetadataLoader
     let diagnostics: ScanDiagnosticsContext?
     let summaryPool: AtomicDirectorySummaryPool?
+    let volumeBoundaryPolicy: ScanEngine.ScanVolumeBoundaryPolicy
     #if DEBUG
     let profileReporter: ProfileReporter?
     #endif
@@ -22,11 +23,13 @@ nonisolated struct AtomicDirectorySummarizer: Sendable {
     init(
         metadataLoader: ScanMetadataLoader,
         diagnostics: ScanDiagnosticsContext? = nil,
-        summaryPool: AtomicDirectorySummaryPool? = nil
+        summaryPool: AtomicDirectorySummaryPool? = nil,
+        volumeBoundaryPolicy: ScanEngine.ScanVolumeBoundaryPolicy = .unrestricted
     ) {
         self.metadataLoader = metadataLoader
         self.diagnostics = diagnostics
         self.summaryPool = summaryPool
+        self.volumeBoundaryPolicy = volumeBoundaryPolicy
         #if DEBUG
         self.profileReporter = nil
         #endif
@@ -37,11 +40,13 @@ nonisolated struct AtomicDirectorySummarizer: Sendable {
         metadataLoader: ScanMetadataLoader,
         diagnostics: ScanDiagnosticsContext? = nil,
         summaryPool: AtomicDirectorySummaryPool? = nil,
+        volumeBoundaryPolicy: ScanEngine.ScanVolumeBoundaryPolicy = .unrestricted,
         profileReporter: ProfileReporter?
     ) {
         self.metadataLoader = metadataLoader
         self.diagnostics = diagnostics
         self.summaryPool = summaryPool
+        self.volumeBoundaryPolicy = volumeBoundaryPolicy
         self.profileReporter = profileReporter
     }
     #endif
@@ -239,6 +244,7 @@ nonisolated struct AtomicDirectorySummarizer: Sendable {
                         treatPackagesAsDirectories: treatPackagesAsDirectories,
                         ownerNodeID: url.path,
                         expectedIdentity: expectedRootIdentity,
+                        volumeBoundaryPolicy: volumeBoundaryPolicy,
                         bufferedEntries: childEntries,
                         needsCursor: false,
                         reloadsMissingBufferedMetadata: true
@@ -368,6 +374,7 @@ nonisolated struct AtomicDirectorySummarizer: Sendable {
                     ownerNodeID: ownerNodeID,
                     exclusionMatcher: exclusionMatcher,
                     metadataLoader: metadataLoader,
+                    volumeBoundaryPolicy: volumeBoundaryPolicy,
                     cancellationCheck: cancellationCheck,
                     metrics: metrics,
                     continuation: continuation,
@@ -398,6 +405,7 @@ nonisolated struct AtomicDirectorySummarizer: Sendable {
                     ownerNodeID: ownerNodeID,
                     exclusionMatcher: exclusionMatcher,
                     metadataLoader: metadataLoader,
+                    volumeBoundaryPolicy: volumeBoundaryPolicy,
                     cancellationCheck: cancellationCheck,
                     metrics: metrics,
                     continuation: continuation,
@@ -414,6 +422,7 @@ nonisolated struct AtomicDirectorySummarizer: Sendable {
                     ownerNodeID: ownerNodeID,
                     exclusionMatcher: exclusionMatcher,
                     metadataLoader: metadataLoader,
+                    volumeBoundaryPolicy: volumeBoundaryPolicy,
                     cancellationCheck: cancellationCheck,
                     metrics: metrics,
                     continuation: continuation,

--- a/Radix/Services/AtomicDirectorySummarizer.swift
+++ b/Radix/Services/AtomicDirectorySummarizer.swift
@@ -89,6 +89,7 @@ nonisolated struct AtomicDirectorySummarizer: Sendable {
         url: URL,
         childEntries: [DirectoryEntry],
         metadata: NodeMetadata,
+        expectedRootIdentity: FileIdentity? = nil,
         includeHiddenFiles: Bool,
         treatPackagesAsDirectories: Bool,
         isNodeDependencyLayout: Bool,
@@ -106,6 +107,7 @@ nonisolated struct AtomicDirectorySummarizer: Sendable {
             url: url,
             childEntries: childEntries,
             metadata: metadata,
+            expectedRootIdentity: expectedRootIdentity,
             includeHiddenFiles: includeHiddenFiles,
             treatPackagesAsDirectories: treatPackagesAsDirectories,
             isNodeDependencyLayout: isNodeDependencyLayout,
@@ -125,6 +127,7 @@ nonisolated struct AtomicDirectorySummarizer: Sendable {
         url: URL,
         childEntries: [DirectoryEntry],
         metadata: NodeMetadata,
+        expectedRootIdentity: FileIdentity? = nil,
         includeHiddenFiles: Bool,
         treatPackagesAsDirectories: Bool,
         isNodeDependencyLayout: Bool,
@@ -235,6 +238,7 @@ nonisolated struct AtomicDirectorySummarizer: Sendable {
                         url: url,
                         treatPackagesAsDirectories: treatPackagesAsDirectories,
                         ownerNodeID: url.path,
+                        expectedIdentity: expectedRootIdentity,
                         bufferedEntries: childEntries,
                         needsCursor: false,
                         reloadsMissingBufferedMetadata: true
@@ -250,6 +254,7 @@ nonisolated struct AtomicDirectorySummarizer: Sendable {
                     progressKind: .autoSummary,
                     representedItemCount: childEntries.count,
                     ownerNodeID: url.path,
+                    expectedRootIdentity: expectedRootIdentity,
                     exclusionMatcher: exclusionMatcher,
                     cancellationCheck: cancellationCheck,
                     metrics: &metrics,
@@ -292,6 +297,7 @@ nonisolated struct AtomicDirectorySummarizer: Sendable {
             progressKind: .autoSummary,
             representedItemCount: childEntries.count,
             ownerNodeID: url.path,
+            expectedRootIdentity: expectedRootIdentity,
             exclusionMatcher: exclusionMatcher,
             cancellationCheck: cancellationCheck,
             metrics: &metrics,
@@ -337,6 +343,7 @@ nonisolated struct AtomicDirectorySummarizer: Sendable {
         progressKind: AtomicSummaryProgressKind = .autoSummary,
         representedItemCount: Int = 0,
         ownerNodeID: String,
+        expectedRootIdentity: FileIdentity? = nil,
         exclusionMatcher: ScanExclusionMatcher,
         cancellationCheck: @escaping CancellationCheck,
         metrics: inout ScanMetrics,
@@ -352,6 +359,7 @@ nonisolated struct AtomicDirectorySummarizer: Sendable {
             let summary = try await summaryPool.summarize(
                 AtomicSummaryPoolRequest(
                     url: url,
+                    expectedRootIdentity: expectedRootIdentity,
                     includeHiddenFiles: includeHiddenFiles,
                     treatPackagesAsDirectories: treatPackagesAsDirectories,
                     progressWeight: progressWeight,
@@ -393,7 +401,8 @@ nonisolated struct AtomicDirectorySummarizer: Sendable {
                     cancellationCheck: cancellationCheck,
                     metrics: metrics,
                     continuation: continuation,
-                    resumeState: resumeState
+                    resumeState: resumeState,
+                    expectedRootIdentity: expectedRootIdentity
                 )
             } catch is AtomicSummaryRootFallbackRequired {
                 resumeState?.invalidateCursors()
@@ -408,7 +417,8 @@ nonisolated struct AtomicDirectorySummarizer: Sendable {
                     cancellationCheck: cancellationCheck,
                     metrics: metrics,
                     continuation: continuation,
-                    forcesFoundationTraversal: true
+                    forcesFoundationTraversal: true,
+                    expectedRootIdentity: expectedRootIdentity
                 )
             }
             #if DEBUG
@@ -429,6 +439,7 @@ nonisolated struct AtomicDirectorySummarizer: Sendable {
             treatPackagesAsDirectories: treatPackagesAsDirectories,
             workerLimit: workerLimit,
             ownerNodeID: ownerNodeID,
+            expectedRootIdentity: expectedRootIdentity,
             exclusionMatcher: exclusionMatcher,
             cancellationCheck: cancellationCheck,
             metrics: &metrics,

--- a/Radix/Services/AtomicDirectorySummaryModels.swift
+++ b/Radix/Services/AtomicDirectorySummaryModels.swift
@@ -91,6 +91,7 @@ nonisolated struct AtomicSummaryWorkItem: @unchecked Sendable {
     let url: URL
     let treatPackagesAsDirectories: Bool
     let ownerNodeID: String
+    let expectedIdentity: FileIdentity?
     var bufferedEntries: [DirectoryEntry]
     var nextEntryIndex: Int
     var cursor: BulkDirectoryEnumerator.Cursor?
@@ -106,6 +107,7 @@ nonisolated struct AtomicSummaryWorkItem: @unchecked Sendable {
         url: URL,
         treatPackagesAsDirectories: Bool,
         ownerNodeID: String,
+        expectedIdentity: FileIdentity? = nil,
         bufferedEntries: [DirectoryEntry] = [],
         nextEntryIndex: Int = 0,
         cursor: BulkDirectoryEnumerator.Cursor? = nil,
@@ -116,6 +118,7 @@ nonisolated struct AtomicSummaryWorkItem: @unchecked Sendable {
         self.url = url
         self.treatPackagesAsDirectories = treatPackagesAsDirectories
         self.ownerNodeID = ownerNodeID
+        self.expectedIdentity = expectedIdentity
         self.bufferedEntries = bufferedEntries
         self.nextEntryIndex = nextEntryIndex
         self.cursor = cursor

--- a/Radix/Services/AtomicDirectorySummaryModels.swift
+++ b/Radix/Services/AtomicDirectorySummaryModels.swift
@@ -92,6 +92,7 @@ nonisolated struct AtomicSummaryWorkItem: @unchecked Sendable {
     let treatPackagesAsDirectories: Bool
     let ownerNodeID: String
     let expectedIdentity: FileIdentity?
+    let volumeBoundaryPolicy: ScanEngine.ScanVolumeBoundaryPolicy
     var bufferedEntries: [DirectoryEntry]
     var nextEntryIndex: Int
     var cursor: BulkDirectoryEnumerator.Cursor?
@@ -108,6 +109,7 @@ nonisolated struct AtomicSummaryWorkItem: @unchecked Sendable {
         treatPackagesAsDirectories: Bool,
         ownerNodeID: String,
         expectedIdentity: FileIdentity? = nil,
+        volumeBoundaryPolicy: ScanEngine.ScanVolumeBoundaryPolicy = .unrestricted,
         bufferedEntries: [DirectoryEntry] = [],
         nextEntryIndex: Int = 0,
         cursor: BulkDirectoryEnumerator.Cursor? = nil,
@@ -119,6 +121,7 @@ nonisolated struct AtomicSummaryWorkItem: @unchecked Sendable {
         self.treatPackagesAsDirectories = treatPackagesAsDirectories
         self.ownerNodeID = ownerNodeID
         self.expectedIdentity = expectedIdentity
+        self.volumeBoundaryPolicy = volumeBoundaryPolicy
         self.bufferedEntries = bufferedEntries
         self.nextEntryIndex = nextEntryIndex
         self.cursor = cursor

--- a/Radix/Services/AtomicDirectorySummaryPool.swift
+++ b/Radix/Services/AtomicDirectorySummaryPool.swift
@@ -45,6 +45,7 @@ nonisolated struct AtomicSummaryPoolRequest: @unchecked Sendable {
     let ownerNodeID: String
     let exclusionMatcher: ScanExclusionMatcher
     let metadataLoader: ScanMetadataLoader
+    let volumeBoundaryPolicy: ScanEngine.ScanVolumeBoundaryPolicy
     let cancellationCheck: CancellationCheck
     let metrics: ScanMetrics
     let continuation: AsyncThrowingStream<ScanProgressEvent, Error>.Continuation
@@ -619,7 +620,8 @@ nonisolated final class AtomicDirectorySummaryPool: @unchecked Sendable {
                 url: request.url,
                 treatPackagesAsDirectories: request.treatPackagesAsDirectories,
                 ownerNodeID: request.ownerNodeID,
-                expectedIdentity: request.expectedRootIdentity
+                expectedIdentity: request.expectedRootIdentity,
+                volumeBoundaryPolicy: request.volumeBoundaryPolicy
             )
         ]
 
@@ -820,7 +822,8 @@ nonisolated final class AtomicDirectorySummaryPool: @unchecked Sendable {
                     url: job.request.url,
                     treatPackagesAsDirectories: job.request.treatPackagesAsDirectories,
                     ownerNodeID: job.request.ownerNodeID,
-                    expectedIdentity: job.request.expectedRootIdentity
+                    expectedIdentity: job.request.expectedRootIdentity,
+                    volumeBoundaryPolicy: job.request.volumeBoundaryPolicy
                 )
             )
             makeRunnableLocked(job)

--- a/Radix/Services/AtomicDirectorySummaryPool.swift
+++ b/Radix/Services/AtomicDirectorySummaryPool.swift
@@ -35,6 +35,7 @@ nonisolated private final class AtomicSummaryGenerationToken: @unchecked Sendabl
 
 nonisolated struct AtomicSummaryPoolRequest: @unchecked Sendable {
     let url: URL
+    let expectedRootIdentity: FileIdentity?
     let includeHiddenFiles: Bool
     let treatPackagesAsDirectories: Bool
     let progressWeight: Double
@@ -617,7 +618,8 @@ nonisolated final class AtomicDirectorySummaryPool: @unchecked Sendable {
             AtomicSummaryWorkItem(
                 url: request.url,
                 treatPackagesAsDirectories: request.treatPackagesAsDirectories,
-                ownerNodeID: request.ownerNodeID
+                ownerNodeID: request.ownerNodeID,
+                expectedIdentity: request.expectedRootIdentity
             )
         ]
 
@@ -817,7 +819,8 @@ nonisolated final class AtomicDirectorySummaryPool: @unchecked Sendable {
                 AtomicSummaryWorkItem(
                     url: job.request.url,
                     treatPackagesAsDirectories: job.request.treatPackagesAsDirectories,
-                    ownerNodeID: job.request.ownerNodeID
+                    ownerNodeID: job.request.ownerNodeID,
+                    expectedIdentity: job.request.expectedRootIdentity
                 )
             )
             makeRunnableLocked(job)

--- a/Radix/Services/AtomicDirectorySummaryProbe.swift
+++ b/Radix/Services/AtomicDirectorySummaryProbe.swift
@@ -215,6 +215,16 @@ extension AtomicDirectorySummarizer {
                     continue
                 }
 
+                if isDirectory, volumeBoundaryPolicy.requiresChildDeviceIdentity {
+                    let childIdentity = try metadataLoader.fileSystemIdentity(at: childURL)
+                    if volumeBoundaryPolicy.shouldStopDescent(
+                        childDeviceID: childIdentity.fileSystemDeviceID
+                    ) {
+                        enumerator.skipDescendants()
+                        continue
+                    }
+                }
+
                 if Self.isNodeDependencyLayoutDirectory(at: childURL) {
                     profile.observedNodeDependencyLayout = true
                 }
@@ -307,6 +317,7 @@ extension AtomicDirectorySummarizer {
                 url: url,
                 treatPackagesAsDirectories: treatPackagesAsDirectories,
                 ownerNodeID: url.path,
+                volumeBoundaryPolicy: volumeBoundaryPolicy,
                 bufferedEntries: rootEntries,
                 needsCursor: false
             ),
@@ -450,6 +461,16 @@ extension AtomicDirectorySummarizer {
                 continue
             }
 
+            if metadata.isDirectory,
+               let boundaryError = frames[frameIndex].workItem.volumeBoundaryPolicy
+                   .descentBoundaryError(
+                       for: entry.url,
+                       childDeviceID: metadata.fileIdentity?.fileSystemDeviceID
+                   ) {
+                partial.recordWarning(for: entry.url, error: boundaryError)
+                continue
+            }
+
             if Self.isNodeDependencyLayoutDirectory(at: entry.url) {
                 profile.observedNodeDependencyLayout = true
             }
@@ -483,7 +504,9 @@ extension AtomicDirectorySummarizer {
                             workItem: AtomicSummaryWorkItem(
                                 url: entry.url,
                                 treatPackagesAsDirectories: treatsPackagesAsDirectories,
-                                ownerNodeID: frames[frameIndex].workItem.ownerNodeID
+                                ownerNodeID: frames[frameIndex].workItem.ownerNodeID,
+                                volumeBoundaryPolicy: frames[frameIndex].workItem
+                                    .volumeBoundaryPolicy
                             ),
                             retainsReusableListing: !treatsPackagesAsDirectories
                         )

--- a/Radix/Services/AtomicDirectorySummaryWalker.swift
+++ b/Radix/Services/AtomicDirectorySummaryWalker.swift
@@ -35,6 +35,7 @@ extension AtomicDirectorySummarizer {
                 ownerNodeID: ownerNodeID,
                 exclusionMatcher: exclusionMatcher,
                 metadataLoader: metadataLoader,
+                volumeBoundaryPolicy: volumeBoundaryPolicy,
                 cancellationCheck: cancellationCheck,
                 metrics: metrics,
                 continuation: continuation,
@@ -51,6 +52,7 @@ extension AtomicDirectorySummarizer {
                 ownerNodeID: ownerNodeID,
                 exclusionMatcher: exclusionMatcher,
                 metadataLoader: metadataLoader,
+                volumeBoundaryPolicy: volumeBoundaryPolicy,
                 cancellationCheck: cancellationCheck,
                 metrics: metrics,
                 continuation: continuation,
@@ -176,6 +178,13 @@ extension AtomicDirectorySummarizer {
         updateAtomicAccessibility(metadata.isReadable, in: state)
 
         if metadata.isDirectory {
+            if let boundaryError = volumeBoundaryPolicy.descentBoundaryError(
+                for: url,
+                childDeviceID: metadata.fileIdentity?.fileSystemDeviceID
+            ) {
+                recordAtomicWarning(for: url, error: boundaryError, in: state)
+                return
+            }
             let nestedTreatsPackagesAsDirectories = metadata.isPackage ? true : treatPackagesAsDirectories
             if metadata.isPackage || !metadata.isSymbolicLink {
                 if let nestedSummary = try await summarize(

--- a/Radix/Services/AtomicDirectorySummaryWalker.swift
+++ b/Radix/Services/AtomicDirectorySummaryWalker.swift
@@ -14,6 +14,7 @@ extension AtomicDirectorySummarizer {
         treatPackagesAsDirectories: Bool,
         workerLimit: Int,
         ownerNodeID: String,
+        expectedRootIdentity: FileIdentity? = nil,
         exclusionMatcher: ScanExclusionMatcher,
         cancellationCheck: @escaping CancellationCheck,
         metrics: inout ScanMetrics,
@@ -37,7 +38,8 @@ extension AtomicDirectorySummarizer {
                 cancellationCheck: cancellationCheck,
                 metrics: metrics,
                 continuation: continuation,
-                resumeState: resumeState
+                resumeState: resumeState,
+                expectedRootIdentity: expectedRootIdentity
             )
         } catch is AtomicSummaryRootFallbackRequired {
             resumeState?.invalidateCursors()
@@ -52,7 +54,8 @@ extension AtomicDirectorySummarizer {
                 cancellationCheck: cancellationCheck,
                 metrics: metrics,
                 continuation: continuation,
-                forcesFoundationTraversal: true
+                forcesFoundationTraversal: true,
+                expectedRootIdentity: expectedRootIdentity
             )
         }
         #if DEBUG
@@ -181,6 +184,7 @@ extension AtomicDirectorySummarizer {
                     treatPackagesAsDirectories: nestedTreatsPackagesAsDirectories,
                     workerLimit: workerLimit,
                     ownerNodeID: state.ownerNodeID,
+                    expectedRootIdentity: metadata.fileIdentity,
                     exclusionMatcher: exclusionMatcher,
                     cancellationCheck: cancellationCheck,
                     metrics: &metrics,

--- a/Radix/Services/ScanEngine.swift
+++ b/Radix/Services/ScanEngine.swift
@@ -152,6 +152,19 @@ actor ScanEngine {
         let mountPath: String
         let deviceName: String
         let fileSystemType: String
+        let deviceID: UInt64?
+
+        init(
+            mountPath: String,
+            deviceName: String,
+            fileSystemType: String,
+            deviceID: UInt64? = nil
+        ) {
+            self.mountPath = mountPath
+            self.deviceName = deviceName
+            self.fileSystemType = fileSystemType
+            self.deviceID = deviceID
+        }
     }
 
     /// Decides whether directory traversal may cross a device boundary. Nested
@@ -161,8 +174,7 @@ actor ScanEngine {
     /// traversable (a startup-scan must reach the Data volume's user data).
     nonisolated struct ScanVolumeBoundaryPolicy: Sendable {
         private let rootDeviceID: UInt64?
-        private let rootContainerID: String?
-        private let containerMountPaths: [String]
+        private let containerDeviceIDs: Set<UInt64>
 
         static func resolve(
             rootPath: String,
@@ -171,43 +183,41 @@ actor ScanEngine {
         ) -> ScanVolumeBoundaryPolicy {
             let normalizedRootPath = normalizedMountPath(rootPath)
             let rootMount = mountedFileSystems
-                .filter { isPath(normalizedRootPath, within: $0.mountPath) }
+                .filter {
+                    isPath(
+                        normalizedRootPath,
+                        within: normalizedMountPath($0.mountPath)
+                    )
+                }
                 .max { $0.mountPath.count < $1.mountPath.count }
             guard let rootMount,
                   let rootContainerID = containerIdentifier(of: rootMount) else {
                 return ScanVolumeBoundaryPolicy(
                     rootDeviceID: rootDeviceID,
-                    rootContainerID: nil,
-                    containerMountPaths: []
+                    containerDeviceIDs: []
                 )
             }
 
-            let containerMountPaths = mountedFileSystems
+            let containerDeviceIDs = Set(mountedFileSystems
                 .filter {
                     $0.fileSystemType == "apfs"
                         && containerIdentifier(of: $0) == rootContainerID
                 }
-                .map { normalizedMountPath($0.mountPath) }
-                .sorted { $0.count > $1.count }
+                .compactMap(\.deviceID))
 
             return ScanVolumeBoundaryPolicy(
                 rootDeviceID: rootDeviceID,
-                rootContainerID: rootContainerID,
-                containerMountPaths: containerMountPaths
+                containerDeviceIDs: containerDeviceIDs
             )
         }
 
-        func shouldStopDescent(childPath: String, childDeviceID: UInt64?) -> Bool {
+        func shouldStopDescent(childDeviceID: UInt64?) -> Bool {
             guard let childDeviceID,
                   let rootDeviceID else {
                 return false
             }
             guard childDeviceID != rootDeviceID else { return false }
-
-            let normalizedChildPath = Self.normalizedMountPath(childPath)
-            return !containerMountPaths.contains { mountPath in
-                Self.isPath(normalizedChildPath, within: mountPath)
-            }
+            return !containerDeviceIDs.contains(childDeviceID)
         }
 
         private static func normalizedMountPath(_ path: String) -> String {
@@ -219,7 +229,10 @@ actor ScanEngine {
         }
 
         private static func isPath(_ path: String, within mountPath: String) -> Bool {
-            path == mountPath || path.hasPrefix(mountPath + "/")
+            if mountPath == "/" {
+                return path.hasPrefix("/")
+            }
+            return path == mountPath || path.hasPrefix(mountPath + "/")
         }
 
         /// APFS synthesizer names encode the container in the disk number:
@@ -713,10 +726,24 @@ actor ScanEngine {
             }
             let mountPath = cString(from: entry.f_mntonname)
             guard !mountPath.isEmpty else { return nil }
+            let fileSystemType = cString(from: entry.f_fstypename)
+            let deviceID: UInt64?
+            if fileSystemType == "apfs" {
+                var mountStatus = stat()
+                let statusResult = mountPath.withCString { path in
+                    lstat(path, &mountStatus)
+                }
+                deviceID = statusResult == 0
+                    ? UInt64(truncatingIfNeeded: mountStatus.st_dev)
+                    : nil
+            } else {
+                deviceID = nil
+            }
             return ScanMountedFileSystem(
                 mountPath: mountPath,
                 deviceName: cString(from: entry.f_mntfromname),
-                fileSystemType: cString(from: entry.f_fstypename)
+                fileSystemType: fileSystemType,
+                deviceID: deviceID
             )
         }
     }
@@ -1426,7 +1453,6 @@ actor ScanEngine {
 
                     if shouldTraverseDirectory(metadata: meta, options: options),
                        !volumeBoundaryPolicy.shouldStopDescent(
-                           childPath: item.url.standardizedFileURL.path,
                            childDeviceID: meta.fileIdentity?.fileSystemDeviceID
                        ) {
                         metrics.directoriesVisited += 1
@@ -2744,18 +2770,11 @@ actor ScanEngine {
             options.insert(.skipsHiddenFiles)
         }
 
-        if let expectedIdentity, expectedIdentity.isFileSystemIdentity {
-            let currentMetadata = try metadataLoader.metadata(for: url)
-            if let currentIdentity = currentMetadata.fileIdentity,
-               currentIdentity.isFileSystemIdentity,
-               currentIdentity != expectedIdentity {
-                throw NSError(
-                    domain: NSPOSIXErrorDomain,
-                    code: Int(ESTALE),
-                    userInfo: [NSURLErrorKey: url]
-                )
-            }
-        }
+        try verifyFoundationDirectoryIdentity(
+            expectedIdentity,
+            at: url,
+            metadataLoader: metadataLoader
+        )
 
         let prefetchKeys = shouldFilterStartupVolumeInternals(under: url, behavior: behavior)
             ? nil
@@ -2764,6 +2783,14 @@ actor ScanEngine {
         let enumerationStart = DispatchTime.now().uptimeNanoseconds
         #endif
         let enumerationResult = try directoryContents(url, prefetchKeys, options, cancellationCheck)
+        // FileManager has no descriptor-relative directory API. Bookend its
+        // path-based enumeration so any replacement that persists across the
+        // call is discarded instead of entering the scan.
+        try verifyFoundationDirectoryIdentity(
+            expectedIdentity,
+            at: url,
+            metadataLoader: metadataLoader
+        )
         #if DEBUG
         let enumerationNanoseconds = DispatchTime.now().uptimeNanoseconds - enumerationStart
         #endif
@@ -2826,6 +2853,24 @@ actor ScanEngine {
             directoryLease: nil
         )
         #endif
+    }
+
+    private nonisolated static func verifyFoundationDirectoryIdentity(
+        _ expectedIdentity: FileIdentity?,
+        at url: URL,
+        metadataLoader: ScanMetadataLoader
+    ) throws {
+        guard let expectedIdentity, expectedIdentity.isFileSystemIdentity else { return }
+        let currentIdentity = try metadataLoader.metadata(for: url).fileIdentity
+        guard let currentIdentity,
+              currentIdentity.isFileSystemIdentity,
+              currentIdentity == expectedIdentity else {
+            throw NSError(
+                domain: NSPOSIXErrorDomain,
+                code: Int(ESTALE),
+                userInfo: [NSURLErrorKey: url]
+            )
+        }
     }
 
     private nonisolated static func classifiedDirectoryEntries(

--- a/Radix/Services/ScanEngine.swift
+++ b/Radix/Services/ScanEngine.swift
@@ -176,6 +176,11 @@ actor ScanEngine {
         private let rootDeviceID: UInt64?
         private let containerDeviceIDs: Set<UInt64>
 
+        static let unrestricted = ScanVolumeBoundaryPolicy(
+            rootDeviceID: nil,
+            containerDeviceIDs: []
+        )
+
         static func resolve(
             rootPath: String,
             rootDeviceID: UInt64?,
@@ -212,12 +217,23 @@ actor ScanEngine {
         }
 
         func shouldStopDescent(childDeviceID: UInt64?) -> Bool {
-            guard let childDeviceID,
-                  let rootDeviceID else {
-                return false
-            }
+            guard let rootDeviceID else { return false }
+            guard let childDeviceID else { return true }
             guard childDeviceID != rootDeviceID else { return false }
             return !containerDeviceIDs.contains(childDeviceID)
+        }
+
+        var requiresChildDeviceIdentity: Bool {
+            rootDeviceID != nil
+        }
+
+        func descentBoundaryError(for url: URL, childDeviceID: UInt64?) -> Error? {
+            guard shouldStopDescent(childDeviceID: childDeviceID) else { return nil }
+            return NSError(
+                domain: NSPOSIXErrorDomain,
+                code: Int(EXDEV),
+                userInfo: [NSURLErrorKey: url]
+            )
         }
 
         private static func normalizedMountPath(_ path: String) -> String {
@@ -1236,13 +1252,15 @@ actor ScanEngine {
             metadataLoader: scanMetadataLoader,
             diagnostics: diagnostics,
             summaryPool: atomicSummaryPool,
+            volumeBoundaryPolicy: volumeBoundaryPolicy,
             profileReporter: autoSummaryProfileReporter
         )
         #else
         let scanAtomicDirectorySummarizer = AtomicDirectorySummarizer(
             metadataLoader: scanMetadataLoader,
             diagnostics: diagnostics,
-            summaryPool: atomicSummaryPool
+            summaryPool: atomicSummaryPool,
+            volumeBoundaryPolicy: volumeBoundaryPolicy
         )
         #endif
         let directoryTraversalWorkerLimit = ScanConcurrencyPolicy.directoryTraversalWorkerLimit(for: options)
@@ -1453,10 +1471,21 @@ actor ScanEngine {
                     }
                     metrics.currentPath = item.url.path
 
-                    if shouldTraverseDirectory(metadata: meta, options: options),
-                       !volumeBoundaryPolicy.shouldStopDescent(
-                           childDeviceID: meta.fileIdentity?.fileSystemDeviceID
-                       ) {
+                    let traversesDirectory = shouldTraverseDirectory(
+                        metadata: meta,
+                        options: options
+                    )
+                    let summarizesPackage = meta.isPackage
+                        && meta.isDirectory
+                        && !options.treatPackagesAsDirectories
+                    let boundaryError = traversesDirectory || summarizesPackage
+                        ? volumeBoundaryPolicy.descentBoundaryError(
+                            for: item.url,
+                            childDeviceID: meta.fileIdentity?.fileSystemDeviceID
+                        )
+                        : nil
+
+                    if traversesDirectory, boundaryError == nil {
                         metrics.directoriesVisited += 1
                         maybeEmitProgress(metrics: &metrics, continuation: continuation, emissionState: &emissionState, summaryPool: atomicSummaryPool)
 
@@ -1569,9 +1598,14 @@ actor ScanEngine {
                         // Leaf node (file, symlink, or package-as-directory). Discovery may
                         // have classified it as a pending directory; release that claim.
                         releasePendingDirectoryIfNeeded(for: item, metrics: &metrics)
-                        if meta.isPackage,
-                           meta.isDirectory,
-                           !options.treatPackagesAsDirectories {
+                        if let boundaryError {
+                            let warning = ScanWarningFactory.makeWarning(
+                                for: item.url,
+                                error: boundaryError
+                            )
+                            warnings.append(warning)
+                            continuation.yield(.warning(warning))
+                        } else if summarizesPackage {
                             metrics.pendingPackageSummaryCount += 1
                             metrics.recalculateProgress()
                             atomicSummaryPool.updateProgress(
@@ -1588,6 +1622,7 @@ actor ScanEngine {
                             behavior: behavior,
                             exclusionMatcher: exclusionMatcher,
                             atomicDirectorySummarizer: scanAtomicDirectorySummarizer,
+                            summarizesPackageContents: boundaryError == nil,
                             progressWeight: item.weight,
                             cancellationCheck: cancellationCheck,
                             metrics: &metrics,
@@ -3032,6 +3067,7 @@ actor ScanEngine {
         behavior: ScanBehavior,
         exclusionMatcher: ScanExclusionMatcher,
         atomicDirectorySummarizer: AtomicDirectorySummarizer,
+        summarizesPackageContents: Bool = true,
         progressWeight: Double,
         cancellationCheck: @escaping CancellationCheck,
         metrics: inout ScanMetrics,
@@ -3039,7 +3075,10 @@ actor ScanEngine {
         emissionState: inout ScanEmissionState
     ) async throws -> LeafNodeResult {
         try cancellationCheck()
-        guard metadata.isPackage, metadata.isDirectory, !options.treatPackagesAsDirectories else {
+        guard summarizesPackageContents,
+              metadata.isPackage,
+              metadata.isDirectory,
+              !options.treatPackagesAsDirectories else {
             let node = makeFileNode(
                 url: url,
                 metadata: metadata

--- a/Radix/Services/ScanEngine.swift
+++ b/Radix/Services/ScanEngine.swift
@@ -2744,6 +2744,19 @@ actor ScanEngine {
             options.insert(.skipsHiddenFiles)
         }
 
+        if let expectedIdentity, expectedIdentity.isFileSystemIdentity {
+            let currentMetadata = try metadataLoader.metadata(for: url)
+            if let currentIdentity = currentMetadata.fileIdentity,
+               currentIdentity.isFileSystemIdentity,
+               currentIdentity != expectedIdentity {
+                throw NSError(
+                    domain: NSPOSIXErrorDomain,
+                    code: Int(ESTALE),
+                    userInfo: [NSURLErrorKey: url]
+                )
+            }
+        }
+
         let prefetchKeys = shouldFilterStartupVolumeInternals(under: url, behavior: behavior)
             ? nil
             : Array(resourceKeys)

--- a/Radix/Services/ScanEngine.swift
+++ b/Radix/Services/ScanEngine.swift
@@ -655,7 +655,7 @@ actor ScanEngine {
            atomicSummaryProgressEmissionInterval: atomicSummaryProgressEmissionInterval)
     }
 
-    private nonisolated static func defaultDirectoryContents(
+    nonisolated static func defaultDirectoryContents(
         url: URL,
         keys: [URLResourceKey]?,
         options: FileManager.DirectoryEnumerationOptions,
@@ -1277,6 +1277,7 @@ actor ScanEngine {
                 url: target.url,
                 metadata: rootMetadata,
                 options: options,
+                behavior: behavior,
                 exclusionMatcher: exclusionMatcher,
                 atomicDirectorySummarizer: scanAtomicDirectorySummarizer,
                 progressWeight: 1,
@@ -1583,6 +1584,7 @@ actor ScanEngine {
                             url: item.url,
                             metadata: meta,
                             options: options,
+                            behavior: behavior,
                             exclusionMatcher: exclusionMatcher,
                             atomicDirectorySummarizer: scanAtomicDirectorySummarizer,
                             progressWeight: item.weight,
@@ -1633,6 +1635,7 @@ actor ScanEngine {
                             url: taskItem.url,
                             metadata: taskMetadata,
                             options: options,
+                            behavior: behavior,
                             exclusionMatcher: exclusionMatcher,
                             atomicDirectorySummarizer: scanAtomicDirectorySummarizer,
                             progressWeight: taskItem.weight,
@@ -1662,6 +1665,10 @@ actor ScanEngine {
                             url: candidate.item.url,
                             childEntries: candidate.contents.entries,
                             metadata: candidate.metadata,
+                            expectedRootIdentity: Self.verifiesDirectoryIdentity(
+                                at: candidate.item.url,
+                                behavior: behavior
+                            ) ? candidate.metadata.fileIdentity : nil,
                             includeHiddenFiles: options.includeHiddenFiles,
                             treatPackagesAsDirectories: options.treatPackagesAsDirectories,
                             isNodeDependencyLayout: candidate.isNodeDependencyLayout,
@@ -2770,10 +2777,9 @@ actor ScanEngine {
             options.insert(.skipsHiddenFiles)
         }
 
-        try verifyFoundationDirectoryIdentity(
+        try metadataLoader.validateFileSystemIdentity(
             expectedIdentity,
-            at: url,
-            metadataLoader: metadataLoader
+            at: url
         )
 
         let prefetchKeys = shouldFilterStartupVolumeInternals(under: url, behavior: behavior)
@@ -2786,10 +2792,9 @@ actor ScanEngine {
         // FileManager has no descriptor-relative directory API. Bookend its
         // path-based enumeration so any replacement that persists across the
         // call is discarded instead of entering the scan.
-        try verifyFoundationDirectoryIdentity(
+        try metadataLoader.validateFileSystemIdentity(
             expectedIdentity,
-            at: url,
-            metadataLoader: metadataLoader
+            at: url
         )
         #if DEBUG
         let enumerationNanoseconds = DispatchTime.now().uptimeNanoseconds - enumerationStart
@@ -2853,24 +2858,6 @@ actor ScanEngine {
             directoryLease: nil
         )
         #endif
-    }
-
-    private nonisolated static func verifyFoundationDirectoryIdentity(
-        _ expectedIdentity: FileIdentity?,
-        at url: URL,
-        metadataLoader: ScanMetadataLoader
-    ) throws {
-        guard let expectedIdentity, expectedIdentity.isFileSystemIdentity else { return }
-        let currentIdentity = try metadataLoader.metadata(for: url).fileIdentity
-        guard let currentIdentity,
-              currentIdentity.isFileSystemIdentity,
-              currentIdentity == expectedIdentity else {
-            throw NSError(
-                domain: NSPOSIXErrorDomain,
-                code: Int(ESTALE),
-                userInfo: [NSURLErrorKey: url]
-            )
-        }
     }
 
     private nonisolated static func classifiedDirectoryEntries(
@@ -3041,6 +3028,7 @@ actor ScanEngine {
         url: URL,
         metadata: NodeMetadata,
         options: ScanOptions,
+        behavior: ScanBehavior,
         exclusionMatcher: ScanExclusionMatcher,
         atomicDirectorySummarizer: AtomicDirectorySummarizer,
         progressWeight: Double,
@@ -3082,6 +3070,10 @@ actor ScanEngine {
             progressKind: .package,
             representedItemCount: 0,
             ownerNodeID: url.path,
+            expectedRootIdentity: Self.verifiesDirectoryIdentity(
+                at: url,
+                behavior: behavior
+            ) ? metadata.fileIdentity : nil,
             exclusionMatcher: exclusionMatcher,
             cancellationCheck: cancellationCheck,
             metrics: &metrics,

--- a/Radix/Services/ScanEngine.swift
+++ b/Radix/Services/ScanEngine.swift
@@ -148,6 +148,91 @@ actor ScanEngine {
         static let standard = ScanBehavior(excludesStartupVolumeInternals: false)
     }
 
+    nonisolated struct ScanMountedFileSystem: Sendable {
+        let mountPath: String
+        let deviceName: String
+        let fileSystemType: String
+    }
+
+    /// Decides whether directory traversal may cross a device boundary. Nested
+    /// mounts from foreign containers (DMGs, network shares, autofs, other disks)
+    /// become leaf nodes so their bytes are not folded into the scanned tree,
+    /// while firmlinked volumes of the scan root's own APFS container remain
+    /// traversable (a startup-scan must reach the Data volume's user data).
+    nonisolated struct ScanVolumeBoundaryPolicy: Sendable {
+        private let rootDeviceID: UInt64?
+        private let rootContainerID: String?
+        private let containerMountPaths: [String]
+
+        static func resolve(
+            rootPath: String,
+            rootDeviceID: UInt64?,
+            mountedFileSystems: [ScanMountedFileSystem]
+        ) -> ScanVolumeBoundaryPolicy {
+            let normalizedRootPath = normalizedMountPath(rootPath)
+            let rootMount = mountedFileSystems
+                .filter { isPath(normalizedRootPath, within: $0.mountPath) }
+                .max { $0.mountPath.count < $1.mountPath.count }
+            guard let rootMount,
+                  let rootContainerID = containerIdentifier(of: rootMount) else {
+                return ScanVolumeBoundaryPolicy(
+                    rootDeviceID: rootDeviceID,
+                    rootContainerID: nil,
+                    containerMountPaths: []
+                )
+            }
+
+            let containerMountPaths = mountedFileSystems
+                .filter {
+                    $0.fileSystemType == "apfs"
+                        && containerIdentifier(of: $0) == rootContainerID
+                }
+                .map { normalizedMountPath($0.mountPath) }
+                .sorted { $0.count > $1.count }
+
+            return ScanVolumeBoundaryPolicy(
+                rootDeviceID: rootDeviceID,
+                rootContainerID: rootContainerID,
+                containerMountPaths: containerMountPaths
+            )
+        }
+
+        func shouldStopDescent(childPath: String, childDeviceID: UInt64?) -> Bool {
+            guard let childDeviceID,
+                  let rootDeviceID else {
+                return false
+            }
+            guard childDeviceID != rootDeviceID else { return false }
+
+            let normalizedChildPath = Self.normalizedMountPath(childPath)
+            return !containerMountPaths.contains { mountPath in
+                Self.isPath(normalizedChildPath, within: mountPath)
+            }
+        }
+
+        private static func normalizedMountPath(_ path: String) -> String {
+            var path = path
+            while path.count > 1 && path.hasSuffix("/") {
+                path.removeLast()
+            }
+            return path
+        }
+
+        private static func isPath(_ path: String, within mountPath: String) -> Bool {
+            path == mountPath || path.hasPrefix(mountPath + "/")
+        }
+
+        /// APFS synthesizer names encode the container in the disk number:
+        /// "disk3s5" and "disk3s1s1" both belong to container "disk3".
+        private static func containerIdentifier(of mount: ScanMountedFileSystem) -> String? {
+            let deviceName = (mount.deviceName as NSString).lastPathComponent
+            guard let match = deviceName.firstMatch(of: /^disk(\d+)(s\d+)+$/) else {
+                return deviceName.isEmpty ? nil : deviceName
+            }
+            return "disk\(match.1)"
+        }
+    }
+
     private struct AggregateStatsAccumulator {
         private(set) var fileCount = 0
         private(set) var directoryCount = 0
@@ -609,6 +694,30 @@ actor ScanEngine {
             let buffer = rawBuffer.bindMemory(to: CChar.self)
             guard let baseAddress = buffer.baseAddress else { return nil }
             return String(cString: baseAddress)
+        }
+    }
+
+    nonisolated static func defaultMountedFileSystems() -> [ScanMountedFileSystem] {
+        var mountBuffer: UnsafeMutablePointer<statfs>?
+        let mountCount = getmntinfo(&mountBuffer, MNT_NOWAIT)
+        guard mountCount > 0, let mountBuffer else { return [] }
+
+        return (0..<Int(mountCount)).compactMap { offset in
+            let entry = mountBuffer[offset]
+            func cString<T>(from field: T) -> String {
+                withUnsafeBytes(of: field) { rawBuffer -> String in
+                    let buffer = rawBuffer.bindMemory(to: CChar.self)
+                    guard let baseAddress = buffer.baseAddress else { return "" }
+                    return String(cString: baseAddress)
+                }
+            }
+            let mountPath = cString(from: entry.f_mntonname)
+            guard !mountPath.isEmpty else { return nil }
+            return ScanMountedFileSystem(
+                mountPath: mountPath,
+                deviceName: cString(from: entry.f_mntfromname),
+                fileSystemType: cString(from: entry.f_fstypename)
+            )
         }
     }
 
@@ -1075,6 +1184,11 @@ actor ScanEngine {
         guard !rootMetadata.isDataless else {
             throw ScanEngineError.cloudOnlyRoot
         }
+        let volumeBoundaryPolicy = ScanVolumeBoundaryPolicy.resolve(
+            rootPath: target.url.standardizedFileURL.path,
+            rootDeviceID: rootMetadata.fileIdentity?.fileSystemDeviceID,
+            mountedFileSystems: Self.defaultMountedFileSystems()
+        )
         metrics.discoveredItems = 1
         metrics.volumeCapacity = target.kind == .volume ? rootMetadata.volumeCapacity : nil
         metrics.estimatedTotalBytes = estimatedTotalBytes(for: target, metadata: rootMetadata)
@@ -1310,7 +1424,11 @@ actor ScanEngine {
                     }
                     metrics.currentPath = item.url.path
 
-                    if shouldTraverseDirectory(metadata: meta, options: options) {
+                    if shouldTraverseDirectory(metadata: meta, options: options),
+                       !volumeBoundaryPolicy.shouldStopDescent(
+                           childPath: item.url.standardizedFileURL.path,
+                           childDeviceID: meta.fileIdentity?.fileSystemDeviceID
+                       ) {
                         metrics.directoriesVisited += 1
                         maybeEmitProgress(metrics: &metrics, continuation: continuation, emissionState: &emissionState, summaryPool: atomicSummaryPool)
 

--- a/Radix/Services/ScanEngine.swift
+++ b/Radix/Services/ScanEngine.swift
@@ -712,8 +712,9 @@ actor ScanEngine {
 
     nonisolated static func defaultMountedFileSystems() -> [ScanMountedFileSystem] {
         var mountBuffer: UnsafeMutablePointer<statfs>?
-        let mountCount = getmntinfo(&mountBuffer, MNT_NOWAIT)
+        let mountCount = getmntinfo_r_np(&mountBuffer, MNT_NOWAIT)
         guard mountCount > 0, let mountBuffer else { return [] }
+        defer { free(mountBuffer) }
 
         return (0..<Int(mountCount)).compactMap { offset in
             let entry = mountBuffer[offset]

--- a/Radix/Services/ScanMetadataLoader.swift
+++ b/Radix/Services/ScanMetadataLoader.swift
@@ -420,6 +420,36 @@ nonisolated struct ScanMetadataLoader: Sendable {
         )
     }
 
+    /// Loads the descriptor-independent identity used to protect Foundation's
+    /// path-based directory enumeration from persistent replacement.
+    nonisolated func fileSystemIdentity(at url: URL) throws -> FileIdentity {
+        guard let identity = fileSystemInfoProvider(url, diagnostics).identity,
+              identity.isFileSystemIdentity else {
+            throw Self.staleFileSystemIdentityError(for: url)
+        }
+        return identity
+    }
+
+    /// Best-effort callers pass `nil`; protected callers fail closed when the
+    /// current path no longer names the filesystem object they discovered.
+    nonisolated func validateFileSystemIdentity(
+        _ expectedIdentity: FileIdentity?,
+        at url: URL
+    ) throws {
+        guard let expectedIdentity, expectedIdentity.isFileSystemIdentity else { return }
+        guard try fileSystemIdentity(at: url) == expectedIdentity else {
+            throw Self.staleFileSystemIdentityError(for: url)
+        }
+    }
+
+    private nonisolated static func staleFileSystemIdentityError(for url: URL) -> NSError {
+        NSError(
+            domain: NSPOSIXErrorDomain,
+            code: Int(ESTALE),
+            userInfo: [NSURLErrorKey: url]
+        )
+    }
+
     private nonisolated static func nodeMetadata(
         for url: URL,
         resourceValues values: URLResourceValues,

--- a/Radix/Services/ScanMetadataLoader.swift
+++ b/Radix/Services/ScanMetadataLoader.swift
@@ -743,6 +743,13 @@ nonisolated enum FileIdentity: Hashable, Sendable {
         }
         return false
     }
+
+    nonisolated var fileSystemDeviceID: UInt64? {
+        if case .fileSystem(let device, _) = self {
+            return device
+        }
+        return nil
+    }
 }
 
 private nonisolated struct ScanMetadataAttributeCursor {

--- a/RadixCoreTests/ScanEngineTests.swift
+++ b/RadixCoreTests/ScanEngineTests.swift
@@ -614,6 +614,50 @@ final class ScanEngineTests: XCTestCase {
         XCTAssertLessThanOrEqual(fallbackPool.debugCounters.peakOpenDescriptorCount, 1)
     }
 
+    func testFoundationFallbackRejectsDirectoryReplacedDuringEnumeration() async throws {
+        let rootURL = try makeTemporaryDirectory()
+        let foreignRootURL = try makeTemporaryDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: rootURL)
+            try? FileManager.default.removeItem(at: foreignRootURL)
+        }
+
+        let directoryURL = rootURL.appending(path: "ReplaceMe", directoryHint: .isDirectory)
+        let originalDirectoryURL = rootURL.appending(path: "Original", directoryHint: .isDirectory)
+        let foreignFileURL = foreignRootURL.appending(path: "foreign.bin")
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        try Data("foreign".utf8).write(to: foreignFileURL)
+
+        let engine = ScanEngine(directoryContents: { url, keys, options, cancellationCheck in
+            try cancellationCheck()
+            if url.standardizedFileURL == directoryURL.standardizedFileURL {
+                try FileManager.default.moveItem(at: directoryURL, to: originalDirectoryURL)
+                try FileManager.default.createSymbolicLink(
+                    at: directoryURL,
+                    withDestinationURL: foreignRootURL
+                )
+            }
+            let contents = try FileManager.default.contentsOfDirectory(
+                at: url,
+                includingPropertiesForKeys: keys,
+                options: options
+            )
+            try cancellationCheck()
+            return contents
+        })
+
+        let snapshot = try await finishedSnapshot(
+            target: ScanTarget(url: rootURL),
+            options: ScanOptions(),
+            engine: engine
+        )
+
+        XCTAssertNil(snapshot.treeStore.node(id: directoryURL.appending(path: "foreign.bin").path))
+        XCTAssertTrue(snapshot.scanWarnings.contains { warning in
+            warning.path == directoryURL.path && warning.category == .fileSystem
+        })
+    }
+
     func testBulkAndFoundationScannersMatchAdversarialFixture() async throws {
         let rootURL = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: rootURL) }

--- a/RadixCoreTests/ScanEngineTests.swift
+++ b/RadixCoreTests/ScanEngineTests.swift
@@ -63,6 +63,147 @@ final class ScanEngineTests: XCTestCase {
         XCTAssertTrue(summary.warnings.isEmpty)
     }
 
+    func testFoundationAtomicWorkResultStopsAtVolumeBoundary() throws {
+        let rootURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+        let boundaryURL = rootURL.appending(path: "Mounted", directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: boundaryURL, withIntermediateDirectories: true)
+        try Data([0x11]).write(to: boundaryURL.appending(path: "foreign.bin"))
+
+        let metadataLoader = ScanMetadataLoader()
+        let rootIdentity = try metadataLoader.fileSystemIdentity(at: rootURL)
+        let policy = try rejectingVolumeBoundaryPolicy(
+            for: rootURL,
+            metadataLoader: metadataLoader
+        )
+        let (progressReporter, continuation) = makeAtomicSummaryProgressReporter()
+        defer { continuation.finish() }
+
+        let result = try AtomicDirectorySummarizer.processFoundationWorkItem(
+            AtomicSummaryWorkItem(
+                url: rootURL,
+                treatPackagesAsDirectories: true,
+                ownerNodeID: rootURL.path,
+                expectedIdentity: rootIdentity,
+                volumeBoundaryPolicy: policy
+            ),
+            includeHiddenFiles: true,
+            exclusionMatcher: ScanExclusionMatcher(patterns: [], rootURL: rootURL),
+            metadataLoader: metadataLoader,
+            cancellationCheck: {},
+            progressReporter: progressReporter,
+            progressVisitedItemCount: 0
+        )
+
+        XCTAssertTrue(result.pendingItems.isEmpty)
+        XCTAssertEqual(result.partial.descendantFileCount, 0)
+        XCTAssertEqual(result.partial.logicalSize, 0)
+        XCTAssertEqual(result.partial.warnings.count, 1)
+        XCTAssertEqual(
+            result.partial.warnings.first.map {
+                URL(filePath: $0.path).resolvingSymlinksInPath().path
+            },
+            boundaryURL.resolvingSymlinksInPath().path
+        )
+        XCTAssertEqual(result.partial.warnings.first?.category, .fileSystem)
+    }
+
+    func testPooledPackageSummaryStopsAtVolumeBoundary() async throws {
+        let packageURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: packageURL) }
+        let boundaryURL = packageURL.appending(path: "Mounted", directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: boundaryURL, withIntermediateDirectories: true)
+        try Data(repeating: 0x11, count: 7).write(to: packageURL.appending(path: "local.bin"))
+        try Data(repeating: 0x22, count: 13).write(to: boundaryURL.appending(path: "foreign.bin"))
+
+        let metadataLoader = ScanMetadataLoader()
+        let rootIdentity = try metadataLoader.fileSystemIdentity(at: packageURL)
+        let policy = try rejectingVolumeBoundaryPolicy(
+            for: packageURL,
+            metadataLoader: metadataLoader
+        )
+        let pool = AtomicDirectorySummaryPool(workerLimit: 2, progressEmissionInterval: 0)
+        let summarizer = AtomicDirectorySummarizer(
+            metadataLoader: metadataLoader,
+            summaryPool: pool,
+            volumeBoundaryPolicy: policy
+        )
+        let (_, continuation) = makeAtomicSummaryProgressReporter()
+        defer { continuation.finish() }
+        var metrics = ScanMetrics()
+        var emissionState = ScanEmissionState()
+
+        let summary = try await summarizer.summarize(
+            at: packageURL,
+            treatPackagesAsDirectories: true,
+            workerLimit: 2,
+            progressWeight: 1,
+            progressKind: .package,
+            ownerNodeID: packageURL.path,
+            expectedRootIdentity: rootIdentity,
+            exclusionMatcher: ScanExclusionMatcher(patterns: [], rootURL: packageURL),
+            cancellationCheck: {},
+            metrics: &metrics,
+            continuation: continuation,
+            emissionState: &emissionState
+        )
+        await pool.finish()
+
+        XCTAssertEqual(summary?.descendantFileCount, 1)
+        XCTAssertEqual(summary?.logicalSize, 7)
+        XCTAssertEqual(summary?.warnings.count, 1)
+        XCTAssertEqual(summary?.warnings.first?.path, boundaryURL.path)
+        XCTAssertEqual(summary?.warnings.first?.category, .fileSystem)
+    }
+
+    func testAutoSummaryProbeStopsAtVolumeBoundary() async throws {
+        let rootURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+        let boundaryURL = rootURL.appending(path: "Mounted", directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: boundaryURL, withIntermediateDirectories: true)
+        try Data([0x11]).write(to: boundaryURL.appending(path: "foreign.bin"))
+
+        let metadataLoader = ScanMetadataLoader()
+        let policy = try rejectingVolumeBoundaryPolicy(
+            for: rootURL,
+            metadataLoader: metadataLoader
+        )
+        let summarizer = AtomicDirectorySummarizer(
+            metadataLoader: metadataLoader,
+            volumeBoundaryPolicy: policy
+        )
+        let rootMetadata = try metadataLoader.metadata(for: rootURL)
+        let boundaryMetadata = try metadataLoader.metadata(for: boundaryURL)
+        let rootEntries = [DirectoryEntry(
+            url: boundaryURL,
+            metadata: boundaryMetadata,
+            isDirectoryHint: true
+        )]
+        let (_, continuation) = makeAtomicSummaryProgressReporter()
+        defer { continuation.finish() }
+        var metrics = ScanMetrics()
+        var emissionState = ScanEmissionState()
+
+        let decision = try await summarizer.summaryDecisionIfNeeded(
+            url: rootURL,
+            childEntries: rootEntries,
+            metadata: rootMetadata,
+            includeHiddenFiles: true,
+            treatPackagesAsDirectories: true,
+            isNodeDependencyLayout: false,
+            minFileCount: 1,
+            maxAverageFileSize: 256,
+            workerLimit: 2,
+            exclusionMatcher: ScanExclusionMatcher(patterns: [], rootURL: rootURL),
+            cancellationCheck: {},
+            metrics: &metrics,
+            continuation: continuation,
+            emissionState: &emissionState
+        )
+
+        XCTAssertNil(decision.summary)
+    }
+
     func testFoundationAtomicWorkResultRejectsPreAndPostEnumerationReplacement() throws {
         let parentURL = try makeTemporaryDirectory()
         let foreignURL = try makeTemporaryDirectory()
@@ -197,6 +338,7 @@ final class ScanEngineTests: XCTestCase {
             ownerNodeID: rootURL.path,
             exclusionMatcher: matcher,
             metadataLoader: metadataLoader,
+            volumeBoundaryPolicy: .unrestricted,
             cancellationCheck: {},
             metrics: ScanMetrics(),
             continuation: continuation,
@@ -223,6 +365,7 @@ final class ScanEngineTests: XCTestCase {
             ownerNodeID: rootURL.path,
             exclusionMatcher: matcher,
             metadataLoader: metadataLoader,
+            volumeBoundaryPolicy: .unrestricted,
             cancellationCheck: {},
             metrics: ScanMetrics(),
             continuation: continuation,
@@ -296,6 +439,7 @@ final class ScanEngineTests: XCTestCase {
             ownerNodeID: rootURL.path,
             exclusionMatcher: ScanExclusionMatcher(patterns: [], rootURL: rootURL),
             metadataLoader: metadataLoader,
+            volumeBoundaryPolicy: .unrestricted,
             cancellationCheck: {},
             metrics: ScanMetrics(),
             continuation: continuation,
@@ -532,6 +676,7 @@ final class ScanEngineTests: XCTestCase {
             ownerNodeID: rootURL.path,
             exclusionMatcher: ScanExclusionMatcher(patterns: [], rootURL: rootURL),
             metadataLoader: metadataLoader,
+            volumeBoundaryPolicy: .unrestricted,
             cancellationCheck: {},
             metrics: base,
             continuation: continuation,
@@ -4469,6 +4614,20 @@ private func makeAtomicSummaryProgressReporter() -> (
     return (
         AtomicSummaryProgressReporter(metrics: ScanMetrics(), continuation: continuation),
         continuation
+    )
+}
+
+private func rejectingVolumeBoundaryPolicy(
+    for rootURL: URL,
+    metadataLoader: ScanMetadataLoader
+) throws -> ScanEngine.ScanVolumeBoundaryPolicy {
+    let actualDeviceID = try XCTUnwrap(
+        metadataLoader.fileSystemIdentity(at: rootURL).fileSystemDeviceID
+    )
+    return ScanEngine.ScanVolumeBoundaryPolicy.resolve(
+        rootPath: rootURL.path,
+        rootDeviceID: actualDeviceID ^ 1,
+        mountedFileSystems: []
     )
 }
 

--- a/RadixCoreTests/ScanEngineTests.swift
+++ b/RadixCoreTests/ScanEngineTests.swift
@@ -3,6 +3,360 @@ import XCTest
 @testable import RadixCore
 
 final class ScanEngineTests: XCTestCase {
+    func testFoundationAtomicWorkResultSeedsProtectedChildrenAndPreservesSemantics() throws {
+        let rootURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+        let nestedURL = rootURL.appending(path: "Nested", directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: nestedURL, withIntermediateDirectories: true)
+        try Data(repeating: 0x11, count: 11).write(to: rootURL.appending(path: "visible.bin"))
+        try Data(repeating: 0x22, count: 7).write(to: rootURL.appending(path: ".hidden.bin"))
+        try Data(repeating: 0x33, count: 13).write(to: rootURL.appending(path: "ignored.tmp"))
+        try Data(repeating: 0x44, count: 20).write(to: nestedURL.appending(path: "nested.bin"))
+
+        let metadataLoader = ScanMetadataLoader()
+        let expectedIdentity = try metadataLoader.fileSystemIdentity(at: rootURL)
+        let (progressReporter, continuation) = makeAtomicSummaryProgressReporter()
+        defer { continuation.finish() }
+        let rootResult = try AtomicDirectorySummarizer.processFoundationWorkItem(
+            AtomicSummaryWorkItem(
+                url: rootURL,
+                treatPackagesAsDirectories: true,
+                ownerNodeID: rootURL.path,
+                expectedIdentity: expectedIdentity
+            ),
+            includeHiddenFiles: false,
+            exclusionMatcher: ScanExclusionMatcher(patterns: ["*.tmp"], rootURL: rootURL),
+            metadataLoader: metadataLoader,
+            cancellationCheck: {},
+            progressReporter: progressReporter,
+            progressVisitedItemCount: 0
+        )
+
+        XCTAssertEqual(rootResult.partial.descendantFileCount, 1)
+        XCTAssertEqual(rootResult.partial.logicalSize, 11)
+        XCTAssertEqual(rootResult.partial.visitedItemCount, 3)
+        XCTAssertTrue(rootResult.partial.warnings.isEmpty)
+        XCTAssertEqual(rootResult.pendingItems.count, 1)
+        let childWork = try XCTUnwrap(rootResult.pendingItems.first)
+        XCTAssertEqual(
+            childWork.url.resolvingSymlinksInPath(),
+            nestedURL.resolvingSymlinksInPath()
+        )
+        XCTAssertTrue(childWork.expectedIdentity?.isFileSystemIdentity == true)
+
+        let childResult = try AtomicDirectorySummarizer.processFoundationWorkItem(
+            childWork,
+            includeHiddenFiles: false,
+            exclusionMatcher: ScanExclusionMatcher(patterns: ["*.tmp"], rootURL: rootURL),
+            metadataLoader: metadataLoader,
+            cancellationCheck: {},
+            progressReporter: progressReporter,
+            progressVisitedItemCount: 0
+        )
+        let accumulator = AtomicSummaryAccumulator(seed: rootResult.partial)
+        accumulator.merge(childResult.partial)
+        let summary = accumulator.makeSummary()
+        XCTAssertEqual(summary.descendantFileCount, 2)
+        XCTAssertEqual(summary.logicalSize, 31)
+        XCTAssertEqual(summary.visitedItemCount, 4)
+        XCTAssertTrue(summary.isAccessible)
+        XCTAssertTrue(summary.warnings.isEmpty)
+    }
+
+    func testFoundationAtomicWorkResultRejectsPreAndPostEnumerationReplacement() throws {
+        let parentURL = try makeTemporaryDirectory()
+        let foreignURL = try makeTemporaryDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: parentURL)
+            try? FileManager.default.removeItem(at: foreignURL)
+        }
+        let rootURL = parentURL.appending(path: "ReplaceMe", directoryHint: .isDirectory)
+        let originalURL = parentURL.appending(path: "Original", directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        try Data([0x11]).write(to: rootURL.appending(path: "original.bin"))
+        try Data([0x22]).write(to: foreignURL.appending(path: "foreign.bin"))
+
+        let metadataLoader = ScanMetadataLoader()
+        let expectedIdentity = try metadataLoader.fileSystemIdentity(at: rootURL)
+        let (progressReporter, continuation) = makeAtomicSummaryProgressReporter()
+        defer { continuation.finish() }
+        let matcher = ScanExclusionMatcher(patterns: [], rootURL: parentURL)
+        let preMismatch = try AtomicDirectorySummarizer.processFoundationWorkItem(
+            AtomicSummaryWorkItem(
+                url: rootURL,
+                treatPackagesAsDirectories: true,
+                ownerNodeID: rootURL.path,
+                expectedIdentity: FileIdentity(device: 0, inode: 0)
+            ),
+            includeHiddenFiles: true,
+            exclusionMatcher: matcher,
+            metadataLoader: metadataLoader,
+            cancellationCheck: {},
+            progressReporter: progressReporter,
+            progressVisitedItemCount: 0
+        )
+        XCTAssertEqual(preMismatch.partial.visitedItemCount, 0)
+        XCTAssertEqual(preMismatch.partial.descendantFileCount, 0)
+        XCTAssertTrue(preMismatch.pendingItems.isEmpty)
+        XCTAssertEqual(preMismatch.partial.warnings.count, 1)
+        XCTAssertEqual(preMismatch.partial.warnings.first?.category, .fileSystem)
+
+        let postMismatch = try AtomicDirectorySummarizer.processFoundationWorkItem(
+            AtomicSummaryWorkItem(
+                url: rootURL,
+                treatPackagesAsDirectories: true,
+                ownerNodeID: rootURL.path,
+                expectedIdentity: expectedIdentity
+            ),
+            includeHiddenFiles: true,
+            exclusionMatcher: matcher,
+            metadataLoader: metadataLoader,
+            cancellationCheck: {},
+            progressReporter: progressReporter,
+            progressVisitedItemCount: 0,
+            directoryContents: { url, keys, options, cancellationCheck in
+                try cancellationCheck()
+                try FileManager.default.moveItem(at: rootURL, to: originalURL)
+                try FileManager.default.createSymbolicLink(at: rootURL, withDestinationURL: foreignURL)
+                return ScanEngine.DirectoryEnumerationResult(
+                    urls: [foreignURL.appending(path: "foreign.bin")]
+                )
+            }
+        )
+        XCTAssertEqual(postMismatch.partial.visitedItemCount, 1)
+        XCTAssertEqual(postMismatch.partial.descendantFileCount, 0)
+        XCTAssertEqual(postMismatch.partial.logicalSize, 0)
+        XCTAssertTrue(postMismatch.pendingItems.isEmpty)
+        XCTAssertEqual(postMismatch.partial.warnings.count, 1)
+        XCTAssertEqual(postMismatch.partial.warnings.first?.path, rootURL.path)
+        XCTAssertEqual(postMismatch.partial.warnings.first?.category, .fileSystem)
+    }
+
+    func testFoundationAtomicWorkResultSkipsChildWithoutFilesystemIdentity() throws {
+        let rootURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+        let childURL = rootURL.appending(path: "Child", directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: childURL, withIntermediateDirectories: true)
+        let metadataLoader = ScanMetadataLoader(fileSystemInfoProvider: { _, _ in (nil, 1) })
+        let (progressReporter, continuation) = makeAtomicSummaryProgressReporter()
+        defer { continuation.finish() }
+
+        let result = try AtomicDirectorySummarizer.processFoundationWorkItem(
+            AtomicSummaryWorkItem(
+                url: rootURL,
+                treatPackagesAsDirectories: true,
+                ownerNodeID: rootURL.path
+            ),
+            includeHiddenFiles: true,
+            exclusionMatcher: ScanExclusionMatcher(patterns: [], rootURL: rootURL),
+            metadataLoader: metadataLoader,
+            cancellationCheck: {},
+            progressReporter: progressReporter,
+            progressVisitedItemCount: 0
+        )
+
+        XCTAssertTrue(result.pendingItems.isEmpty)
+        XCTAssertEqual(result.partial.warnings.count, 1)
+        XCTAssertEqual(
+            result.partial.warnings.first.map {
+                URL(filePath: $0.path).resolvingSymlinksInPath().path
+            },
+            childURL.resolvingSymlinksInPath().path
+        )
+        XCTAssertEqual(result.partial.warnings.first?.category, .fileSystem)
+    }
+
+    func testPooledAndNonPooledForcedFoundationSummariesMatch() async throws {
+        let rootURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+        let nestedURL = rootURL.appending(path: "Nested", directoryHint: .isDirectory)
+        let packageURL = rootURL.appending(path: "Payload.app/Contents", directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: nestedURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: packageURL, withIntermediateDirectories: true)
+        let originalURL = rootURL.appending(path: "original.bin")
+        try Data(repeating: 0x11, count: 64).write(to: originalURL)
+        try FileManager.default.linkItem(at: originalURL, to: nestedURL.appending(path: "linked.bin"))
+        try Data(repeating: 0x22, count: 32).write(to: packageURL.appending(path: "asset.bin"))
+        try Data(repeating: 0x33, count: 16).write(to: rootURL.appending(path: ".hidden.bin"))
+        try Data(repeating: 0x44, count: 8).write(to: nestedURL.appending(path: "ignored.tmp"))
+        try FileManager.default.createSymbolicLink(
+            at: rootURL.appending(path: "alias.bin"),
+            withDestinationURL: originalURL
+        )
+
+        let metadataLoader = ScanMetadataLoader()
+        let rootIdentity = try metadataLoader.fileSystemIdentity(at: rootURL)
+        let matcher = ScanExclusionMatcher(patterns: ["*.tmp"], rootURL: rootURL)
+        let (_, continuation) = makeAtomicSummaryProgressReporter()
+        defer { continuation.finish() }
+        let nonPooled = try await AtomicDirectorySummarizer.summarizeInParallel(
+            at: rootURL,
+            includeHiddenFiles: false,
+            treatPackagesAsDirectories: false,
+            workerLimit: 3,
+            ownerNodeID: rootURL.path,
+            exclusionMatcher: matcher,
+            metadataLoader: metadataLoader,
+            cancellationCheck: {},
+            metrics: ScanMetrics(),
+            continuation: continuation,
+            forcesFoundationTraversal: true,
+            expectedRootIdentity: rootIdentity
+        )
+
+        let cursor = try BulkDirectoryEnumerator.makeCursor(
+            at: rootURL,
+            includeHiddenFiles: false,
+            metadataLoader: metadataLoader,
+            cancellationCheck: {},
+            forcedUnavailableAfterBatchCount: 0
+        )
+        let pool = AtomicDirectorySummaryPool(workerLimit: 3, progressEmissionInterval: 0)
+        let pooled = try await pool.summarize(AtomicSummaryPoolRequest(
+            url: rootURL,
+            expectedRootIdentity: rootIdentity,
+            includeHiddenFiles: false,
+            treatPackagesAsDirectories: false,
+            progressWeight: 1,
+            progressKind: .autoSummary,
+            representedItemCount: 0,
+            ownerNodeID: rootURL.path,
+            exclusionMatcher: matcher,
+            metadataLoader: metadataLoader,
+            cancellationCheck: {},
+            metrics: ScanMetrics(),
+            continuation: continuation,
+            resumeState: AtomicDirectoryProbeResumeState(
+                partial: AtomicDirectorySummaryPartial(),
+                workItems: [AtomicSummaryWorkItem(
+                    url: rootURL,
+                    treatPackagesAsDirectories: false,
+                    ownerNodeID: rootURL.path,
+                    expectedIdentity: rootIdentity,
+                    cursor: cursor,
+                    needsCursor: false,
+                    requiresRootRestartOnFallback: true
+                )],
+                visitedItemCount: 0
+            )
+        ))
+        await pool.finish()
+
+        let reference = try XCTUnwrap(nonPooled)
+        let candidate = try XCTUnwrap(pooled)
+        XCTAssertEqual(candidate.allocatedSize, reference.allocatedSize)
+        XCTAssertEqual(candidate.logicalSize, reference.logicalSize)
+        XCTAssertEqual(candidate.descendantFileCount, reference.descendantFileCount)
+        XCTAssertEqual(candidate.visitedItemCount, reference.visitedItemCount)
+        XCTAssertEqual(candidate.isAccessible, reference.isAccessible)
+        XCTAssertEqual(warningSemantics(candidate.warnings), warningSemantics(reference.warnings))
+        XCTAssertEqual(
+            candidate.sharedAllocationAccumulator.duplicateAllocatedSizeByOwner,
+            reference.sharedAllocationAccumulator.duplicateAllocatedSizeByOwner
+        )
+        XCTAssertEqual(
+            candidate.sharedAllocationAccumulator.identityCount,
+            reference.sharedAllocationAccumulator.identityCount
+        )
+    }
+
+    func testLateNativeFallbackPreservesOriginalRootIdentity() async throws {
+        let parentURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: parentURL) }
+        let rootURL = parentURL.appending(path: "Root", directoryHint: .isDirectory)
+        let movedURL = parentURL.appending(path: "Moved", directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        for index in 0..<128 {
+            try Data([UInt8(index)]).write(to: rootURL.appending(path: "payload-\(index).bin"))
+        }
+        let metadataLoader = ScanMetadataLoader()
+        let originalIdentity = try metadataLoader.fileSystemIdentity(at: rootURL)
+        let cursor = try BulkDirectoryEnumerator.makeCursor(
+            at: rootURL,
+            includeHiddenFiles: true,
+            metadataLoader: metadataLoader,
+            cancellationCheck: {},
+            forcedUnavailableAfterBatchCount: 1
+        )
+        try FileManager.default.moveItem(at: rootURL, to: movedURL)
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        try Data([0xFF]).write(to: rootURL.appending(path: "foreign.bin"))
+
+        let (_, continuation) = makeAtomicSummaryProgressReporter()
+        defer { continuation.finish() }
+        let pool = AtomicDirectorySummaryPool(workerLimit: 1, progressEmissionInterval: 0)
+        let summary = try await pool.summarize(AtomicSummaryPoolRequest(
+            url: rootURL,
+            expectedRootIdentity: originalIdentity,
+            includeHiddenFiles: true,
+            treatPackagesAsDirectories: true,
+            progressWeight: 1,
+            progressKind: .autoSummary,
+            representedItemCount: 0,
+            ownerNodeID: rootURL.path,
+            exclusionMatcher: ScanExclusionMatcher(patterns: [], rootURL: rootURL),
+            metadataLoader: metadataLoader,
+            cancellationCheck: {},
+            metrics: ScanMetrics(),
+            continuation: continuation,
+            resumeState: AtomicDirectoryProbeResumeState(
+                partial: AtomicDirectorySummaryPartial(),
+                workItems: [AtomicSummaryWorkItem(
+                    url: rootURL,
+                    treatPackagesAsDirectories: true,
+                    ownerNodeID: rootURL.path,
+                    expectedIdentity: originalIdentity,
+                    cursor: cursor,
+                    needsCursor: false,
+                    requiresRootRestartOnFallback: true
+                )],
+                visitedItemCount: 0
+            )
+        ))
+        await pool.finish()
+
+        XCTAssertEqual(summary?.descendantFileCount, 0)
+        XCTAssertEqual(summary?.logicalSize, 0)
+        XCTAssertTrue(summary?.warnings.contains {
+            $0.path == rootURL.path && $0.category == .fileSystem
+        } == true)
+    }
+
+    func testFoundationAtomicWorkCancellationDoesNotReturnPartialWork() throws {
+        let rootURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+        let urls = try (0..<4).map { index in
+            let url = rootURL.appending(path: "payload-\(index).bin")
+            try Data([UInt8(index)]).write(to: url)
+            return url
+        }
+        let cancellation = AtomicFoundationCancellation(cancelAfterCheckCount: 3)
+        let (_, continuation) = makeAtomicSummaryProgressReporter()
+        defer { continuation.finish() }
+
+        XCTAssertThrowsError(try AtomicDirectorySummarizer.processFoundationWorkItem(
+            AtomicSummaryWorkItem(
+                url: rootURL,
+                treatPackagesAsDirectories: true,
+                ownerNodeID: rootURL.path
+            ),
+            includeHiddenFiles: true,
+            exclusionMatcher: ScanExclusionMatcher(patterns: [], rootURL: rootURL),
+            metadataLoader: ScanMetadataLoader(),
+            cancellationCheck: cancellation.check,
+            progressReporter: AtomicSummaryProgressReporter(
+                metrics: ScanMetrics(),
+                continuation: continuation
+            ),
+            progressVisitedItemCount: 0,
+            directoryContents: { _, _, _, _ in
+                ScanEngine.DirectoryEnumerationResult(urls: urls)
+            }
+        )) { error in
+            XCTAssertTrue(error is CancellationError)
+        }
+    }
+
     func testPooledReusedEntriesReloadMissingPrefetchedMetadata() throws {
         let rootURL = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: rootURL) }
@@ -169,6 +523,7 @@ final class ScanEngineTests: XCTestCase {
 
         let summary = try await pool.summarize(AtomicSummaryPoolRequest(
             url: rootURL,
+            expectedRootIdentity: nil,
             includeHiddenFiles: true,
             treatPackagesAsDirectories: true,
             progressWeight: 1,
@@ -4103,6 +4458,24 @@ private final class BlockingLiveChildOpen: @unchecked Sendable {
     }
 }
 
+private func makeAtomicSummaryProgressReporter() -> (
+    AtomicSummaryProgressReporter,
+    AsyncThrowingStream<ScanProgressEvent, Error>.Continuation
+) {
+    var continuation: AsyncThrowingStream<ScanProgressEvent, Error>.Continuation!
+    _ = AsyncThrowingStream<ScanProgressEvent, Error> {
+        continuation = $0
+    }
+    return (
+        AtomicSummaryProgressReporter(metrics: ScanMetrics(), continuation: continuation),
+        continuation
+    )
+}
+
+private func warningSemantics(_ warnings: [ScanWarning]) -> Set<String> {
+    Set(warnings.map { "\($0.path)|\($0.category.rawValue)|\($0.message)" })
+}
+
 private func finishedSnapshot(
     target: ScanTarget,
     options: ScanOptions,
@@ -4197,6 +4570,26 @@ private final class DirectoryEnumerationCancellation: @unchecked Sendable {
     func check() throws {
         lock.lock()
         let isCancelled = isCancelled
+        lock.unlock()
+        if isCancelled {
+            throw CancellationError()
+        }
+    }
+}
+
+private final class AtomicFoundationCancellation: @unchecked Sendable {
+    private let lock = NSLock()
+    private let cancelAfterCheckCount: Int
+    private var checkCount = 0
+
+    init(cancelAfterCheckCount: Int) {
+        self.cancelAfterCheckCount = cancelAfterCheckCount
+    }
+
+    func check() throws {
+        lock.lock()
+        checkCount += 1
+        let isCancelled = checkCount >= cancelAfterCheckCount
         lock.unlock()
         if isCancelled {
             throw CancellationError()

--- a/RadixCoreTests/ScanMetadataLoaderTests.swift
+++ b/RadixCoreTests/ScanMetadataLoaderTests.swift
@@ -3,6 +3,40 @@ import XCTest
 @testable import RadixCore
 
 final class ScanMetadataLoaderTests: XCTestCase {
+    func testFileSystemIdentityValidationUsesTheDedicatedProvider() throws {
+        let url = URL(filePath: "/virtual/directory", directoryHint: .isDirectory)
+        let expectedIdentity = FileIdentity(device: 7, inode: 42)
+        let counters = MetadataProbeCounters()
+        let loader = ScanMetadataLoader(fileSystemInfoProvider: { requestedURL, _ in
+            XCTAssertEqual(requestedURL, url)
+            counters.recordLstat()
+            return (expectedIdentity, 1)
+        })
+
+        XCTAssertEqual(try loader.fileSystemIdentity(at: url), expectedIdentity)
+        XCTAssertNoThrow(try loader.validateFileSystemIdentity(expectedIdentity, at: url))
+        XCTAssertEqual(counters.lstatCount, 2)
+    }
+
+    func testFileSystemIdentityValidationFailsClosedForMissingOrChangedIdentity() {
+        let url = URL(filePath: "/virtual/directory", directoryHint: .isDirectory)
+        let expectedIdentity = FileIdentity(device: 7, inode: 42)
+        for currentIdentity in [nil, FileIdentity(device: 7, inode: 43)] {
+            let loader = ScanMetadataLoader(fileSystemInfoProvider: { _, _ in
+                (currentIdentity, 1)
+            })
+
+            XCTAssertThrowsError(
+                try loader.validateFileSystemIdentity(expectedIdentity, at: url)
+            ) { error in
+                let nsError = error as NSError
+                XCTAssertEqual(nsError.domain, NSPOSIXErrorDomain)
+                XCTAssertEqual(nsError.code, Int(ESTALE))
+                XCTAssertEqual(nsError.userInfo[NSURLErrorKey] as? URL, url)
+            }
+        }
+    }
+
     func testCloneProbeRequestsPhysicalDeviceIdentity() {
         XCTAssertNotEqual(
             ScanMetadataLoader.cloneProbeOptions & UInt32(FSOPT_RETURN_REALDEV),

--- a/RadixCoreTests/ScanVolumeBoundaryPolicyTests.swift
+++ b/RadixCoreTests/ScanVolumeBoundaryPolicyTests.swift
@@ -100,20 +100,28 @@ final class ScanVolumeBoundaryPolicyTests: XCTestCase {
         XCTAssertTrue(policy.shouldStopDescent(childDeviceID: dataVolumeDevice))
     }
 
-    func testMissingDeviceInformationNeverStopsTraversal() {
+    func testMissingChildDeviceStopsWhenRootDeviceIsKnown() throws {
         let policy = ScanEngine.ScanVolumeBoundaryPolicy.resolve(
             rootPath: "/",
             rootDeviceID: systemVolumeDevice,
             mountedFileSystems: makeDefaultMounts()
         )
-        XCTAssertFalse(policy.shouldStopDescent(childDeviceID: nil))
+        XCTAssertTrue(policy.shouldStopDescent(childDeviceID: nil))
+        let url = URL(filePath: "/unverified", directoryHint: .isDirectory)
+        let error = try XCTUnwrap(
+            policy.descentBoundaryError(for: url, childDeviceID: nil)
+        )
+        XCTAssertEqual(ScanWarningFactory.makeWarning(for: url, error: error).category, .fileSystem)
+    }
 
+    func testMissingRootDeviceLeavesBoundaryPolicyUnrestricted() {
         let unresolvedPolicy = ScanEngine.ScanVolumeBoundaryPolicy.resolve(
             rootPath: "/",
             rootDeviceID: nil,
             mountedFileSystems: makeDefaultMounts()
         )
         XCTAssertFalse(unresolvedPolicy.shouldStopDescent(childDeviceID: externalVolumeDevice))
+        XCTAssertFalse(unresolvedPolicy.shouldStopDescent(childDeviceID: nil))
     }
 
     func testNonAPFSMountsWithMatchingDiskPrefixStayBlocked() {

--- a/RadixCoreTests/ScanVolumeBoundaryPolicyTests.swift
+++ b/RadixCoreTests/ScanVolumeBoundaryPolicyTests.swift
@@ -6,28 +6,33 @@ final class ScanVolumeBoundaryPolicyTests: XCTestCase {
     private let dataVolumeDevice: UInt64 = 0x0100_0005
     private let externalVolumeDevice: UInt64 = 0x0200_0002
     private let diskImageDevice: UInt64 = 0x0300_0004
+    private let virtualMemoryVolumeDevice: UInt64 = 0x0100_0004
 
     private func makeDefaultMounts() -> [ScanEngine.ScanMountedFileSystem] {
         [
             ScanEngine.ScanMountedFileSystem(
                 mountPath: "/",
                 deviceName: "/dev/disk1s1s1",
-                fileSystemType: "apfs"
+                fileSystemType: "apfs",
+                deviceID: systemVolumeDevice
             ),
             ScanEngine.ScanMountedFileSystem(
                 mountPath: "/System/Volumes/Data",
                 deviceName: "/dev/disk1s5",
-                fileSystemType: "apfs"
+                fileSystemType: "apfs",
+                deviceID: dataVolumeDevice
             ),
             ScanEngine.ScanMountedFileSystem(
                 mountPath: "/System/Volumes/VM",
                 deviceName: "/dev/disk1s4",
-                fileSystemType: "apfs"
+                fileSystemType: "apfs",
+                deviceID: virtualMemoryVolumeDevice
             ),
             ScanEngine.ScanMountedFileSystem(
                 mountPath: "/Volumes/External",
                 deviceName: "/dev/disk2s2",
-                fileSystemType: "apfs"
+                fileSystemType: "apfs",
+                deviceID: externalVolumeDevice
             ),
             ScanEngine.ScanMountedFileSystem(
                 mountPath: "/home",
@@ -44,18 +49,8 @@ final class ScanVolumeBoundaryPolicyTests: XCTestCase {
             mountedFileSystems: makeDefaultMounts()
         )
 
-        XCTAssertFalse(policy.shouldStopDescent(
-            childPath: "/System/Volumes/Data",
-            childDeviceID: dataVolumeDevice
-        ))
-        XCTAssertFalse(policy.shouldStopDescent(
-            childPath: "/System/Volumes/Data/Users/colin",
-            childDeviceID: dataVolumeDevice
-        ))
-        XCTAssertFalse(policy.shouldStopDescent(
-            childPath: "/System/Volumes/VM/swapfile0",
-            childDeviceID: 0x0100_0004
-        ))
+        XCTAssertFalse(policy.shouldStopDescent(childDeviceID: dataVolumeDevice))
+        XCTAssertFalse(policy.shouldStopDescent(childDeviceID: virtualMemoryVolumeDevice))
     }
 
     func testForeignContainerMountsBecomeLeaves() {
@@ -65,41 +60,26 @@ final class ScanVolumeBoundaryPolicyTests: XCTestCase {
             mountedFileSystems: makeDefaultMounts()
         )
 
-        XCTAssertTrue(policy.shouldStopDescent(
-            childPath: "/Volumes/External",
-            childDeviceID: externalVolumeDevice
-        ))
-        XCTAssertTrue(policy.shouldStopDescent(
-            childPath: "/Volumes/External/Backup/Library",
-            childDeviceID: externalVolumeDevice
-        ))
-        XCTAssertTrue(policy.shouldStopDescent(
-            childPath: "/home/smb-user",
-            childDeviceID: externalVolumeDevice
-        ))
+        XCTAssertTrue(policy.shouldStopDescent(childDeviceID: externalVolumeDevice))
+        XCTAssertTrue(policy.shouldStopDescent(childDeviceID: diskImageDevice))
     }
 
     func testDiskImageMountInsideScannedTreeBecomesLeaf() {
         var mounts = makeDefaultMounts()
         mounts.append(ScanEngine.ScanMountedFileSystem(
-            mountPath: "/Users/colin/MountedImage",
+            mountPath: "/System/Volumes/Data/Users/tester/MountedImage",
             deviceName: "/dev/disk3s4",
-            fileSystemType: "apfs"
+            fileSystemType: "apfs",
+            deviceID: diskImageDevice
         ))
         let policy = ScanEngine.ScanVolumeBoundaryPolicy.resolve(
-            rootPath: "/System/Volumes/Data/Users/colin",
+            rootPath: "/System/Volumes/Data/Users/tester",
             rootDeviceID: dataVolumeDevice,
             mountedFileSystems: mounts
         )
 
-        XCTAssertTrue(policy.shouldStopDescent(
-            childPath: "/Users/colin/MountedImage",
-            childDeviceID: diskImageDevice
-        ))
-        XCTAssertFalse(policy.shouldStopDescent(
-            childPath: "/Users/colin/Documents",
-            childDeviceID: dataVolumeDevice
-        ))
+        XCTAssertTrue(policy.shouldStopDescent(childDeviceID: diskImageDevice))
+        XCTAssertFalse(policy.shouldStopDescent(childDeviceID: dataVolumeDevice))
     }
 
     func testFolderScanOnExternalVolumeUsesItsOwnContainer() {
@@ -107,7 +87,8 @@ final class ScanVolumeBoundaryPolicyTests: XCTestCase {
         mounts.append(ScanEngine.ScanMountedFileSystem(
             mountPath: "/Volumes/External/SecondSlice",
             deviceName: "/dev/disk2s3",
-            fileSystemType: "apfs"
+            fileSystemType: "apfs",
+            deviceID: 0x0200_0003
         ))
         let policy = ScanEngine.ScanVolumeBoundaryPolicy.resolve(
             rootPath: "/Volumes/External/scan-me",
@@ -115,14 +96,8 @@ final class ScanVolumeBoundaryPolicyTests: XCTestCase {
             mountedFileSystems: mounts
         )
 
-        XCTAssertFalse(policy.shouldStopDescent(
-            childPath: "/Volumes/External/SecondSlice/data",
-            childDeviceID: 0x0200_0003
-        ))
-        XCTAssertTrue(policy.shouldStopDescent(
-            childPath: "/System/Volumes/Data/Users/colin",
-            childDeviceID: dataVolumeDevice
-        ))
+        XCTAssertFalse(policy.shouldStopDescent(childDeviceID: 0x0200_0003))
+        XCTAssertTrue(policy.shouldStopDescent(childDeviceID: dataVolumeDevice))
     }
 
     func testMissingDeviceInformationNeverStopsTraversal() {
@@ -131,17 +106,14 @@ final class ScanVolumeBoundaryPolicyTests: XCTestCase {
             rootDeviceID: systemVolumeDevice,
             mountedFileSystems: makeDefaultMounts()
         )
-        XCTAssertFalse(policy.shouldStopDescent(childPath: "/Volumes/Unknown", childDeviceID: nil))
+        XCTAssertFalse(policy.shouldStopDescent(childDeviceID: nil))
 
         let unresolvedPolicy = ScanEngine.ScanVolumeBoundaryPolicy.resolve(
             rootPath: "/",
             rootDeviceID: nil,
             mountedFileSystems: makeDefaultMounts()
         )
-        XCTAssertFalse(unresolvedPolicy.shouldStopDescent(
-            childPath: "/Volumes/External",
-            childDeviceID: externalVolumeDevice
-        ))
+        XCTAssertFalse(unresolvedPolicy.shouldStopDescent(childDeviceID: externalVolumeDevice))
     }
 
     func testNonAPFSMountsWithMatchingDiskPrefixStayBlocked() {
@@ -149,7 +121,8 @@ final class ScanVolumeBoundaryPolicyTests: XCTestCase {
         mounts.append(ScanEngine.ScanMountedFileSystem(
             mountPath: "/LegacySlice",
             deviceName: "/dev/disk1s7",
-            fileSystemType: "hfs"
+            fileSystemType: "hfs",
+            deviceID: 0x0100_0007
         ))
         let policy = ScanEngine.ScanVolumeBoundaryPolicy.resolve(
             rootPath: "/",
@@ -157,17 +130,25 @@ final class ScanVolumeBoundaryPolicyTests: XCTestCase {
             mountedFileSystems: mounts
         )
 
-        XCTAssertTrue(policy.shouldStopDescent(
-            childPath: "/LegacySlice/data",
-            childDeviceID: 0x0100_0007
-        ))
+        XCTAssertTrue(policy.shouldStopDescent(childDeviceID: 0x0100_0007))
     }
 
-    func testSimilarMountPathsDoNotAliasEachOther() {
+    func testRootMountMatchesFolderScansBelowSlash() {
+        let policy = ScanEngine.ScanVolumeBoundaryPolicy.resolve(
+            rootPath: "/Users/tester",
+            rootDeviceID: dataVolumeDevice,
+            mountedFileSystems: makeDefaultMounts()
+        )
+
+        XCTAssertFalse(policy.shouldStopDescent(childDeviceID: virtualMemoryVolumeDevice))
+        XCTAssertTrue(policy.shouldStopDescent(childDeviceID: externalVolumeDevice))
+    }
+
+    func testSameContainerMountWithoutDeviceIdentityStaysBlocked() {
         var mounts = makeDefaultMounts()
         mounts.append(ScanEngine.ScanMountedFileSystem(
-            mountPath: "/System/Volumes/DataPrivate",
-            deviceName: "/dev/disk9s9",
+            mountPath: "/System/Volumes/Unresolved",
+            deviceName: "/dev/disk1s7",
             fileSystemType: "apfs"
         ))
         let policy = ScanEngine.ScanVolumeBoundaryPolicy.resolve(
@@ -176,13 +157,6 @@ final class ScanVolumeBoundaryPolicyTests: XCTestCase {
             mountedFileSystems: mounts
         )
 
-        XCTAssertTrue(policy.shouldStopDescent(
-            childPath: "/System/Volumes/DataPrivate/stash",
-            childDeviceID: 0x0900_0009
-        ))
-        XCTAssertFalse(policy.shouldStopDescent(
-            childPath: "/System/Volumes/Data/Users",
-            childDeviceID: dataVolumeDevice
-        ))
+        XCTAssertTrue(policy.shouldStopDescent(childDeviceID: 0x0100_0007))
     }
 }

--- a/RadixCoreTests/ScanVolumeBoundaryPolicyTests.swift
+++ b/RadixCoreTests/ScanVolumeBoundaryPolicyTests.swift
@@ -1,0 +1,188 @@
+import XCTest
+@testable import RadixCore
+
+final class ScanVolumeBoundaryPolicyTests: XCTestCase {
+    private let systemVolumeDevice: UInt64 = 0x0100_0001
+    private let dataVolumeDevice: UInt64 = 0x0100_0005
+    private let externalVolumeDevice: UInt64 = 0x0200_0002
+    private let diskImageDevice: UInt64 = 0x0300_0004
+
+    private func makeDefaultMounts() -> [ScanEngine.ScanMountedFileSystem] {
+        [
+            ScanEngine.ScanMountedFileSystem(
+                mountPath: "/",
+                deviceName: "/dev/disk1s1s1",
+                fileSystemType: "apfs"
+            ),
+            ScanEngine.ScanMountedFileSystem(
+                mountPath: "/System/Volumes/Data",
+                deviceName: "/dev/disk1s5",
+                fileSystemType: "apfs"
+            ),
+            ScanEngine.ScanMountedFileSystem(
+                mountPath: "/System/Volumes/VM",
+                deviceName: "/dev/disk1s4",
+                fileSystemType: "apfs"
+            ),
+            ScanEngine.ScanMountedFileSystem(
+                mountPath: "/Volumes/External",
+                deviceName: "/dev/disk2s2",
+                fileSystemType: "apfs"
+            ),
+            ScanEngine.ScanMountedFileSystem(
+                mountPath: "/home",
+                deviceName: "map auto_home",
+                fileSystemType: "autofs"
+            ),
+        ]
+    }
+
+    func testFirmlinkedSameContainerMountsRemainTraversable() {
+        let policy = ScanEngine.ScanVolumeBoundaryPolicy.resolve(
+            rootPath: "/",
+            rootDeviceID: systemVolumeDevice,
+            mountedFileSystems: makeDefaultMounts()
+        )
+
+        XCTAssertFalse(policy.shouldStopDescent(
+            childPath: "/System/Volumes/Data",
+            childDeviceID: dataVolumeDevice
+        ))
+        XCTAssertFalse(policy.shouldStopDescent(
+            childPath: "/System/Volumes/Data/Users/colin",
+            childDeviceID: dataVolumeDevice
+        ))
+        XCTAssertFalse(policy.shouldStopDescent(
+            childPath: "/System/Volumes/VM/swapfile0",
+            childDeviceID: 0x0100_0004
+        ))
+    }
+
+    func testForeignContainerMountsBecomeLeaves() {
+        let policy = ScanEngine.ScanVolumeBoundaryPolicy.resolve(
+            rootPath: "/",
+            rootDeviceID: systemVolumeDevice,
+            mountedFileSystems: makeDefaultMounts()
+        )
+
+        XCTAssertTrue(policy.shouldStopDescent(
+            childPath: "/Volumes/External",
+            childDeviceID: externalVolumeDevice
+        ))
+        XCTAssertTrue(policy.shouldStopDescent(
+            childPath: "/Volumes/External/Backup/Library",
+            childDeviceID: externalVolumeDevice
+        ))
+        XCTAssertTrue(policy.shouldStopDescent(
+            childPath: "/home/smb-user",
+            childDeviceID: externalVolumeDevice
+        ))
+    }
+
+    func testDiskImageMountInsideScannedTreeBecomesLeaf() {
+        var mounts = makeDefaultMounts()
+        mounts.append(ScanEngine.ScanMountedFileSystem(
+            mountPath: "/Users/colin/MountedImage",
+            deviceName: "/dev/disk3s4",
+            fileSystemType: "apfs"
+        ))
+        let policy = ScanEngine.ScanVolumeBoundaryPolicy.resolve(
+            rootPath: "/System/Volumes/Data/Users/colin",
+            rootDeviceID: dataVolumeDevice,
+            mountedFileSystems: mounts
+        )
+
+        XCTAssertTrue(policy.shouldStopDescent(
+            childPath: "/Users/colin/MountedImage",
+            childDeviceID: diskImageDevice
+        ))
+        XCTAssertFalse(policy.shouldStopDescent(
+            childPath: "/Users/colin/Documents",
+            childDeviceID: dataVolumeDevice
+        ))
+    }
+
+    func testFolderScanOnExternalVolumeUsesItsOwnContainer() {
+        var mounts = makeDefaultMounts()
+        mounts.append(ScanEngine.ScanMountedFileSystem(
+            mountPath: "/Volumes/External/SecondSlice",
+            deviceName: "/dev/disk2s3",
+            fileSystemType: "apfs"
+        ))
+        let policy = ScanEngine.ScanVolumeBoundaryPolicy.resolve(
+            rootPath: "/Volumes/External/scan-me",
+            rootDeviceID: externalVolumeDevice,
+            mountedFileSystems: mounts
+        )
+
+        XCTAssertFalse(policy.shouldStopDescent(
+            childPath: "/Volumes/External/SecondSlice/data",
+            childDeviceID: 0x0200_0003
+        ))
+        XCTAssertTrue(policy.shouldStopDescent(
+            childPath: "/System/Volumes/Data/Users/colin",
+            childDeviceID: dataVolumeDevice
+        ))
+    }
+
+    func testMissingDeviceInformationNeverStopsTraversal() {
+        let policy = ScanEngine.ScanVolumeBoundaryPolicy.resolve(
+            rootPath: "/",
+            rootDeviceID: systemVolumeDevice,
+            mountedFileSystems: makeDefaultMounts()
+        )
+        XCTAssertFalse(policy.shouldStopDescent(childPath: "/Volumes/Unknown", childDeviceID: nil))
+
+        let unresolvedPolicy = ScanEngine.ScanVolumeBoundaryPolicy.resolve(
+            rootPath: "/",
+            rootDeviceID: nil,
+            mountedFileSystems: makeDefaultMounts()
+        )
+        XCTAssertFalse(unresolvedPolicy.shouldStopDescent(
+            childPath: "/Volumes/External",
+            childDeviceID: externalVolumeDevice
+        ))
+    }
+
+    func testNonAPFSMountsWithMatchingDiskPrefixStayBlocked() {
+        var mounts = makeDefaultMounts()
+        mounts.append(ScanEngine.ScanMountedFileSystem(
+            mountPath: "/LegacySlice",
+            deviceName: "/dev/disk1s7",
+            fileSystemType: "hfs"
+        ))
+        let policy = ScanEngine.ScanVolumeBoundaryPolicy.resolve(
+            rootPath: "/",
+            rootDeviceID: systemVolumeDevice,
+            mountedFileSystems: mounts
+        )
+
+        XCTAssertTrue(policy.shouldStopDescent(
+            childPath: "/LegacySlice/data",
+            childDeviceID: 0x0100_0007
+        ))
+    }
+
+    func testSimilarMountPathsDoNotAliasEachOther() {
+        var mounts = makeDefaultMounts()
+        mounts.append(ScanEngine.ScanMountedFileSystem(
+            mountPath: "/System/Volumes/DataPrivate",
+            deviceName: "/dev/disk9s9",
+            fileSystemType: "apfs"
+        ))
+        let policy = ScanEngine.ScanVolumeBoundaryPolicy.resolve(
+            rootPath: "/",
+            rootDeviceID: systemVolumeDevice,
+            mountedFileSystems: mounts
+        )
+
+        XCTAssertTrue(policy.shouldStopDescent(
+            childPath: "/System/Volumes/DataPrivate/stash",
+            childDeviceID: 0x0900_0009
+        ))
+        XCTAssertFalse(policy.shouldStopDescent(
+            childPath: "/System/Volumes/Data/Users",
+            childDeviceID: dataVolumeDevice
+        ))
+    }
+}


### PR DESCRIPTION
## Summary

- keep scans on the selected filesystem by rejecting foreign-device traversal
- validate directory identity around path-based Foundation enumeration and convert replacement races into localized partial warnings
- apply the same identity contract to pooled and nonpooled atomic and package summary work, including child queueing and pool restart

## Validation

- swift test --scratch-path .build/.swiftpm (835 tests, 24 skipped)
- xcodebuild -project Radix.xcodeproj -scheme Radix -configuration Debug -destination platform=macOS -derivedDataPath .build/xcode-derived-data build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Scans now respect volume boundaries, treating mounted disks, disk images, and other foreign volumes as leaf nodes while continuing through supported same-volume paths.
  - Directory scans validate filesystem identity during traversal to help prevent incorrect results when folders are replaced or moved.
  - Improved fallback handling preserves partial results and continues processing remaining work.

- **Bug Fixes**
  - Improved cancellation, progress reporting, and error handling during directory enumeration.
  - Added safeguards for unavailable, missing, or changed filesystem identities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->