### PR TITLE
feat(ui): explain APFS shared storage

### DIFF
--- a/Radix/Features/FileList/FileBrowserNameCell.swift
+++ b/Radix/Features/FileList/FileBrowserNameCell.swift
@@ -5,22 +5,47 @@ struct FileBrowserNameCell: View {
     let subtitleOverride: String?
     let isExpanding: Bool
     let expandAction: () -> Void
+    @Binding var presentedSharedStorageNodeID: FileNodeRecord.ID?
 
     var body: some View {
-        HStack(spacing: 10) {
-            Image(systemName: node.systemImageName)
-                .foregroundStyle(node.isDirectory || node.isSynthetic ? Color.accentColor : Color.secondary)
-
-            VStack(alignment: .leading, spacing: 2) {
-                Text(node.name)
-                    .lineLimit(1)
-
-                if let statusText = subtitleOverride ?? node.secondaryStatusText {
-                    Text(statusText)
-                        .font(.caption)
-                        .foregroundStyle(searchSubtitleColor)
-                        .lineLimit(1)
+        if node.sharedStorageDescription != nil {
+            cellContent
+                .accessibilityAction(named: "About shared APFS storage") {
+                    presentedSharedStorageNodeID = node.id
                 }
+        } else {
+            cellContent
+        }
+    }
+
+    private var cellContent: some View {
+        HStack(spacing: 10) {
+            HStack(spacing: 10) {
+                Image(systemName: fileBrowserSystemImageName)
+                    .foregroundStyle(node.isDirectory || node.isSynthetic ? Color.accentColor : Color.secondary)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(node.name)
+                        .lineLimit(1)
+
+                    if let statusText = subtitleOverride ?? node.secondaryStatusText {
+                        Text(statusText)
+                            .font(.caption)
+                            .foregroundStyle(searchSubtitleColor)
+                            .lineLimit(1)
+                    }
+                }
+            }
+            .accessibilityElement(children: .combine)
+
+            if let title = node.secondaryStatusText,
+               let description = node.sharedStorageDescription {
+                SharedStorageInfoButton(
+                    nodeID: node.id,
+                    title: title,
+                    description: description,
+                    presentedNodeID: $presentedSharedStorageNodeID
+                )
             }
 
             if node.isAutoSummarized {
@@ -31,7 +56,11 @@ struct FileBrowserNameCell: View {
                 )
             }
         }
-        .accessibilityElement(children: .combine)
+        .accessibilityElement(children: .contain)
+    }
+
+    private var fileBrowserSystemImageName: String {
+        node.cloneIdentity == nil ? node.systemImageName : "doc.on.doc"
     }
 
     private var searchSubtitleColor: Color {
@@ -39,6 +68,52 @@ struct FileBrowserNameCell: View {
             return .secondary
         }
         return node.isSynthetic ? .secondary : .orange
+    }
+}
+
+private struct SharedStorageInfoButton: View {
+    let nodeID: FileNodeRecord.ID
+    let title: String
+    let description: String
+    @Binding var presentedNodeID: FileNodeRecord.ID?
+
+    var body: some View {
+        Button {
+            presentedNodeID = nodeID
+        } label: {
+            Label("About shared APFS storage", systemImage: "info.circle")
+                .labelStyle(.iconOnly)
+                .foregroundStyle(.secondary)
+        }
+        .buttonStyle(.plain)
+        .selectionDisabled()
+        .help("About shared APFS storage")
+        .popover(isPresented: isPresented, arrowEdge: .bottom) {
+            VStack(alignment: .leading, spacing: 8) {
+                Text(title)
+                    .font(.headline)
+
+                Text(description)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .font(.callout)
+            .padding(16)
+            .frame(width: 310, alignment: .leading)
+        }
+    }
+
+    private var isPresented: Binding<Bool> {
+        Binding(
+            get: { presentedNodeID == nodeID },
+            set: { shouldPresent in
+                if shouldPresent {
+                    presentedNodeID = nodeID
+                } else if presentedNodeID == nodeID {
+                    presentedNodeID = nil
+                }
+            }
+        )
     }
 }
 

--- a/Radix/Features/FileList/FileBrowserTableView.swift
+++ b/Radix/Features/FileList/FileBrowserTableView.swift
@@ -31,6 +31,7 @@ struct FileBrowserTableView: View {
 
     @StateObject private var model: FileBrowserModel
     @FocusState private var isSearchFieldFocused: Bool
+    @State private var presentedSharedStorageNodeID: FileNodeRecord.ID?
 
     init(
         scanState: ScanCoordinator,
@@ -152,6 +153,7 @@ struct FileBrowserTableView: View {
             updateModelContent()
         }
         .onDisappear {
+            presentedSharedStorageNodeID = nil
             model.cleanup()
         }
         .onChange(of: focusedWorkspaceTarget) { _, target in
@@ -197,7 +199,8 @@ struct FileBrowserTableView: View {
                     node: node,
                     subtitleOverride: subtitle(for: node),
                     isExpanding: isExpanding(node),
-                    expandAction: { expandSummarizedNode(node) }
+                    expandAction: { expandSummarizedNode(node) },
+                    presentedSharedStorageNodeID: $presentedSharedStorageNodeID
                 )
             }
             .width(min: 260, ideal: 360)

--- a/Radix/Features/Inspector/InspectorDetailsSections.swift
+++ b/Radix/Features/Inspector/InspectorDetailsSections.swift
@@ -16,6 +16,15 @@ struct InspectorDetailsSections: View {
             )
         }
 
+        if let sharedStorageDescription = node.sharedStorageDescription {
+            Section("Storage") {
+                Text(sharedStorageDescription)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+
         Section("Metadata") {
             LabeledContent("Kind") {
                 Text(node.itemKind(activeTarget: activeTarget))

--- a/Radix/Localizable.xcstrings
+++ b/Radix/Localizable.xcstrings
@@ -15646,6 +15646,47 @@
         }
       }
     },
+    "About shared APFS storage" : {
+      "comment" : "Help and accessibility label for a button that explains shared APFS storage.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Über gemeinsam genutzten APFS-Speicher"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "About shared APFS storage"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Acerca del almacenamiento APFS compartido"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "À propos du stockage APFS partagé"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Informazioni sullo spazio APFS condiviso"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关于共享 APFS 存储空间"
+          }
+        }
+      }
+    },
     "APFS clone · shared storage" : {
       "comment" : "Secondary status for a full APFS clone whose data storage is shared with another file.",
       "localizations" : {

--- a/Radix/Localizable.xcstrings
+++ b/Radix/Localizable.xcstrings
@@ -15687,6 +15687,129 @@
         }
       }
     },
+    "APFS lets files share storage. Radix counts shared bytes once, so one file carries the allocated size and the others may show zero. That file is only an accounting representative, not an original. Deleting one clone may not free the displayed amount." : {
+      "comment" : "Inspector explanation for a full APFS clone and Radix's shared-storage accounting.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "APFS ermöglicht es Dateien, Speicher gemeinsam zu nutzen. Radix zählt gemeinsam genutzte Bytes nur einmal, sodass eine Datei die zugeordnete Größe trägt und die anderen möglicherweise null anzeigen. Diese Datei ist nur ein Repräsentant für die Speicherzuordnung, nicht das Original. Durch das Löschen eines Klons wird möglicherweise nicht der angezeigte Speicherplatz freigegeben."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "APFS lets files share storage. Radix counts shared bytes once, so one file carries the allocated size and the others may show zero. That file is only an accounting representative, not an original. Deleting one clone may not free the displayed amount."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "APFS permite que los archivos compartan almacenamiento. Radix cuenta los bytes compartidos una sola vez, por lo que un archivo muestra el tamaño asignado y los demás pueden mostrar cero. Ese archivo es solo un representante contable, no el original. Eliminar un clon puede no liberar la cantidad mostrada."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "APFS permet aux fichiers de partager de l’espace de stockage. Radix ne compte les octets partagés qu’une seule fois : un fichier porte donc la taille allouée et les autres peuvent afficher zéro. Ce fichier est uniquement un représentant comptable, pas l’original. La suppression d’un clone peut ne pas libérer la quantité affichée."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "APFS consente ai file di condividere spazio di archiviazione. Radix conta i byte condivisi una sola volta, quindi un file riporta la dimensione allocata e gli altri possono mostrare zero. Quel file è solo un riferimento contabile, non l’originale. L’eliminazione di un clone potrebbe non liberare la quantità indicata."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "APFS 允许文件共享存储空间。Radix 只计算一次共享字节，因此一个文件会显示已分配大小，而其他文件可能显示为零。该文件只是记账代表，并非原始文件。删除一个克隆文件不一定会释放所显示的空间。"
+          }
+        }
+      }
+    },
+    "Parts of this file may share APFS storage. macOS does not expose enough information for Radix to calculate exact shared or reclaimable bytes." : {
+      "comment" : "Inspector explanation for a file that may still share some APFS data blocks.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Teile dieser Datei nutzen möglicherweise APFS-Speicher gemeinsam. macOS stellt Radix nicht genügend Informationen bereit, um die genaue Anzahl gemeinsam genutzter oder freigebbarer Bytes zu berechnen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Parts of this file may share APFS storage. macOS does not expose enough information for Radix to calculate exact shared or reclaimable bytes."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Es posible que partes de este archivo compartan almacenamiento APFS. macOS no proporciona a Radix suficiente información para calcular con exactitud los bytes compartidos o recuperables."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Certaines parties de ce fichier peuvent partager du stockage APFS. macOS ne fournit pas à Radix suffisamment d’informations pour calculer précisément les octets partagés ou récupérables."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Parti di questo file potrebbero condividere spazio APFS. macOS non fornisce a Radix informazioni sufficienti per calcolare con esattezza i byte condivisi o recuperabili."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此文件的部分内容可能共享 APFS 存储空间。macOS 未向 Radix 提供足够的信息，无法精确计算共享或可释放的字节数。"
+          }
+        }
+      }
+    },
+    "Storage" : {
+      "comment" : "Inspector section containing information about a file's storage behavior.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Speicher"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Storage"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Almacenamiento"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stockage"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Archiviazione"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "存储空间"
+          }
+        }
+      }
+    },
     "Show" : {
       "localizations" : {
         "de" : {

--- a/Radix/Localizable.xcstrings
+++ b/Radix/Localizable.xcstrings
@@ -15646,43 +15646,43 @@
         }
       }
     },
-    "Shared APFS storage" : {
+    "APFS clone · shared storage" : {
       "comment" : "Secondary status for a full APFS clone whose data storage is shared with another file.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Geteilter APFS-Speicher"
+            "value" : "APFS-Klon · geteilter Speicher"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Shared APFS storage"
+            "value" : "APFS clone · shared storage"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Almacenamiento APFS compartido"
+            "value" : "Clon de APFS · almacenamiento compartido"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Stockage APFS partagé"
+            "value" : "Clone APFS · stockage partagé"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Spazio APFS condiviso"
+            "value" : "Clone APFS · spazio condiviso"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "共享的 APFS 存储空间"
+            "value" : "APFS 克隆 · 共享存储空间"
           }
         }
       }

--- a/Radix/Models/FileNodeRecord.swift
+++ b/Radix/Models/FileNodeRecord.swift
@@ -209,7 +209,7 @@ extension FileNodeRecord {
             return String(localized: "Limited access", comment: "Secondary status for a file or folder that could not be fully read.")
         }
         if cloneIdentity != nil {
-            return String(localized: "Shared APFS storage", comment: "Secondary status for a full APFS clone whose data storage is shared with another file.")
+            return String(localized: "APFS clone · shared storage", comment: "Secondary status for a full APFS clone whose data storage is shared with another file.")
         }
         if mayShareDataBlocks {
             return String(localized: "May share APFS storage", comment: "Secondary status for a file that may still share some APFS data blocks with another file.")

--- a/Radix/Models/FileNodeRecord.swift
+++ b/Radix/Models/FileNodeRecord.swift
@@ -217,6 +217,22 @@ extension FileNodeRecord {
         return nil
     }
 
+    var sharedStorageDescription: String? {
+        if cloneIdentity != nil {
+            return String(
+                localized: "APFS lets files share storage. Radix counts shared bytes once, so one file carries the allocated size and the others may show zero. That file is only an accounting representative, not an original. Deleting one clone may not free the displayed amount.",
+                comment: "Inspector explanation for a full APFS clone and Radix's shared-storage accounting."
+            )
+        }
+        if mayShareDataBlocks {
+            return String(
+                localized: "Parts of this file may share APFS storage. macOS does not expose enough information for Radix to calculate exact shared or reclaimable bytes.",
+                comment: "Inspector explanation for a file that may still share some APFS data blocks."
+            )
+        }
+        return nil
+    }
+
     var accessDescription: String {
         if isSynthetic {
             return String(localized: "Estimated", comment: "Metadata value indicating that storage is estimated.")

--- a/RadixCoreTests/FileNodeRecordTests.swift
+++ b/RadixCoreTests/FileNodeRecordTests.swift
@@ -40,7 +40,7 @@ final class FileNodeRecordTests: XCTestCase {
             mayShareDataBlocks: true
         )
 
-        XCTAssertEqual(fullClone.secondaryStatusText, "Shared APFS storage")
+        XCTAssertEqual(fullClone.secondaryStatusText, "APFS clone · shared storage")
         XCTAssertEqual(partialClone.secondaryStatusText, "May share APFS storage")
     }
 }

--- a/RadixCoreTests/FileNodeRecordTests.swift
+++ b/RadixCoreTests/FileNodeRecordTests.swift
@@ -39,8 +39,18 @@ final class FileNodeRecordTests: XCTestCase {
             name: "partial.bin",
             mayShareDataBlocks: true
         )
+        let regularFile = makeTestFileNode(id: "/regular.bin", name: "regular.bin")
 
         XCTAssertEqual(fullClone.secondaryStatusText, "APFS clone · shared storage")
         XCTAssertEqual(partialClone.secondaryStatusText, "May share APFS storage")
+        XCTAssertEqual(
+            fullClone.sharedStorageDescription,
+            "APFS lets files share storage. Radix counts shared bytes once, so one file carries the allocated size and the others may show zero. That file is only an accounting representative, not an original. Deleting one clone may not free the displayed amount."
+        )
+        XCTAssertEqual(
+            partialClone.sharedStorageDescription,
+            "Parts of this file may share APFS storage. macOS does not expose enough information for Radix to calculate exact shared or reclaimable bytes."
+        )
+        XCTAssertNil(regularFile.sharedStorageDescription)
     }
 }


### PR DESCRIPTION
## Summary

- label confirmed APFS clones as shared storage and distinguish possible partial sharing
- explain Radix allocation attribution and reclaimability limits in the Inspector
- add a confirmed-clone icon and contextual info popover in the File Browser
- localize the new UI for every supported locale

## Validation

- swift test: 846 passed, 24 skipped
- complete Debug macOS app build
- manual rendering with a real APFS clone fixture

Closes #47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clear labels and explanations for files using shared APFS storage.
  * Added an accessible info action and popover with shared-storage details.
  * Added a Storage section to file details when applicable.
  * Updated clone icons and status text for improved clarity.

* **Localization**
  * Added and updated translations for shared APFS storage terminology and explanations.

* **Bug Fixes**
  * Improved accessibility structure and interaction for file name cells.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->