### PR TITLE
feat(inspector): redesign selection experience

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -105,6 +105,7 @@ let package = Package(
                 "ViewModels/AppModel.swift",
                 "ViewModels/AppPresentationCoordinator.swift",
                 "ViewModels/ComparisonFlowController.swift",
+                "ViewModels/InspectorSelectionSummary.swift",
                 "ViewModels/ScanComparisonBrowserModel.swift",
                 "ViewModels/ScanComparisonSetup.swift",
                 "ViewModels/SidebarScanCacheController.swift",

--- a/Radix/ContentView.swift
+++ b/Radix/ContentView.swift
@@ -818,6 +818,7 @@ private extension ContentView {
             zoomIntoSelection: { appModel.zoomIntoSelection() },
             selectedFileActions: primarySelectedFileActions,
             addPrimarySelectionToDiscardPile: { appModel.addPrimarySelectionToDiscardPileAfterViewUpdate() },
+            bulkFileActions: bulkFileActions,
             openFullDiskAccessSettings: { appModel.prepareAndOpenFullDiskAccessSettings() }
         )
     }

--- a/Radix/ContentView.swift
+++ b/Radix/ContentView.swift
@@ -815,7 +815,6 @@ private extension ContentView {
             selectNodeAfterViewUpdate: { appModel.selectAfterViewUpdate(nodeID: $0) },
             selectAndFocusNodeAfterViewUpdate: { appModel.selectAndFocusAfterViewUpdate(nodeID: $0) },
             expandSummarizedNode: { appModel.expandSummarizedNode($0) {} },
-            zoomIntoSelection: { appModel.zoomIntoSelection() },
             selectedFileActions: primarySelectedFileActions,
             addPrimarySelectionToDiscardPile: { appModel.addPrimarySelectionToDiscardPileAfterViewUpdate() },
             bulkFileActions: bulkFileActions,

--- a/Radix/Features/Inspector/InspectorActionsSection.swift
+++ b/Radix/Features/Inspector/InspectorActionsSection.swift
@@ -1,106 +1,42 @@
 import SwiftUI
 
-struct InspectorActionsSection: View {
-    let availability: FileNodeActionAvailability
-    let canExpandSummarizedSelection: Bool
-    let canZoomIntoSelection: Bool
-    let fileActions: SelectedFileActions
-    let addToDiscardPile: () -> Void
-    let expandAction: () -> Void
-    let zoomAction: () -> Void
+struct InspectorActionBar: View {
+    let revealAction: (() -> Void)?
+    let addToDiscardPileAction: (() -> Void)?
+    let addToDiscardPileTitle: String
 
     var body: some View {
-        Section("Actions") {
-            VStack(alignment: .leading, spacing: 8) {
-                Button {
-                    fileActions.perform(.quickLook)
-                } label: {
-                    Label(FileNodeAction.quickLook.title, systemImage: FileNodeAction.quickLook.systemImageName)
-                        .frame(maxWidth: .infinity)
-                }
-                .buttonStyle(.borderedProminent)
-                .disabled(!FileNodeAction.quickLook.isEnabled(in: availability))
+        VStack(spacing: 0) {
+            Divider()
 
-                Button {
-                    fileActions.perform(.revealInFinder)
-                } label: {
-                    Label(FileNodeAction.revealInFinder.title, systemImage: FileNodeAction.revealInFinder.systemImageName)
+            VStack(spacing: 8) {
+                if let revealAction {
+                    Button {
+                        revealAction()
+                    } label: {
+                        Label(
+                            FileNodeAction.revealInFinder.title,
+                            systemImage: FileNodeAction.revealInFinder.systemImageName
+                        )
                         .frame(maxWidth: .infinity)
-                }
-                .buttonStyle(.bordered)
-                .disabled(!FileNodeAction.revealInFinder.isEnabled(in: availability))
-
-                if canExpandSummarizedSelection {
-                    Button {
-                        expandAction()
-                    } label: {
-                        Label("Expand Fully", systemImage: "arrowshape.turn.up.right.circle.fill")
-                            .frame(maxWidth: .infinity)
-                    }
-                    .buttonStyle(.bordered)
-                } else if canZoomIntoSelection {
-                    Button {
-                        zoomAction()
-                    } label: {
-                        Label("Zoom Into Folder", systemImage: "plus.magnifyingglass")
-                            .frame(maxWidth: .infinity)
                     }
                     .buttonStyle(.bordered)
                 }
 
-                ViewThatFits(in: .horizontal) {
-                    HStack(spacing: 8) {
-                        openButton
-                        copyPathButton
+                if let addToDiscardPileAction {
+                    Button {
+                        addToDiscardPileAction()
+                    } label: {
+                        Label(addToDiscardPileTitle, systemImage: "checklist")
+                            .frame(maxWidth: .infinity)
                     }
-
-                    VStack(spacing: 8) {
-                        openButton
-                        copyPathButton
-                    }
+                    .buttonStyle(.borderedProminent)
                 }
-
-                Button {
-                    addToDiscardPile()
-                } label: {
-                    Label("Add to Discard Pile", systemImage: "checklist")
-                        .frame(maxWidth: .infinity)
-                }
-                .buttonStyle(.bordered)
-                .disabled(!availability.canMoveToTrash)
-
-                Button(role: .destructive) {
-                    fileActions.perform(.moveToTrash)
-                } label: {
-                    Label(FileNodeAction.moveToTrash.title, systemImage: FileNodeAction.moveToTrash.systemImageName)
-                        .frame(maxWidth: .infinity)
-                }
-                .buttonStyle(.bordered)
-                .disabled(!FileNodeAction.moveToTrash.isEnabled(in: availability))
             }
             .controlSize(.regular)
+            .padding(.horizontal, 18)
+            .padding(.vertical, 10)
+            .background(.bar)
         }
-    }
-
-    private var openButton: some View {
-        Button {
-            fileActions.perform(.open)
-        } label: {
-            Label(FileNodeAction.open.title, systemImage: FileNodeAction.open.systemImageName)
-                .frame(maxWidth: .infinity)
-        }
-        .buttonStyle(.bordered)
-        .disabled(!FileNodeAction.open.isEnabled(in: availability))
-    }
-
-    private var copyPathButton: some View {
-        Button {
-            fileActions.perform(.copyPath)
-        } label: {
-            Label(FileNodeAction.copyPath.title, systemImage: FileNodeAction.copyPath.systemImageName)
-                .frame(maxWidth: .infinity)
-        }
-        .buttonStyle(.bordered)
-        .disabled(!FileNodeAction.copyPath.isEnabled(in: availability))
     }
 }

--- a/Radix/Features/Inspector/InspectorDetailsSections.swift
+++ b/Radix/Features/Inspector/InspectorDetailsSections.swift
@@ -1,112 +1,236 @@
 import SwiftUI
 
-struct InspectorDetailsSections: View {
-    let node: FileNodeRecord
-    let parentName: String?
-    let percentOfParent: String
+struct InspectorStorageSection: View {
+    let allocatedSize: Int64
+    let percentOfParent: String?
     let percentOfScan: String
-    let activeTarget: ScanTarget?
+    var notes: [String] = []
 
     var body: some View {
-        Section("Key Stats") {
-            InspectorKeyStats(stats: [
-                InspectorStat(
-                    id: "allocated",
-                    title: String(localized: "Allocated", comment: "Inspector storage statistic title."),
-                    value: RadixFormatters.size(node.allocatedSize)
-                ),
-                InspectorStat(
-                    id: "parent",
-                    title: String(localized: "Of Parent", comment: "Inspector statistic for a selected item's share of its parent folder."),
-                    value: percentOfParent
-                ),
-                InspectorStat(
-                    id: "scan",
-                    title: String(localized: "Of Scan", comment: "Inspector statistic for a selection's share of the entire scan."),
-                    value: percentOfScan
-                )
-            ])
-        }
+        Section {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(alignment: .firstTextBaseline, spacing: 7) {
+                    Text(RadixFormatters.size(allocatedSize))
+                        .font(.title2.weight(.semibold).monospacedDigit())
+                        .accessibilityLabel(
+                            String(
+                                localized: "Allocated size \(RadixFormatters.size(allocatedSize))",
+                                comment: "Accessibility label for the allocated storage value in the Inspector."
+                            )
+                        )
 
-        if let sharedStorageDescription = node.sharedStorageDescription {
-            Section("Storage") {
-                Text(sharedStorageDescription)
+                    Text("Allocated")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                if allocatedSize > 0 {
+                    HStack(spacing: 18) {
+                        if let percentOfParent {
+                            InspectorPercentageMetric(value: percentOfParent, label: "of parent")
+                        }
+
+                        InspectorPercentageMetric(value: percentOfScan, label: "of scan")
+                    }
+                }
+
+                ForEach(notes, id: \.self) { note in
+                    Text(note)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(.top, 2)
+                }
+            }
+        }
+    }
+}
+
+private struct InspectorPercentageMetric: View {
+    let value: String
+    let label: LocalizedStringKey
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 4) {
+            Text(value)
+                .font(.subheadline.weight(.semibold).monospacedDigit())
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .accessibilityElement(children: .combine)
+    }
+}
+
+struct InspectorSharedStorageSection: View {
+    let node: FileNodeRecord
+
+    var body: some View {
+        Section {
+            VStack(alignment: .leading, spacing: 6) {
+                Label(title, systemImage: "doc.on.doc.fill")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Color.accentColor)
+
+                Text(message)
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
         }
+    }
 
-        Section("Metadata") {
+    private var title: LocalizedStringKey {
+        node.cloneIdentity == nil ? "May share APFS storage" : "Shared APFS storage"
+    }
+
+    private var message: String {
+        let logicalSize = RadixFormatters.size(node.logicalSize)
+        if node.cloneIdentity != nil {
+            return String(
+                localized: "\(logicalSize) logical size. Radix counts shared bytes once across clones, so deleting this file may free less than its apparent size.",
+                comment: "Inspector explanation for an APFS clone's logical size and attributed allocated storage."
+            )
+        }
+        return String(
+            localized: "\(logicalSize) logical size. Parts of this file may share storage; exact shared and reclaimable bytes aren’t available from macOS.",
+            comment: "Inspector explanation for a file that may share APFS storage."
+        )
+    }
+}
+
+struct InspectorMultiSharedStorageSection: View {
+    let containsKnownClones: Bool
+
+    var body: some View {
+        Section {
+            VStack(alignment: .leading, spacing: 6) {
+                Label(title, systemImage: "doc.on.doc.fill")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Color.accentColor)
+
+                Text("Some selected files may share APFS storage. Allocated totals reflect Radix’s storage attribution and may differ from the space reclaimed by deletion.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private var title: LocalizedStringKey {
+        containsKnownClones ? "Shared APFS storage" : "May share APFS storage"
+    }
+}
+
+enum InspectorAvailabilityNoticeKind {
+    case savedScan
+    case scanRoot
+    case protectedLocation
+    case protectedSelection
+    case limitedSelection
+}
+
+struct InspectorAvailabilityNotice: View {
+    let kind: InspectorAvailabilityNoticeKind
+
+    var body: some View {
+        Section {
+            VStack(alignment: .leading, spacing: 6) {
+                Label(title, systemImage: systemImage)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(color)
+
+                Text(message)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private var title: LocalizedStringKey {
+        switch kind {
+        case .savedScan: "Saved scan"
+        case .scanRoot: "Scan root"
+        case .protectedLocation: "Protected location"
+        case .protectedSelection: "Protected selection"
+        case .limitedSelection: "Limited actions"
+        }
+    }
+
+    private var message: LocalizedStringKey {
+        switch kind {
+        case .savedScan:
+            "This selection comes from a saved scan. Removal actions are unavailable."
+        case .scanRoot:
+            "The scanned volume itself cannot be added to the Discard Pile or moved to Trash."
+        case .protectedLocation:
+            "This location is protected from removal. You can still open it or reveal it in Finder."
+        case .protectedSelection:
+            "Some selected items are protected from removal. You can still reveal them in Finder."
+        case .limitedSelection:
+            "Some selected items do not represent regular file paths, so file actions are unavailable."
+        }
+    }
+
+    private var systemImage: String {
+        switch kind {
+        case .savedScan: "archivebox.fill"
+        case .scanRoot: "externaldrive.fill"
+        case .protectedLocation: "lock.fill"
+        case .protectedSelection: "lock.fill"
+        case .limitedSelection: "exclamationmark.triangle.fill"
+        }
+    }
+
+    private var color: Color {
+        switch kind {
+        case .savedScan, .scanRoot: .accentColor
+        case .protectedLocation, .protectedSelection, .limitedSelection: .orange
+        }
+    }
+}
+
+struct InspectorSummarizedSection: View {
+    let expand: () -> Void
+
+    var body: some View {
+        Section {
+            VStack(alignment: .leading, spacing: 8) {
+                Label("Contents summarized", systemImage: "square.stack.3d.up.fill")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Color.accentColor)
+
+                Text("Radix grouped this folder during the scan. Expand it to inspect individual items.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Button {
+                    expand()
+                } label: {
+                    Label("Expand Fully", systemImage: "arrowshape.turn.up.right.circle.fill")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+            }
+        }
+    }
+}
+
+struct InspectorDetailsSection: View {
+    let node: FileNodeRecord
+    let activeTarget: ScanTarget?
+
+    var body: some View {
+        Section("Details") {
             LabeledContent("Kind") {
                 Text(node.itemKind(activeTarget: activeTarget))
-            }
-
-            LabeledContent("Logical Size") {
-                Text(RadixFormatters.size(node.logicalSize))
-            }
-
-            if let parentName {
-                LabeledContent("Parent") {
-                    Text(parentName)
-                }
             }
 
             LabeledContent("Modified") {
                 Text(RadixFormatters.date(node.lastModified))
             }
-
-            LabeledContent("Access") {
-                Text(node.accessDescription)
-            }
         }
-    }
-}
-
-struct InspectorStat: Identifiable {
-    let id: String
-    let title: String
-    let value: String
-}
-
-struct InspectorKeyStats: View {
-    let stats: [InspectorStat]
-
-    var body: some View {
-        ViewThatFits(in: .horizontal) {
-            HStack(spacing: 8) {
-                ForEach(stats) { stat in
-                    InspectorStatCard(title: stat.title, value: stat.value)
-                }
-            }
-
-            VStack(spacing: 8) {
-                ForEach(stats) { stat in
-                    InspectorStatCard(title: stat.title, value: stat.value)
-                }
-            }
-        }
-    }
-}
-
-private struct InspectorStatCard: View {
-    let title: String
-    let value: String
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(title)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-
-            Text(value)
-                .font(.headline.monospacedDigit())
-                .lineLimit(1)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.horizontal, 10)
-        .padding(.vertical, 8)
-        .background(Color(nsColor: .controlBackgroundColor), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
-        .accessibilityElement(children: .combine)
     }
 }

--- a/Radix/Features/Inspector/InspectorDetailsSections.swift
+++ b/Radix/Features/Inspector/InspectorDetailsSections.swift
@@ -9,11 +9,23 @@ struct InspectorDetailsSections: View {
 
     var body: some View {
         Section("Key Stats") {
-            InspectorKeyStats(
-                allocatedSize: RadixFormatters.size(node.allocatedSize),
-                percentOfParent: percentOfParent,
-                percentOfScan: percentOfScan
-            )
+            InspectorKeyStats(stats: [
+                InspectorStat(
+                    id: "allocated",
+                    title: String(localized: "Allocated", comment: "Inspector storage statistic title."),
+                    value: RadixFormatters.size(node.allocatedSize)
+                ),
+                InspectorStat(
+                    id: "parent",
+                    title: String(localized: "Of Parent", comment: "Inspector statistic for a selected item's share of its parent folder."),
+                    value: percentOfParent
+                ),
+                InspectorStat(
+                    id: "scan",
+                    title: String(localized: "Of Scan", comment: "Inspector statistic for a selection's share of the entire scan."),
+                    value: percentOfScan
+                )
+            ])
         }
 
         if let sharedStorageDescription = node.sharedStorageDescription {
@@ -51,23 +63,27 @@ struct InspectorDetailsSections: View {
     }
 }
 
-private struct InspectorKeyStats: View {
-    let allocatedSize: String
-    let percentOfParent: String
-    let percentOfScan: String
+struct InspectorStat: Identifiable {
+    let id: String
+    let title: String
+    let value: String
+}
+
+struct InspectorKeyStats: View {
+    let stats: [InspectorStat]
 
     var body: some View {
         ViewThatFits(in: .horizontal) {
             HStack(spacing: 8) {
-                InspectorStatCard(title: "Allocated", value: allocatedSize)
-                InspectorStatCard(title: "% Parent", value: percentOfParent)
-                InspectorStatCard(title: "% Scan", value: percentOfScan)
+                ForEach(stats) { stat in
+                    InspectorStatCard(title: stat.title, value: stat.value)
+                }
             }
 
             VStack(spacing: 8) {
-                InspectorStatCard(title: "Allocated", value: allocatedSize)
-                InspectorStatCard(title: "% Parent", value: percentOfParent)
-                InspectorStatCard(title: "% Scan", value: percentOfScan)
+                ForEach(stats) { stat in
+                    InspectorStatCard(title: stat.title, value: stat.value)
+                }
             }
         }
     }
@@ -91,5 +107,6 @@ private struct InspectorStatCard: View {
         .padding(.horizontal, 10)
         .padding(.vertical, 8)
         .background(Color(nsColor: .controlBackgroundColor), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+        .accessibilityElement(children: .combine)
     }
 }

--- a/Radix/Features/Inspector/InspectorLargestChildrenSection.swift
+++ b/Radix/Features/Inspector/InspectorLargestChildrenSection.swift
@@ -7,39 +7,49 @@ struct InspectorLargestChildrenSection: View {
     var body: some View {
         Section("Largest Children") {
             ForEach(children) { child in
-                Button {
+                InspectorLargestChildButton(node: child) {
                     selectChild(child)
-                } label: {
-                    LargestChildRow(node: child)
                 }
-                .buttonStyle(.plain)
             }
         }
     }
 }
 
-private struct LargestChildRow: View {
+private struct InspectorLargestChildButton: View {
     let node: FileNodeRecord
+    let select: () -> Void
+
+    @State private var isHovering = false
 
     var body: some View {
-        HStack(spacing: 10) {
-            Image(systemName: node.systemImageName)
-                .foregroundStyle(node.isDirectory ? Color.accentColor : Color.secondary)
+        Button {
+            select()
+        } label: {
+            HStack(spacing: 9) {
+                Image(systemName: node.systemImageName)
+                    .foregroundStyle(node.isDirectory ? Color.accentColor : Color.secondary)
+                    .frame(width: 18)
 
-            VStack(alignment: .leading, spacing: 2) {
                 Text(node.name)
                     .lineLimit(1)
-                Text(node.itemKind)
-                    .font(.caption)
+
+                Spacer()
+
+                Text(RadixFormatters.size(node.allocatedSize))
+                    .font(.caption.monospacedDigit())
                     .foregroundStyle(.secondary)
             }
-
-            Spacer()
-
-            Text(RadixFormatters.size(node.allocatedSize))
-                .font(.caption.monospacedDigit())
-                .foregroundStyle(.secondary)
+            .padding(.horizontal, 4)
+            .padding(.vertical, 3)
+            .background {
+                if isHovering {
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .fill(Color.accentColor.opacity(0.08))
+                }
+            }
+            .contentShape(Rectangle())
         }
-        .contentShape(Rectangle())
+        .buttonStyle(.plain)
+        .onHover { isHovering = $0 }
     }
 }

--- a/Radix/Features/Inspector/InspectorMultiSelectionView.swift
+++ b/Radix/Features/Inspector/InspectorMultiSelectionView.swift
@@ -1,0 +1,132 @@
+import SwiftUI
+
+struct InspectorMultiSelectionView: View {
+    let summary: InspectorSelectionSummary
+    let percentOfScan: String
+    let availability: FileNodeActionAvailability
+    let actions: BulkFileActions
+
+    var body: some View {
+        Form {
+            Section {
+                HStack(alignment: .top, spacing: 12) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.title2)
+                        .foregroundStyle(Color.accentColor)
+                        .frame(width: 28, height: 28)
+
+                    Text(selectionTitle)
+                        .font(.headline)
+                }
+            }
+
+            Section {
+                InspectorKeyStats(stats: [
+                    InspectorStat(
+                        id: "allocated",
+                        title: String(localized: "Allocated", comment: "Inspector storage statistic title."),
+                        value: RadixFormatters.size(summary.allocatedSize)
+                    ),
+                    InspectorStat(
+                        id: "logical",
+                        title: String(localized: "Logical Size", comment: "Inspector statistic for the apparent size of selected items."),
+                        value: RadixFormatters.size(summary.logicalSize)
+                    ),
+                    InspectorStat(
+                        id: "scan",
+                        title: String(localized: "Of Scan", comment: "Inspector statistic for a selection's share of the entire scan."),
+                        value: percentOfScan
+                    )
+                ])
+            } header: {
+                Text("Key Stats")
+            } footer: {
+                VStack(alignment: .leading, spacing: 4) {
+                    if summary.containsOverlappingSelections {
+                        Text("Overlapping selections are counted once in totals.")
+                    }
+                    Text("Sizes show attributed allocated storage, not guaranteed space reclaimed.")
+                }
+            }
+
+            Section("Actions") {
+                VStack(alignment: .leading, spacing: 8) {
+                    ViewThatFits(in: .horizontal) {
+                        HStack(spacing: 8) {
+                            revealButton
+                            copyPathsButton
+                        }
+
+                        VStack(spacing: 8) {
+                            revealButton
+                            copyPathsButton
+                        }
+                    }
+
+                    Button {
+                        actions.addToDiscardPile(summary.selectedNodes)
+                    } label: {
+                        Label(addToDiscardPileTitle, systemImage: "checklist")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.bordered)
+                    .disabled(!availability.canMoveToTrash)
+
+                    Button(role: .destructive) {
+                        actions.moveToTrash(summary.selectedNodes)
+                    } label: {
+                        Label(moveToTrashTitle, systemImage: FileNodeAction.moveToTrash.systemImageName)
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.bordered)
+                    .disabled(!availability.canMoveToTrash)
+                }
+                .controlSize(.regular)
+            }
+        }
+        .formStyle(.grouped)
+    }
+
+    private var selectionTitle: String {
+        String(
+            localized: "\(summary.selectedCount) Items Selected",
+            comment: "Inspector heading for a selection containing multiple items."
+        )
+    }
+
+    private var addToDiscardPileTitle: String {
+        String(
+            localized: "Add \(summary.selectedCount) Items to Discard Pile",
+            comment: "Action for marking multiple selected items for possible deletion."
+        )
+    }
+
+    private var moveToTrashTitle: String {
+        String(
+            localized: "Move \(summary.selectedCount) Items to Trash",
+            comment: "Destructive action for moving multiple selected items to the Trash."
+        )
+    }
+
+    private var revealButton: some View {
+        Button {
+            actions.revealInFinder(summary.selectedNodes)
+        } label: {
+            Label(FileNodeAction.revealInFinder.title, systemImage: FileNodeAction.revealInFinder.systemImageName)
+                .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.borderedProminent)
+        .disabled(!availability.canRevealInFinder)
+    }
+
+    private var copyPathsButton: some View {
+        Button {
+            actions.copyPaths(summary.selectedNodes)
+        } label: {
+            Label("Copy Paths", systemImage: FileNodeAction.copyPath.systemImageName)
+                .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.bordered)
+        .disabled(!availability.canCopyPath)
+    }
+}

--- a/Radix/Features/Inspector/InspectorMultiSelectionView.swift
+++ b/Radix/Features/Inspector/InspectorMultiSelectionView.swift
@@ -4,87 +4,113 @@ struct InspectorMultiSelectionView: View {
     let summary: InspectorSelectionSummary
     let percentOfScan: String
     let availability: FileNodeActionAvailability
+    let canMoveSelectionToTrash: Bool
+    let availabilityNotice: InspectorAvailabilityNoticeKind?
+    let warnings: [ScanWarning]
+    let fullDiskAccessAdvice: FullDiskAccessAdvice
     let actions: BulkFileActions
+    let openFullDiskAccessSettings: () -> Void
 
     var body: some View {
-        Form {
-            Section {
-                HStack(alignment: .top, spacing: 12) {
-                    Image(systemName: "checkmark.circle.fill")
-                        .font(.title2)
-                        .foregroundStyle(Color.accentColor)
-                        .frame(width: 28, height: 28)
-
-                    Text(selectionTitle)
-                        .font(.headline)
+        VStack(spacing: 0) {
+            Form {
+                Section {
+                    header
                 }
-            }
 
-            Section {
-                InspectorKeyStats(stats: [
-                    InspectorStat(
-                        id: "allocated",
-                        title: String(localized: "Allocated", comment: "Inspector storage statistic title."),
-                        value: RadixFormatters.size(summary.allocatedSize)
-                    ),
-                    InspectorStat(
-                        id: "logical",
-                        title: String(localized: "Logical Size", comment: "Inspector statistic for the apparent size of selected items."),
-                        value: RadixFormatters.size(summary.logicalSize)
-                    ),
-                    InspectorStat(
-                        id: "scan",
-                        title: String(localized: "Of Scan", comment: "Inspector statistic for a selection's share of the entire scan."),
-                        value: percentOfScan
+                InspectorStorageSection(
+                    allocatedSize: summary.allocatedSize,
+                    percentOfParent: nil,
+                    percentOfScan: percentOfScan,
+                    notes: storageNotes
+                )
+
+                if summary.containsSharedStorageItems {
+                    InspectorMultiSharedStorageSection(
+                        containsKnownClones: summary.containsKnownClones
                     )
-                ])
-            } header: {
-                Text("Key Stats")
-            } footer: {
-                VStack(alignment: .leading, spacing: 4) {
-                    if summary.containsOverlappingSelections {
-                        Text("Overlapping selections are counted once in totals.")
-                    }
-                    Text("Sizes show attributed allocated storage, not guaranteed space reclaimed.")
                 }
+
+                if !warnings.isEmpty {
+                    InspectorWarningsSection(
+                        selectionName: selectionTitle,
+                        warnings: warnings,
+                        fullDiskAccessAdvice: fullDiskAccessAdvice,
+                        openFullDiskAccessSettings: openFullDiskAccessSettings
+                    )
+                }
+
+                if let availabilityNotice {
+                    InspectorAvailabilityNotice(kind: availabilityNotice)
+                }
+
+                InspectorSelectedItemsSection(summary: summary)
             }
+            .formStyle(.grouped)
 
-            Section("Actions") {
-                VStack(alignment: .leading, spacing: 8) {
-                    ViewThatFits(in: .horizontal) {
-                        HStack(spacing: 8) {
-                            revealButton
-                            copyPathsButton
-                        }
-
-                        VStack(spacing: 8) {
-                            revealButton
-                            copyPathsButton
-                        }
-                    }
-
-                    Button {
-                        actions.addToDiscardPile(summary.selectedNodes)
-                    } label: {
-                        Label(addToDiscardPileTitle, systemImage: "checklist")
-                            .frame(maxWidth: .infinity)
-                    }
-                    .buttonStyle(.bordered)
-                    .disabled(!availability.canMoveToTrash)
-
-                    Button(role: .destructive) {
-                        actions.moveToTrash(summary.selectedNodes)
-                    } label: {
-                        Label(moveToTrashTitle, systemImage: FileNodeAction.moveToTrash.systemImageName)
-                            .frame(maxWidth: .infinity)
-                    }
-                    .buttonStyle(.bordered)
-                    .disabled(!availability.canMoveToTrash)
-                }
-                .controlSize(.regular)
+            if availability.canRevealInFinder || canMoveSelectionToTrash {
+                InspectorActionBar(
+                    revealAction: availability.canRevealInFinder
+                        ? { actions.revealInFinder(summary.selectedNodes) }
+                        : nil,
+                    addToDiscardPileAction: canMoveSelectionToTrash
+                        ? { actions.addToDiscardPile(summary.topLevelSelectedNodes) }
+                        : nil,
+                    addToDiscardPileTitle: addToDiscardPileTitle
+                )
             }
         }
-        .formStyle(.grouped)
+    }
+
+    private var header: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.title2)
+                .foregroundStyle(Color.accentColor)
+                .frame(width: 28, height: 28)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(selectionTitle)
+                    .font(.headline)
+
+                Text(selectionBreakdown)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+
+            Spacer(minLength: 4)
+
+            if availability.canCopyPath || canMoveSelectionToTrash {
+                Menu {
+                    if availability.canCopyPath {
+                        Button("Copy Paths", systemImage: FileNodeAction.copyPath.systemImageName) {
+                            actions.copyPaths(summary.selectedNodes)
+                        }
+                    }
+
+                    if canMoveSelectionToTrash {
+                        Divider()
+
+                        Button(
+                            moveToTrashTitle,
+                            systemImage: FileNodeAction.moveToTrash.systemImageName,
+                            role: .destructive
+                        ) {
+                            actions.moveToTrash(summary.topLevelSelectedNodes)
+                        }
+                    }
+                } label: {
+                    Image(systemName: "ellipsis.circle")
+                        .font(.title3)
+                        .frame(width: 28, height: 28)
+                }
+                .menuStyle(.borderlessButton)
+                .fixedSize()
+                .help("More Actions")
+                .accessibilityLabel("More Actions")
+            }
+        }
     }
 
     private var selectionTitle: String {
@@ -94,39 +120,196 @@ struct InspectorMultiSelectionView: View {
         )
     }
 
+    private var selectionBreakdown: String {
+        var components: [String] = []
+        if summary.selectedFolderCount > 0 {
+            components.append(folderCountDescription)
+        }
+        if summary.selectedFileCount > 0 {
+            components.append(fileCountDescription)
+        }
+        if summary.selectedPackageCount > 0 {
+            components.append(packageCountDescription)
+        }
+        if summary.selectedStorageCategoryCount > 0 {
+            components.append(storageCategoryCountDescription)
+        }
+        return components.joined(separator: " · ")
+    }
+
+    private var storageNotes: [String] {
+        var notes: [String] = []
+        if summary.containsOverlappingSelections {
+            notes.append(String(localized: "Items inside another selected folder are included with that folder."))
+        }
+        if summary.missingSelectedNodeCount > 0 {
+            notes.append(String(localized: "Some selected items are no longer available in this scan and are excluded from totals."))
+        }
+        notes.append(String(localized: "Allocated totals reflect Radix’s storage attribution, not guaranteed space reclaimed."))
+        return notes
+    }
+
+    private var folderCountDescription: String {
+        return String(
+            localized: "\(summary.selectedFolderCount) folders",
+            comment: "Inspector multiple-selection folder count."
+        )
+    }
+
+    private var fileCountDescription: String {
+        return String(
+            localized: "\(summary.selectedFileCount) files",
+            comment: "Inspector multiple-selection file count."
+        )
+    }
+
+    private var packageCountDescription: String {
+        return String(
+            localized: "\(summary.selectedPackageCount) packages",
+            comment: "Inspector multiple-selection package count."
+        )
+    }
+
+    private var storageCategoryCountDescription: String {
+        return String(
+            localized: "\(summary.selectedStorageCategoryCount) storage categories",
+            comment: "Inspector multiple-selection synthetic storage category count."
+        )
+    }
+
     private var addToDiscardPileTitle: String {
         String(
-            localized: "Add \(summary.selectedCount) Items to Discard Pile",
-            comment: "Action for marking multiple selected items for possible deletion."
+            localized: "Add \(summary.topLevelSelectedCount) Items to Discard Pile",
+            comment: "Action for marking one or more effective top-level selected items for possible deletion."
         )
     }
 
     private var moveToTrashTitle: String {
         String(
-            localized: "Move \(summary.selectedCount) Items to Trash",
-            comment: "Destructive action for moving multiple selected items to the Trash."
+            localized: "Move \(summary.topLevelSelectedCount) Items to Trash",
+            comment: "Destructive action for moving one or more effective top-level selected items to the Trash."
         )
     }
+}
 
-    private var revealButton: some View {
-        Button {
-            actions.revealInFinder(summary.selectedNodes)
-        } label: {
-            Label(FileNodeAction.revealInFinder.title, systemImage: FileNodeAction.revealInFinder.systemImageName)
-                .frame(maxWidth: .infinity)
+private struct InspectorSelectedItemsSection: View {
+    let summary: InspectorSelectionSummary
+
+    @State private var showsAllItems = false
+    @State private var showsAllItemsSheet = false
+
+    private let defaultVisibleCount = 3
+    private let maximumInlineCount = 100
+
+    var body: some View {
+        Section("Selected Items") {
+            ForEach(visibleNodes) { node in
+                InspectorSelectedItemRow(node: node)
+            }
+
+            if summary.selectedCount > defaultVisibleCount {
+                Button {
+                    if presentsAllItemsInSheet {
+                        showsAllItemsSheet = true
+                    } else {
+                        showsAllItems.toggle()
+                    }
+                } label: {
+                    HStack {
+                        Text(disclosureTitle)
+                        Spacer()
+                        Image(systemName: showsAllItems ? "chevron.up" : "chevron.down")
+                            .font(.caption.weight(.semibold))
+                    }
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(Color.accentColor)
+            }
         }
-        .buttonStyle(.borderedProminent)
-        .disabled(!availability.canRevealInFinder)
+        .onChange(of: summary.selectedNodes.map(\.id)) { _, _ in
+            showsAllItems = false
+            showsAllItemsSheet = false
+        }
+        .sheet(isPresented: $showsAllItemsSheet) {
+            InspectorAllSelectedItemsView(nodes: summary.selectedNodesByAllocatedSize)
+        }
     }
 
-    private var copyPathsButton: some View {
-        Button {
-            actions.copyPaths(summary.selectedNodes)
-        } label: {
-            Label("Copy Paths", systemImage: FileNodeAction.copyPath.systemImageName)
-                .frame(maxWidth: .infinity)
+    private var visibleNodes: [FileNodeRecord] {
+        showsAllItems && !presentsAllItemsInSheet
+            ? summary.selectedNodesByAllocatedSize
+            : summary.largestSelectedNodes(limit: defaultVisibleCount)
+    }
+
+    private var presentsAllItemsInSheet: Bool {
+        summary.selectedCount > maximumInlineCount
+    }
+
+    private var disclosureTitle: String {
+        if presentsAllItemsInSheet {
+            return String(
+                localized: "View All \(summary.selectedCount) Items…",
+                comment: "Action that opens the complete Inspector selected-items list in a sheet."
+            )
         }
-        .buttonStyle(.bordered)
-        .disabled(!availability.canCopyPath)
+        if showsAllItems {
+            return String(localized: "Show Less", comment: "Action that collapses the Inspector selected-items list.")
+        }
+        return String(
+            localized: "Show \(summary.selectedCount - defaultVisibleCount) More",
+            comment: "Action that expands the Inspector selected-items list."
+        )
+    }
+}
+
+private struct InspectorAllSelectedItemsView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    let nodes: [FileNodeRecord]
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("Selected Items")
+                    .font(.title2.weight(.semibold))
+
+                Spacer()
+
+                Button("Done") {
+                    dismiss()
+                }
+                .keyboardShortcut(.defaultAction)
+            }
+            .padding(16)
+
+            Divider()
+
+            List(nodes) { node in
+                InspectorSelectedItemRow(node: node)
+            }
+        }
+        .frame(minWidth: 460, minHeight: 420)
+    }
+}
+
+private struct InspectorSelectedItemRow: View {
+    let node: FileNodeRecord
+
+    var body: some View {
+        HStack(spacing: 9) {
+            Image(systemName: node.systemImageName)
+                .foregroundStyle(node.isDirectory ? Color.accentColor : Color.secondary)
+                .frame(width: 18)
+
+            Text(node.name)
+                .lineLimit(1)
+
+            Spacer()
+
+            Text(RadixFormatters.size(node.allocatedSize))
+                .font(.caption.monospacedDigit())
+                .foregroundStyle(.secondary)
+        }
     }
 }

--- a/Radix/Features/Inspector/InspectorMultiSelectionView.swift
+++ b/Radix/Features/Inspector/InspectorMultiSelectionView.swift
@@ -145,7 +145,6 @@ struct InspectorMultiSelectionView: View {
         if summary.missingSelectedNodeCount > 0 {
             notes.append(String(localized: "Some selected items are no longer available in this scan and are excluded from totals."))
         }
-        notes.append(String(localized: "Allocated totals reflect Radix’s storage attribution, not guaranteed space reclaimed."))
         return notes
     }
 
@@ -196,10 +195,11 @@ private struct InspectorSelectedItemsSection: View {
     let summary: InspectorSelectionSummary
 
     @State private var showsAllItems = false
-    @State private var showsAllItemsSheet = false
+    @State private var isPresentingAllItems = false
+    @State private var selectedItemOrder: [String] = []
 
     private let defaultVisibleCount = 3
-    private let maximumInlineCount = 100
+    private let maximumInlineCount = 12
 
     var body: some View {
         Section("Selected Items") {
@@ -209,8 +209,9 @@ private struct InspectorSelectedItemsSection: View {
 
             if summary.selectedCount > defaultVisibleCount {
                 Button {
-                    if presentsAllItemsInSheet {
-                        showsAllItemsSheet = true
+                    if usesPopover {
+                        selectedItemOrder = summary.selectedNodesByAllocatedSize.map(\.id)
+                        isPresentingAllItems = true
                     } else {
                         showsAllItems.toggle()
                     }
@@ -218,39 +219,45 @@ private struct InspectorSelectedItemsSection: View {
                     HStack {
                         Text(disclosureTitle)
                         Spacer()
-                        Image(systemName: showsAllItems ? "chevron.up" : "chevron.down")
-                            .font(.caption.weight(.semibold))
+                        if let disclosureSystemImage {
+                            Image(systemName: disclosureSystemImage)
+                                .font(.caption.weight(.semibold))
+                        }
                     }
                     .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
                 .foregroundStyle(Color.accentColor)
+                .popover(isPresented: $isPresentingAllItems, arrowEdge: .trailing) {
+                    InspectorSelectedItemsPopover(
+                        selectionTitle: selectionTitle,
+                        nodes: selectedNodesForPopover
+                    )
+                }
             }
         }
         .onChange(of: summary.selectedNodes.map(\.id)) { _, _ in
             showsAllItems = false
-            showsAllItemsSheet = false
-        }
-        .sheet(isPresented: $showsAllItemsSheet) {
-            InspectorAllSelectedItemsView(nodes: summary.selectedNodesByAllocatedSize)
+            isPresentingAllItems = false
+            selectedItemOrder = []
         }
     }
 
     private var visibleNodes: [FileNodeRecord] {
-        showsAllItems && !presentsAllItemsInSheet
+        showsAllItems
             ? summary.selectedNodesByAllocatedSize
             : summary.largestSelectedNodes(limit: defaultVisibleCount)
     }
 
-    private var presentsAllItemsInSheet: Bool {
+    private var usesPopover: Bool {
         summary.selectedCount > maximumInlineCount
     }
 
     private var disclosureTitle: String {
-        if presentsAllItemsInSheet {
+        if usesPopover {
             return String(
                 localized: "View All \(summary.selectedCount) Items…",
-                comment: "Action that opens the complete Inspector selected-items list in a sheet."
+                comment: "Action that opens the complete selected-items list in a popover."
             )
         }
         if showsAllItems {
@@ -261,35 +268,59 @@ private struct InspectorSelectedItemsSection: View {
             comment: "Action that expands the Inspector selected-items list."
         )
     }
+
+    private var disclosureSystemImage: String? {
+        if usesPopover {
+            return nil
+        }
+        return showsAllItems ? "chevron.up" : "chevron.down"
+    }
+
+    private var selectionTitle: String {
+        String(
+            localized: "\(summary.selectedCount) Items Selected",
+            comment: "Inspector heading for a selection containing multiple items."
+        )
+    }
+
+    private var selectedNodesForPopover: [FileNodeRecord] {
+        let nodesByID = Dictionary(
+            uniqueKeysWithValues: summary.selectedNodes.map { ($0.id, $0) }
+        )
+        return selectedItemOrder.compactMap { nodesByID[$0] }
+    }
 }
 
-private struct InspectorAllSelectedItemsView: View {
-    @Environment(\.dismiss) private var dismiss
-
+private struct InspectorSelectedItemsPopover: View {
+    let selectionTitle: String
     let nodes: [FileNodeRecord]
 
     var body: some View {
         VStack(spacing: 0) {
-            HStack {
+            VStack(alignment: .leading, spacing: 2) {
                 Text("Selected Items")
-                    .font(.title2.weight(.semibold))
+                    .font(.headline)
 
-                Spacer()
-
-                Button("Done") {
-                    dismiss()
-                }
-                .keyboardShortcut(.defaultAction)
+                Text(selectionTitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
-            .padding(16)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 11)
 
             Divider()
 
             List(nodes) { node in
                 InspectorSelectedItemRow(node: node)
             }
+            .listStyle(.inset)
         }
-        .frame(minWidth: 460, minHeight: 420)
+        .frame(width: 360, height: popoverHeight)
+    }
+
+    private var popoverHeight: CGFloat {
+        min(max(CGFloat(nodes.count) * 28 + 58, 220), 420)
     }
 }
 

--- a/Radix/Features/Inspector/InspectorNoSelectionView.swift
+++ b/Radix/Features/Inspector/InspectorNoSelectionView.swift
@@ -1,35 +1,11 @@
 import SwiftUI
 
 struct InspectorNoSelectionView: View {
-    let scanWarningsPreview: [ScanWarning]
-    let shouldSuggestFullDiskAccess: Bool
-    let openFullDiskAccessSettings: () -> Void
-
     var body: some View {
-        VStack(spacing: 0) {
-            Spacer(minLength: 0)
-
-            ContentUnavailableView {
-                Label("No Selection", systemImage: "sidebar.trailing")
-            } description: {
-                Text("Select a chart segment or table row to inspect metadata and file actions.")
-            }
-            .frame(maxWidth: .infinity)
-            .frame(maxHeight: .infinity)
-
-            if !scanWarningsPreview.isEmpty {
-                Divider()
-
-                Form {
-                    InspectorWarningsSection(
-                        warnings: scanWarningsPreview,
-                        shouldSuggestFullDiskAccess: shouldSuggestFullDiskAccess,
-                        openFullDiskAccessSettings: openFullDiskAccessSettings
-                    )
-                }
-                .formStyle(.grouped)
-                .frame(maxHeight: 240)
-            }
+        ContentUnavailableView {
+            Label("Nothing Selected", systemImage: "cursorarrow.click")
+        } description: {
+            Text("Select an item in the disk map or file browser to inspect it.")
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }

--- a/Radix/Features/Inspector/InspectorSummarySection.swift
+++ b/Radix/Features/Inspector/InspectorSummarySection.swift
@@ -2,41 +2,85 @@ import SwiftUI
 
 struct InspectorSummarySection: View {
     let node: FileNodeRecord
+    let availability: FileNodeActionAvailability
+    let actions: SelectedFileActions
 
     var body: some View {
         Section {
-            InspectorHeader(node: node)
-        }
-    }
-}
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: node.systemImageName)
+                    .font(.title2)
+                    .foregroundStyle(Color.accentColor)
+                    .frame(width: 28, height: 28)
 
-private struct InspectorHeader: View {
-    let node: FileNodeRecord
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(node.name)
+                        .font(.headline)
+                        .lineLimit(2)
 
-    var body: some View {
-        HStack(alignment: .top, spacing: 12) {
-            Image(systemName: node.systemImageName)
-                .font(.title2)
-                .foregroundStyle(node.isDirectory ? Color.accentColor : Color.secondary)
-                .frame(width: 28, height: 28)
+                    if node.isSynthetic {
+                        Text("Estimated storage that macOS reports as used but that Radix could not attribute to a regular file path.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    } else {
+                        Text(node.url.path)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                            .help(node.url.path)
+                    }
+                }
 
-            VStack(alignment: .leading, spacing: 4) {
-                Text(node.name)
-                    .font(.headline)
-                    .lineLimit(3)
+                Spacer(minLength: 4)
 
-                if node.isSynthetic {
-                    Text("Estimated storage that macOS reports as used but that Radix could not attribute to a regular file path.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                } else {
-                    Text(node.url.path)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .textSelection(.enabled)
-                        .fixedSize(horizontal: false, vertical: true)
+                if showsMoreMenu {
+                    Menu {
+                        if availability.canOpen {
+                            Button(
+                                FileNodeAction.open.title,
+                                systemImage: FileNodeAction.open.systemImageName
+                            ) {
+                                actions.perform(.open)
+                            }
+                        }
+
+                        if availability.canCopyPath {
+                            Button(
+                                FileNodeAction.copyPath.title,
+                                systemImage: FileNodeAction.copyPath.systemImageName
+                            ) {
+                                actions.perform(.copyPath)
+                            }
+                        }
+
+                        if availability.canMoveToTrash {
+                            Divider()
+
+                            Button(
+                                FileNodeAction.moveToTrash.title,
+                                systemImage: FileNodeAction.moveToTrash.systemImageName,
+                                role: .destructive
+                            ) {
+                                actions.perform(.moveToTrash)
+                            }
+                        }
+                    } label: {
+                        Image(systemName: "ellipsis.circle")
+                            .font(.title3)
+                            .frame(width: 28, height: 28)
+                    }
+                    .menuStyle(.borderlessButton)
+                    .fixedSize()
+                    .help("More Actions")
+                    .accessibilityLabel("More Actions")
                 }
             }
         }
+    }
+
+    private var showsMoreMenu: Bool {
+        availability.canOpen || availability.canCopyPath || availability.canMoveToTrash
     }
 }

--- a/Radix/Features/Inspector/InspectorWarningsSection.swift
+++ b/Radix/Features/Inspector/InspectorWarningsSection.swift
@@ -1,29 +1,259 @@
 import SwiftUI
 
-struct InspectorWarningsSection: View {
+private struct InspectorWarningPresentation {
+    private enum Kind {
+        case incomplete
+        case expectedMacOSProtection
+        case fullDiskAccessMayHelp
+        case fullDiskAccessEnabled
+        case savedScanHistorical
+    }
+
+    private static let expectedMacOSProtectionPrefix = String(
+        localized: "This is expected on macOS.",
+        comment: "Inspector guidance that a protected system location is normal macOS behavior."
+    )
+
+    let selectionName: String
     let warnings: [ScanWarning]
-    let shouldSuggestFullDiskAccess: Bool
+    private let kind: Kind
+
+    init(
+        selectionName: String,
+        warnings: [ScanWarning],
+        fullDiskAccessAdvice: FullDiskAccessAdvice
+    ) {
+        self.selectionName = selectionName
+        self.warnings = warnings
+        if fullDiskAccessAdvice == .openSettings {
+            kind = .fullDiskAccessMayHelp
+        } else if fullDiskAccessAdvice == .rescanMayBeNeeded {
+            kind = .fullDiskAccessEnabled
+        } else if fullDiskAccessAdvice == .savedScanIsHistorical {
+            kind = .savedScanHistorical
+        } else if !warnings.isEmpty,
+                  warnings.allSatisfy(PermissionAdvisor.isExpectedMacOSProtection) {
+            kind = .expectedMacOSProtection
+        } else {
+            kind = .incomplete
+        }
+    }
+
+    var noticeTitle: LocalizedStringKey {
+        kind == .expectedMacOSProtection ? "Protected by macOS" : "Incomplete contents"
+    }
+
+    var noticeSummary: String {
+        if kind == .expectedMacOSProtection {
+            return Self.expectedMacOSProtectionPrefix + " " + String(
+                localized: "\(warnings.count) system locations are protected by macOS, so this selection’s total may be incomplete.",
+                comment: "Inspector warning summary for protected locations that Full Disk Access cannot unlock."
+            )
+        }
+        return String(
+            localized: "\(warnings.count) locations in this selection couldn’t be read. Its allocated size and contents may be incomplete.",
+            comment: "Inspector warning summary for unreadable locations within the current selection."
+        )
+    }
+
+    var showWarningsTitle: String {
+        return String(
+            localized: "Show \(warnings.count) Warnings",
+            comment: "Action that opens the Inspector warning details popover. The warning count controls pluralization."
+        )
+    }
+
+    var reviewTitle: String {
+        return kind == .expectedMacOSProtection
+            ? String(localized: "\(warnings.count) Protected Locations in \(selectionName)", comment: "Inspector warning popover title for protected locations.")
+            : String(localized: "\(warnings.count) Warnings in \(selectionName)", comment: "Inspector warning popover title. The warning count controls pluralization.")
+    }
+
+    var reviewSummary: String {
+        if kind == .expectedMacOSProtection {
+            return Self.expectedMacOSProtectionPrefix + " " + String(
+                localized: "\(warnings.count) protected locations were skipped, so \(selectionName)’s total may be incomplete.",
+                comment: "Inspector warning popover summary for protected locations."
+            )
+        }
+        return String(
+            localized: "\(warnings.count) locations were skipped, so \(selectionName)’s allocated size and contents may be incomplete.",
+            comment: "Inspector warning popover summary for skipped locations."
+        )
+    }
+
+    var suggestsFullDiskAccess: Bool {
+        kind == .fullDiskAccessMayHelp
+    }
+
+    var confirmsExpectedProtection: Bool {
+        kind == .expectedMacOSProtection
+    }
+
+    var fullDiskAccessIsEnabled: Bool {
+        kind == .fullDiskAccessEnabled
+    }
+
+    var describesHistoricalSavedScan: Bool {
+        kind == .savedScanHistorical
+    }
+}
+
+struct InspectorWarningsSection: View {
+    let selectionName: String
+    let warnings: [ScanWarning]
+    let fullDiskAccessAdvice: FullDiskAccessAdvice
     let openFullDiskAccessSettings: () -> Void
 
-    var body: some View {
-        Section("Warnings") {
-            ForEach(warnings) { warning in
-                VStack(alignment: .leading, spacing: 4) {
-                    Label(warning.path, systemImage: warning.category.symbolName)
-                        .font(.caption.weight(.semibold))
-                        .lineLimit(2)
-                    Text(warning.message)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-            }
+    @State private var showsWarnings = false
 
-            if shouldSuggestFullDiskAccess {
-                Button("Open Full Disk Access Settings") {
-                    openFullDiskAccessSettings()
+    private var presentation: InspectorWarningPresentation {
+        InspectorWarningPresentation(
+            selectionName: selectionName,
+            warnings: warnings,
+            fullDiskAccessAdvice: fullDiskAccessAdvice
+        )
+    }
+
+    var body: some View {
+        Section {
+            VStack(alignment: .leading, spacing: 6) {
+                Label(presentation.noticeTitle, systemImage: "exclamationmark.triangle.fill")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.orange)
+
+                Text(presentation.noticeSummary)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Button(presentation.showWarningsTitle) {
+                    showsWarnings.toggle()
+                }
+                .buttonStyle(.link)
+                .font(.caption.weight(.medium))
+                .popover(isPresented: $showsWarnings, arrowEdge: .trailing) {
+                    InspectorWarningReviewPopover(
+                        presentation: presentation,
+                        openFullDiskAccessSettings: openFullDiskAccessSettings
+                    )
                 }
             }
         }
+    }
+}
+
+private struct InspectorWarningReviewPopover: View {
+    let presentation: InspectorWarningPresentation
+    let openFullDiskAccessSettings: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Label(presentation.reviewTitle, systemImage: "exclamationmark.triangle.fill")
+                    .font(.headline)
+                    .foregroundStyle(.orange)
+
+                Text(presentation.reviewSummary)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Divider()
+
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 10) {
+                    ForEach(Array(presentation.warnings.enumerated()), id: \.element.id) { index, warning in
+                        InspectorWarningReviewRow(warning: warning)
+
+                        if index < presentation.warnings.count - 1 {
+                            Divider()
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .frame(height: min(CGFloat(presentation.warnings.count) * 76, 304))
+
+            if presentation.suggestsFullDiskAccess {
+                Divider()
+
+                Button("Open Full Disk Access Settings", systemImage: "gear") {
+                    openFullDiskAccessSettings()
+                }
+                .buttonStyle(.borderedProminent)
+
+                Text("Full Disk Access may allow Radix to scan some of these locations.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            } else if presentation.confirmsExpectedProtection {
+                Divider()
+
+                Label("No Full Disk Access change is required.", systemImage: "checkmark.circle")
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(.secondary)
+            } else if presentation.fullDiskAccessIsEnabled {
+                Divider()
+
+                Label("Full Disk Access is enabled.", systemImage: "checkmark.circle")
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(.secondary)
+
+                Text("If you enabled it after this scan, rescan to update these results.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            } else if presentation.describesHistoricalSavedScan {
+                Divider()
+
+                Label("Saved scan", systemImage: "archivebox.fill")
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(.secondary)
+
+                Text("This warning reflects the access available when this saved scan was created.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(16)
+        .frame(width: 360, alignment: .leading)
+    }
+}
+
+private struct InspectorWarningReviewRow: View {
+    let warning: ScanWarning
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: warning.category.symbolName)
+                .foregroundStyle(.orange)
+                .frame(width: 18)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(locationName)
+                    .font(.subheadline.weight(.semibold))
+
+                Text(warning.path)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .help(warning.path)
+
+                Text(warning.message)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var locationName: String {
+        let name = URL(filePath: warning.path).lastPathComponent
+        return name.isEmpty ? warning.path : name
     }
 }

--- a/Radix/Features/Inspector/InspectorWarningsSection.swift
+++ b/Radix/Features/Inspector/InspectorWarningsSection.swift
@@ -162,32 +162,22 @@ private struct InspectorWarningReviewPopover: View {
 
             Divider()
 
-            ScrollView {
-                LazyVStack(alignment: .leading, spacing: 10) {
-                    ForEach(Array(presentation.warnings.enumerated()), id: \.element.id) { index, warning in
-                        InspectorWarningReviewRow(warning: warning)
-
-                        if index < presentation.warnings.count - 1 {
-                            Divider()
-                        }
-                    }
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-            }
-            .frame(height: min(CGFloat(presentation.warnings.count) * 76, 304))
+            warningList
 
             if presentation.suggestsFullDiskAccess {
                 Divider()
 
-                Button("Open Full Disk Access Settings", systemImage: "gear") {
-                    openFullDiskAccessSettings()
-                }
-                .buttonStyle(.borderedProminent)
+                VStack(alignment: .leading, spacing: 10) {
+                    Button("Open Full Disk Access Settings", systemImage: "gear") {
+                        openFullDiskAccessSettings()
+                    }
+                    .buttonStyle(.borderedProminent)
 
-                Text("Full Disk Access may allow Radix to scan some of these locations.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
+                    Text("Enable Full Disk Access for Radix, then rescan to include these locations.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
             } else if presentation.confirmsExpectedProtection {
                 Divider()
 
@@ -220,6 +210,31 @@ private struct InspectorWarningReviewPopover: View {
         }
         .padding(16)
         .frame(width: 360, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private var warningList: some View {
+        if presentation.warnings.count > 3 {
+            ScrollView {
+                warningRows
+            }
+            .frame(height: 304)
+        } else {
+            warningRows
+        }
+    }
+
+    private var warningRows: some View {
+        LazyVStack(alignment: .leading, spacing: 10) {
+            ForEach(Array(presentation.warnings.enumerated()), id: \.element.id) { index, warning in
+                InspectorWarningReviewRow(warning: warning)
+
+                if index < presentation.warnings.count - 1 {
+                    Divider()
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 

--- a/Radix/Features/Inspector/SelectionInspectorView.swift
+++ b/Radix/Features/Inspector/SelectionInspectorView.swift
@@ -7,6 +7,7 @@ struct SelectionInspectorActions {
     let zoomIntoSelection: () -> Void
     let selectedFileActions: SelectedFileActions
     let addPrimarySelectionToDiscardPile: () -> Void
+    let bulkFileActions: BulkFileActions
     let openFullDiskAccessSettings: () -> Void
 }
 
@@ -18,9 +19,26 @@ struct SelectionInspectorView: View {
 
     var body: some View {
         let largestChildren = largestSelectedChildren
+        let selectedNodes = navigation.selectedNodes
 
         Group {
-            if let node = navigation.selectedNode {
+            if selectedNodes.count > 1 {
+                let summary = InspectorSelectionSummary(
+                    selectedNodes: selectedNodes,
+                    fileTreeStore: scanState.fileTreeStore
+                )
+                InspectorMultiSelectionView(
+                    summary: summary,
+                    percentOfScan: selectionPercentOfScanText(summary) ?? "—",
+                    availability: FileNodeActionAvailability(
+                        nodes: selectedNodes,
+                        activeTarget: scanState.selectedTarget,
+                        trashSafetyPolicy: scanState.trashSafetyPolicy,
+                        snapshotSource: scanState.snapshotSource
+                    ),
+                    actions: actions.bulkFileActions
+                )
+            } else if let node = navigation.selectedNode {
                 Form {
                     InspectorSummarySection(node: node)
 
@@ -98,6 +116,11 @@ struct SelectionInspectorView: View {
         guard let selectedNode = navigation.selectedNode,
               let root = scanState.snapshot?.root else { return nil }
         return RadixFormatters.percentage(part: selectedNode.allocatedSize, total: root.allocatedSize)
+    }
+
+    private func selectionPercentOfScanText(_ summary: InspectorSelectionSummary) -> String? {
+        guard let root = scanState.snapshot?.root else { return nil }
+        return RadixFormatters.percentage(part: summary.allocatedSize, total: root.allocatedSize)
     }
 
     private var selectedActionAvailability: FileNodeActionAvailability {

--- a/Radix/Features/Inspector/SelectionInspectorView.swift
+++ b/Radix/Features/Inspector/SelectionInspectorView.swift
@@ -4,7 +4,6 @@ struct SelectionInspectorActions {
     let selectNodeAfterViewUpdate: (String?) -> Void
     let selectAndFocusNodeAfterViewUpdate: (String) -> Void
     let expandSummarizedNode: (FileNodeRecord) -> Void
-    let zoomIntoSelection: () -> Void
     let selectedFileActions: SelectedFileActions
     let addPrimarySelectionToDiscardPile: () -> Void
     let bulkFileActions: BulkFileActions
@@ -18,92 +17,166 @@ struct SelectionInspectorView: View {
     let actions: SelectionInspectorActions
 
     var body: some View {
-        let largestChildren = largestSelectedChildren
         let selectedNodes = navigation.selectedNodes
 
         Group {
             if selectedNodes.count > 1 {
-                let summary = InspectorSelectionSummary(
-                    selectedNodes: selectedNodes,
-                    fileTreeStore: scanState.fileTreeStore
-                )
-                InspectorMultiSelectionView(
-                    summary: summary,
-                    percentOfScan: selectionPercentOfScanText(summary) ?? "—",
-                    availability: FileNodeActionAvailability(
-                        nodes: selectedNodes,
-                        activeTarget: scanState.selectedTarget,
-                        trashSafetyPolicy: scanState.trashSafetyPolicy,
-                        snapshotSource: scanState.snapshotSource
-                    ),
-                    actions: actions.bulkFileActions
-                )
+                multiSelectionView(selectedNodes)
             } else if let node = navigation.selectedNode {
-                Form {
-                    InspectorSummarySection(node: node)
-
-                    InspectorDetailsSections(
-                        node: node,
-                        parentName: navigation.selectedNodeParent?.name,
-                        percentOfParent: selectedNodePercentOfParentText ?? "—",
-                        percentOfScan: selectedNodePercentOfScanText ?? "—",
-                        activeTarget: scanState.selectedTarget
-                    )
-
-                    InspectorActionsSection(
-                        availability: selectedActionAvailability,
-                        canExpandSummarizedSelection: canExpandSummarizedSelection,
-                        canZoomIntoSelection: canZoomIntoSelection,
-                        fileActions: actions.selectedFileActions,
-                        addToDiscardPile: actions.addPrimarySelectionToDiscardPile,
-                        expandAction: { expandSummarizedSelection() },
-                        zoomAction: actions.zoomIntoSelection
-                    )
-
-                    if !largestChildren.isEmpty {
-                        InspectorLargestChildrenSection(children: largestChildren) { child in
-                            selectLargestChild(child)
-                        }
-                    }
-
-                    if !scanWarningsPreview.isEmpty {
-                        InspectorWarningsSection(
-                            warnings: scanWarningsPreview,
-                            shouldSuggestFullDiskAccess: shouldSuggestFullDiskAccess
-                        ) {
-                            actions.openFullDiskAccessSettings()
-                        }
-                    }
-                }
-                .formStyle(.grouped)
+                singleSelectionView(node)
             } else {
-                InspectorNoSelectionView(
-                    scanWarningsPreview: scanWarningsPreview,
-                    shouldSuggestFullDiskAccess: shouldSuggestFullDiskAccess
-                ) {
-                    actions.openFullDiskAccessSettings()
-                }
+                InspectorNoSelectionView()
             }
         }
         .background(Color(nsColor: .windowBackgroundColor))
     }
 
-    private var scanWarningsPreview: [ScanWarning] {
-        Array((scanState.snapshot?.scanWarnings ?? []).prefix(5))
-    }
+    private func multiSelectionView(_ selectedNodes: [FileNodeRecord]) -> some View {
+        let summary = InspectorSelectionSummary(
+            selectedNodes: selectedNodes,
+            fileTreeStore: scanState.fileTreeStore
+        )
+        let availability = FileNodeActionAvailability(
+            nodes: selectedNodes,
+            activeTarget: scanState.selectedTarget,
+            trashSafetyPolicy: scanState.trashSafetyPolicy,
+            snapshotSource: scanState.snapshotSource
+        )
+        let removalAvailability = FileNodeActionAvailability(
+            nodes: summary.topLevelSelectedNodes,
+            activeTarget: scanState.selectedTarget,
+            trashSafetyPolicy: scanState.trashSafetyPolicy,
+            snapshotSource: scanState.snapshotSource
+        )
+        let canMoveSelectionToTrash = summary.missingSelectedNodeCount == 0
+            && removalAvailability.canMoveToTrash
+        let warnings = relevantWarnings(for: summary.topLevelSelectedNodes)
 
-    private var shouldSuggestFullDiskAccess: Bool {
-        PermissionAdvisor.shouldSuggestFullDiskAccess(
-            for: scanState.snapshot,
-            fullDiskAccessStatus: fullDiskAccessStatus
+        return InspectorMultiSelectionView(
+            summary: summary,
+            percentOfScan: selectionPercentOfScanText(summary) ?? "—",
+            availability: availability,
+            canMoveSelectionToTrash: canMoveSelectionToTrash,
+            availabilityNotice: multiSelectionAvailabilityNotice(
+                summary: summary,
+                canMoveSelectionToTrash: canMoveSelectionToTrash
+            ),
+            warnings: warnings,
+            fullDiskAccessAdvice: fullDiskAccessAdvice(for: warnings),
+            actions: actions.bulkFileActions,
+            openFullDiskAccessSettings: actions.openFullDiskAccessSettings
         )
     }
 
-    private var largestSelectedChildren: [FileNodeRecord] {
-        guard let fileTreeStore = scanState.fileTreeStore,
-              let selectedNode = navigation.selectedNode,
-              selectedNode.isDirectory else { return [] }
-        return fileTreeStore.childrenPrefix(of: selectedNode.id, maxCount: 8)
+    private func singleSelectionView(_ node: FileNodeRecord) -> some View {
+        let availability = FileNodeActionAvailability(
+            node: node,
+            activeTarget: scanState.selectedTarget,
+            trashSafetyPolicy: scanState.trashSafetyPolicy,
+            snapshotSource: scanState.snapshotSource
+        )
+        let warnings = relevantWarnings(for: [node])
+        let largestChildren = largestChildren(of: node)
+
+        return VStack(spacing: 0) {
+            Form {
+                InspectorSummarySection(
+                    node: node,
+                    availability: availability,
+                    actions: actions.selectedFileActions
+                )
+
+                InspectorStorageSection(
+                    allocatedSize: node.allocatedSize,
+                    percentOfParent: selectedNodePercentOfParentText,
+                    percentOfScan: selectedNodePercentOfScanText ?? "—"
+                )
+
+                if node.cloneIdentity != nil || node.mayShareDataBlocks {
+                    InspectorSharedStorageSection(node: node)
+                }
+
+                if !warnings.isEmpty {
+                    InspectorWarningsSection(
+                        selectionName: node.name,
+                        warnings: warnings,
+                        fullDiskAccessAdvice: fullDiskAccessAdvice(for: warnings),
+                        openFullDiskAccessSettings: actions.openFullDiskAccessSettings
+                    )
+                }
+
+                if let notice = singleSelectionAvailabilityNotice(for: node) {
+                    InspectorAvailabilityNotice(kind: notice)
+                }
+
+                if canExpandSummarizedSelection(node) {
+                    InspectorSummarizedSection {
+                        actions.expandSummarizedNode(node)
+                    }
+                }
+
+                if !largestChildren.isEmpty {
+                    InspectorLargestChildrenSection(children: largestChildren) { child in
+                        selectLargestChild(child)
+                    }
+                }
+
+                if !node.isSynthetic {
+                    InspectorDetailsSection(
+                        node: node,
+                        activeTarget: scanState.selectedTarget
+                    )
+                }
+            }
+            .formStyle(.grouped)
+
+            if availability.canRevealInFinder || availability.canMoveToTrash {
+                InspectorActionBar(
+                    revealAction: availability.canRevealInFinder
+                        ? { actions.selectedFileActions.perform(.revealInFinder) }
+                        : nil,
+                    addToDiscardPileAction: availability.canMoveToTrash
+                        ? actions.addPrimarySelectionToDiscardPile
+                        : nil,
+                    addToDiscardPileTitle: String(
+                        localized: "Add to Discard Pile",
+                        comment: "Action for marking the selected item for possible deletion."
+                    )
+                )
+            }
+        }
+    }
+
+    private func relevantWarnings(for nodes: [FileNodeRecord]) -> [ScanWarning] {
+        guard let warnings = scanState.snapshot?.scanWarnings, !warnings.isEmpty else {
+            return []
+        }
+        let rootPaths = nodes
+            .filter { !$0.isSynthetic }
+            .map { $0.url.standardizedFileURL.path }
+        guard !rootPaths.isEmpty else { return [] }
+
+        return warnings.filter { warning in
+            let warningPath = URL(filePath: warning.path).standardizedFileURL.path
+            return rootPaths.contains { rootPath in
+                warningPath == rootPath || warningPath.hasPrefix(rootPath == "/" ? "/" : rootPath + "/")
+            }
+        }
+    }
+
+    private func fullDiskAccessAdvice(for warnings: [ScanWarning]) -> FullDiskAccessAdvice {
+        PermissionAdvisor.fullDiskAccessAdvice(
+            for: warnings,
+            fullDiskAccessStatus: fullDiskAccessStatus,
+            snapshotSource: scanState.snapshotSource
+        )
+    }
+
+    private func largestChildren(of node: FileNodeRecord) -> [FileNodeRecord] {
+        guard node.isDirectory, let fileTreeStore = scanState.fileTreeStore else {
+            return []
+        }
+        return fileTreeStore.childrenPrefix(of: node.id, maxCount: 3)
     }
 
     private var selectedNodePercentOfParentText: String? {
@@ -123,26 +196,40 @@ struct SelectionInspectorView: View {
         return RadixFormatters.percentage(part: summary.allocatedSize, total: root.allocatedSize)
     }
 
-    private var selectedActionAvailability: FileNodeActionAvailability {
-        FileNodeActionAvailability(
-            node: navigation.selectedNode,
-            activeTarget: scanState.selectedTarget,
-            trashSafetyPolicy: scanState.trashSafetyPolicy,
-            snapshotSource: scanState.snapshotSource
-        )
+    private func singleSelectionAvailabilityNotice(
+        for node: FileNodeRecord
+    ) -> InspectorAvailabilityNoticeKind? {
+        if scanState.snapshotSource.isImported {
+            return .savedScan
+        }
+        if scanState.selectedTarget?.kind == .volume,
+           scanState.selectedTarget?.id == node.id {
+            return .scanRoot
+        }
+        if scanState.trashSafetyPolicy.blockReason(for: node.url) != nil {
+            return .protectedLocation
+        }
+        return nil
     }
 
-    private var canExpandSummarizedSelection: Bool {
-        navigation.selectedNode?.isAutoSummarized == true
+    private func multiSelectionAvailabilityNotice(
+        summary: InspectorSelectionSummary,
+        canMoveSelectionToTrash: Bool
+    ) -> InspectorAvailabilityNoticeKind? {
+        if scanState.snapshotSource.isImported {
+            return .savedScan
+        }
+        if summary.selectedNodes.contains(where: { !$0.supportsFileActions }) {
+            return .limitedSelection
+        }
+        if summary.missingSelectedNodeCount == 0, !canMoveSelectionToTrash {
+            return .protectedSelection
+        }
+        return nil
     }
 
-    private var canZoomIntoSelection: Bool {
-        navigation.canZoomIntoSelection
-    }
-
-    private func expandSummarizedSelection() {
-        guard let node = navigation.selectedNode else { return }
-        actions.expandSummarizedNode(node)
+    private func canExpandSummarizedSelection(_ node: FileNodeRecord) -> Bool {
+        node.isAutoSummarized && !scanState.snapshotSource.isImported
     }
 
     private func selectLargestChild(_ child: FileNodeRecord) {

--- a/Radix/Localizable.xcstrings
+++ b/Radix/Localizable.xcstrings
@@ -1,6 +1,145 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "%lld Items Selected" : {
+      "comment" : "Inspector heading for a selection containing multiple items.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld Elemente ausgewählt"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld elementos seleccionados"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld éléments sélectionnés"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld elementi selezionati"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已选择 %lld 个项目"
+          }
+        }
+      }
+    },
+    "Of Parent" : {
+      "comment" : "Inspector statistic for a selected item's share of its parent folder.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vom übergeordneten Element"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Del elemento superior"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Du parent"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dell'elemento superiore"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "占父项"
+          }
+        }
+      }
+    },
+    "Of Scan" : {
+      "comment" : "Inspector statistic for a selection's share of the entire scan.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vom Scan"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Del análisis"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "De l’analyse"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Della scansione"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "占扫描"
+          }
+        }
+      }
+    },
+    "Overlapping selections are counted once in totals." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Überlappende Auswahlen werden in den Summen nur einmal gezählt."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Las selecciones superpuestas se cuentan una sola vez en los totales."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les sélections qui se chevauchent ne sont comptées qu’une seule fois dans les totaux."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le selezioni sovrapposte vengono conteggiate una sola volta nei totali."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重叠的选择在总计中只计算一次。"
+          }
+        }
+      }
+    },
     "Scans run" : {
       "comment" : "Stats pane label for the total number of scans run.",
       "localizations" : {

--- a/Radix/Localizable.xcstrings
+++ b/Radix/Localizable.xcstrings
@@ -2,7 +2,7 @@
   "sourceLanguage" : "en",
   "strings" : {
     "View All %lld Items…": {
-      "comment": "Action that opens the complete Inspector selected-items list in a sheet.",
+      "comment": "Action that opens the complete selected-items list in a popover.",
       "localizations": {
         "de": {
           "variations": {
@@ -464,41 +464,6 @@
         }
       }
     },
-    "Allocated totals reflect Radix’s storage attribution, not guaranteed space reclaimed.": {
-      "comment": "Inspector disclaimer that attributed allocated storage is not guaranteed reclaimable space.",
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zugewiesene Summen spiegeln die Speicherzuordnung von Radix wider, nicht den garantiert freigegebenen Speicherplatz."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Los totales asignados reflejan la atribución de almacenamiento de Radix, no el espacio cuya liberación esté garantizada."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Les totaux alloués reflètent l’attribution du stockage par Radix, pas l’espace dont la libération est garantie."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "I totali allocati riflettono l’attribuzione dello spazio di Radix, non lo spazio che verrà liberato con certezza."
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "已分配总量反映 Radix 的存储归属，并不保证可释放相同空间。"
-          }
-        }
-      }
-    },
     "Items inside another selected folder are included with that folder.": {
       "comment": "Inspector note explaining how overlapping parent and child selections are treated.",
       "localizations": {
@@ -530,6 +495,41 @@
           "stringUnit": {
             "state": "translated",
             "value": "位于另一个已选文件夹中的项目会随该文件夹一并处理。"
+          }
+        }
+      }
+    },
+    "Some selected items are no longer available in this scan and are excluded from totals.": {
+      "comment": "Inspector note explaining that stale selected items are excluded from storage totals.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einige ausgewählte Objekte sind in diesem Scan nicht mehr verfügbar und werden von den Summen ausgeschlossen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Algunos elementos seleccionados ya no están disponibles en este análisis y se excluyen de los totales."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Certains éléments sélectionnés ne sont plus disponibles dans cette analyse et sont exclus des totaux."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alcuni elementi selezionati non sono più disponibili in questa scansione e sono esclusi dai totali."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "部分所选项目在此扫描中已不再可用，因此不会计入总计。"
           }
         }
       }
@@ -746,41 +746,6 @@
           }
         }
       },
-      "Some selected items are no longer available in this scan and are excluded from totals.": {
-        "comment": "Inspector note explaining that stale selected items are excluded from storage totals.",
-        "localizations": {
-          "de": {
-            "stringUnit": {
-              "state": "translated",
-              "value": "Einige ausgewählte Objekte sind in diesem Scan nicht mehr verfügbar und werden von den Summen ausgeschlossen."
-            }
-          },
-          "es": {
-            "stringUnit": {
-              "state": "translated",
-              "value": "Algunos elementos seleccionados ya no están disponibles en este análisis y se excluyen de los totales."
-            }
-          },
-          "fr": {
-            "stringUnit": {
-              "state": "translated",
-              "value": "Certains éléments sélectionnés ne sont plus disponibles dans cette analyse et sont exclus des totaux."
-            }
-          },
-          "it": {
-            "stringUnit": {
-              "state": "translated",
-              "value": "Alcuni elementi selezionati non sono più disponibili in questa scansione e sono esclusi dai totali."
-            }
-          },
-          "zh-Hans": {
-            "stringUnit": {
-              "state": "translated",
-              "value": "部分所选项目在此扫描中已不再可用，因此不会计入总计。"
-            }
-          }
-        }
-      },
       "This is expected on macOS.": {
         "comment": "Inspector guidance that a protected system location is normal macOS behavior.",
         "localizations": {
@@ -816,40 +781,40 @@
           }
         }
       },
-      "Full Disk Access may allow Radix to scan some of these locations.": {
-        "comment": "Inspector warning popover guidance when Full Disk Access may help.",
-        "localizations": {
-          "de": {
-            "stringUnit": {
-              "state": "translated",
-              "value": "Mit Festplattenvollzugriff kann Radix möglicherweise einige dieser Orte scannen."
-            }
-          },
-          "es": {
-            "stringUnit": {
-              "state": "translated",
-              "value": "El acceso total al disco puede permitir que Radix analice algunas de estas ubicaciones."
-            }
-          },
-          "fr": {
-            "stringUnit": {
-              "state": "translated",
-              "value": "L’accès complet au disque peut permettre à Radix d’analyser certains de ces emplacements."
-            }
-          },
-          "it": {
-            "stringUnit": {
-              "state": "translated",
-              "value": "Accesso completo al disco potrebbe consentire a Radix di scansionare alcune di queste posizioni."
-            }
-          },
-          "zh-Hans": {
-            "stringUnit": {
-              "state": "translated",
-              "value": "完全磁盘访问权限可能允许 Radix 扫描其中部分位置。"
-            }
+    "Enable Full Disk Access for Radix, then rescan to include these locations.": {
+      "comment": "Inspector warning popover instructions when Full Disk Access may help.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktivieren Sie den Festplattenvollzugriff für Radix und scannen Sie anschließend erneut, um diese Orte einzubeziehen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activa el acceso total al disco para Radix y vuelve a analizar para incluir estas ubicaciones."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activez l’accès complet au disque pour Radix, puis relancez l’analyse pour inclure ces emplacements."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abilita Accesso completo al disco per Radix, quindi esegui nuovamente la scansione per includere queste posizioni."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "为 Radix 启用完全磁盘访问权限，然后重新扫描以包含这些位置。"
           }
         }
+      }
       },
       "No Full Disk Access change is required.": {
         "comment": "Inspector warning popover confirmation when protected locations are expected.",

--- a/Radix/Localizable.xcstrings
+++ b/Radix/Localizable.xcstrings
@@ -4603,40 +4603,6 @@
         }
       }
     },
-    "Access" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zugriff"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Acceso"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Accès"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Accesso"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "访问权限"
-          }
-        }
-      }
-    },
     "Action Failed" : {
       "comment" : "Fallback alert title shown when a file action fails.",
       "localizations" : {
@@ -4668,40 +4634,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "操作失败"
-          }
-        }
-      }
-    },
-    "Actions" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktionen"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Acciones"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Actions"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Azioni"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "操作"
           }
         }
       }
@@ -8914,41 +8846,6 @@
         }
       }
     },
-    "Estimated" : {
-      "comment" : "Metadata value indicating that storage is estimated.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Geschätzt"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Estimado"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Estimé"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stimato"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "估计"
-          }
-        }
-      }
-    },
     "Estimated from volume usage" : {
       "comment" : "Secondary status shown for system storage estimated from volume usage.",
       "localizations" : {
@@ -11644,41 +11541,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "资源库"
-          }
-        }
-      }
-    },
-    "Limited" : {
-      "comment" : "Metadata value indicating that access to a file or folder is limited.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eingeschränkt"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Limitado"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Limité"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Limitato"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "受限"
           }
         }
       }
@@ -14603,40 +14465,6 @@
         }
       }
     },
-    "Parent" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Übergeordnet"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Superior"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Parent"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Superiore"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "上级"
-          }
-        }
-      }
-    },
     "parent %@ is missing from node order" : {
       "localizations" : {
         "de" : {
@@ -15896,41 +15724,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Radix 不会将 %@ 处的受保护位置移到废纸篓。"
-          }
-        }
-      }
-    },
-    "Readable" : {
-      "comment" : "Metadata value indicating that a file or folder is readable.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lesbar"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Legible"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lisible"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Leggibile"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "可读取"
           }
         }
       }

--- a/Radix/Localizable.xcstrings
+++ b/Radix/Localizable.xcstrings
@@ -1,146 +1,2693 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
-    "%lld Items Selected" : {
-      "comment" : "Inspector heading for a selection containing multiple items.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld Elemente ausgewählt"
+    "View All %lld Items…": {
+      "comment": "Action that opens the complete Inspector selected-items list in a sheet.",
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Element anzeigen…"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Alle %lld Elemente anzeigen…"
+                }
+              }
+            }
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld elementos seleccionados"
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "View All %lld Item…"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "View All %lld Items…"
+                }
+              }
+            }
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld éléments sélectionnés"
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Ver %lld elemento…"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Ver los %lld elementos…"
+                }
+              }
+            }
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld elementi selezionati"
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Afficher %lld élément…"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Afficher les %lld éléments…"
+                }
+              }
+            }
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已选择 %lld 个项目"
+        "it": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Visualizza %lld elemento…"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Visualizza tutti i %lld elementi…"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "查看全部 %lld 个项目…"
+                }
+              }
+            }
           }
         }
       }
     },
-    "Of Parent" : {
-      "comment" : "Inspector statistic for a selected item's share of its parent folder.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vom übergeordneten Element"
+    "1 file": {
+      "comment": "Tooltip metadata for a directory containing one file.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 Datei"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Del elemento superior"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 archivo"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Du parent"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 fichier"
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dell'elemento superiore"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 file"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "占父项"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 个文件"
           }
         }
       }
     },
-    "Of Scan" : {
-      "comment" : "Inspector statistic for a selection's share of the entire scan.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vom Scan"
+"%lld files": {
+      "comment": "Inspector multiple-selection file count.",
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Datei"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Dateien"
+                }
+              }
+            }
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Del análisis"
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld file"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld files"
+                }
+              }
+            }
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "De l’analyse"
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld archivo"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld archivos"
+                }
+              }
+            }
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Della scansione"
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld fichier"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld fichiers"
+                }
+              }
+            }
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "占扫描"
+        "it": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld file"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld file"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld 个文件"
+                }
+              }
+            }
           }
         }
       }
     },
-    "Overlapping selections are counted once in totals." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Überlappende Auswahlen werden in den Summen nur einmal gezählt."
+    "%lld protected locations were skipped, so %@’s total may be incomplete.": {
+      "comment": "Inspector warning popover summary for protected locations.",
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld geschützter Ort wurde übersprungen, daher ist die Summe von %@ möglicherweise unvollständig."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld geschützte Orte wurden übersprungen, daher ist die Summe von %@ möglicherweise unvollständig."
+                }
+              }
+            }
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Las selecciones superpuestas se cuentan una sola vez en los totales."
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld protected location was skipped, so %@’s total may be incomplete."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld protected locations were skipped, so %@’s total may be incomplete."
+                }
+              }
+            }
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Les sélections qui se chevauchent ne sont comptées qu’une seule fois dans les totaux."
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Se omitió %lld ubicación protegida, por lo que el total de %@ puede estar incompleto."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Se omitieron %lld ubicaciones protegidas, por lo que el total de %@ puede estar incompleto."
+                }
+              }
+            }
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le selezioni sovrapposte vengono conteggiate una sola volta nei totali."
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld emplacement protégé a été ignoré ; le total de %@ peut donc être incomplet."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld emplacements protégés ont été ignorés ; le total de %@ peut donc être incomplet."
+                }
+              }
+            }
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重叠的选择在总计中只计算一次。"
+        "it": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld posizione protetta è stata ignorata, quindi il totale di %@ potrebbe essere incompleto."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld posizioni protette sono state ignorate, quindi il totale di %@ potrebbe essere incompleto."
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "已跳过 %1$lld 个受保护位置，因此 %2$@ 的总计可能不完整。"
+                }
+              }
+            }
           }
         }
       }
     },
-    "Scans run" : {
+    "%lld locations were skipped, so %@’s allocated size and contents may be incomplete.": {
+      "comment": "Inspector warning popover summary for skipped locations.",
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Ort wurde übersprungen, daher sind die zugewiesene Größe und der Inhalt von %@ möglicherweise unvollständig."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Orte wurden übersprungen, daher sind die zugewiesene Größe und der Inhalt von %@ möglicherweise unvollständig."
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld location was skipped, so %@’s allocated size and contents may be incomplete."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld locations were skipped, so %@’s allocated size and contents may be incomplete."
+                }
+              }
+            }
+          }
+        },
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Se omitió %lld ubicación, por lo que el tamaño asignado y el contenido de %@ pueden estar incompletos."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Se omitieron %lld ubicaciones, por lo que el tamaño asignado y el contenido de %@ pueden estar incompletos."
+                }
+              }
+            }
+          }
+        },
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld emplacement a été ignoré ; la taille allouée et le contenu de %@ peuvent donc être incomplets."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld emplacements ont été ignorés ; la taille allouée et le contenu de %@ peuvent donc être incomplets."
+                }
+              }
+            }
+          }
+        },
+        "it": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld posizione è stata ignorata, quindi la dimensione allocata e i contenuti di %@ potrebbero essere incompleti."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld posizioni sono state ignorate, quindi la dimensione allocata e i contenuti di %@ potrebbero essere incompleti."
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "已跳过 %1$lld 个位置，因此 %2$@ 的已分配大小和内容可能不完整。"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "Allocated totals reflect Radix’s storage attribution, not guaranteed space reclaimed.": {
+      "comment": "Inspector disclaimer that attributed allocated storage is not guaranteed reclaimable space.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zugewiesene Summen spiegeln die Speicherzuordnung von Radix wider, nicht den garantiert freigegebenen Speicherplatz."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los totales asignados reflejan la atribución de almacenamiento de Radix, no el espacio cuya liberación esté garantizada."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les totaux alloués reflètent l’attribution du stockage par Radix, pas l’espace dont la libération est garantie."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I totali allocati riflettono l’attribuzione dello spazio di Radix, non lo spazio che verrà liberato con certezza."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已分配总量反映 Radix 的存储归属，并不保证可释放相同空间。"
+          }
+        }
+      }
+    },
+    "Items inside another selected folder are included with that folder.": {
+      "comment": "Inspector note explaining how overlapping parent and child selections are treated.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elemente in einem anderen ausgewählten Ordner sind in diesem Ordner enthalten."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los elementos dentro de otra carpeta seleccionada se incluyen con esa carpeta."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les éléments contenus dans un autre dossier sélectionné sont inclus avec ce dossier."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gli elementi all’interno di un’altra cartella selezionata sono inclusi con tale cartella."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "位于另一个已选文件夹中的项目会随该文件夹一并处理。"
+          }
+        }
+      }
+    },
+    "If you enabled it after this scan, rescan to update these results.": {
+      "comment": "Inspector guidance shown when Full Disk Access is enabled but the current live scan still contains relevant access warnings.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wenn Sie ihn nach diesem Scan aktiviert haben, scannen Sie erneut, um diese Ergebnisse zu aktualisieren."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Si lo activaste después de este análisis, vuelve a analizar para actualizar estos resultados."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Si vous l’avez activé après cette analyse, relancez l’analyse pour actualiser ces résultats."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se lo hai abilitato dopo questa scansione, esegui una nuova scansione per aggiornare i risultati."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "如果你是在本次扫描后启用的，请重新扫描以更新这些结果。"
+          }
+        }
+      }
+    },
+    "This warning reflects the access available when this saved scan was created.": {
+      "comment": "Inspector explanation that a warning in an imported saved scan is historical.",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diese Warnung spiegelt den Zugriff wider, der beim Erstellen dieses gespeicherten Scans verfügbar war."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta advertencia refleja el acceso disponible cuando se creó este análisis guardado."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cet avertissement reflète l’accès disponible lors de la création de cette analyse enregistrée."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Questo avviso riflette l’accesso disponibile quando è stata creata la scansione salvata."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此警告反映创建该已存扫描时可用的访问权限。"
+          }
+        }
+      }
+    },
+"%lld storage categories": {
+      "comment": "Inspector multiple-selection synthetic storage category count.",
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Speicherkategorie"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Speicherkategorien"
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld storage category"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld storage categories"
+                }
+              }
+            }
+          }
+        },
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld categoría de almacenamiento"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld categorías de almacenamiento"
+                }
+              }
+            }
+          }
+        },
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld catégorie de stockage"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld catégories de stockage"
+                }
+              }
+            }
+          }
+        },
+        "it": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld categoria di archiviazione"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld categorie di archiviazione"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld 个存储类别"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+"Some selected files may share APFS storage. Allocated totals reflect Radix’s storage attribution and may differ from the space reclaimed by deletion.": {
+        "comment": "Inspector explanation for a multiple selection containing files with shared APFS storage.",
+        "localizations": {
+          "de": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Einige ausgewählte Dateien nutzen möglicherweise gemeinsam APFS-Speicher. Die Summen für „Belegt“ basieren auf der Speicherzuordnung von Radix und können vom durch Löschen freigegebenen Speicherplatz abweichen."
+            }
+          },
+          "es": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Es posible que algunos archivos seleccionados compartan almacenamiento APFS. Los totales asignados reflejan la atribución de almacenamiento de Radix y pueden diferir del espacio recuperado al eliminarlos."
+            }
+          },
+          "fr": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Certains fichiers sélectionnés peuvent partager du stockage APFS. Les totaux alloués reflètent l’attribution du stockage par Radix et peuvent différer de l’espace récupéré après suppression."
+            }
+          },
+          "it": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Alcuni file selezionati potrebbero condividere spazio APFS. I totali allocati riflettono l’attribuzione dello spazio di Radix e potrebbero differire dallo spazio recuperato con l’eliminazione."
+            }
+          },
+          "zh-Hans": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "部分所选文件可能共享 APFS 存储空间。“已分配”总计反映 Radix 的存储归属计算，可能与删除后释放的空间不同。"
+            }
+          }
+        }
+      },
+      "Some selected items are no longer available in this scan and are excluded from totals.": {
+        "comment": "Inspector note explaining that stale selected items are excluded from storage totals.",
+        "localizations": {
+          "de": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Einige ausgewählte Objekte sind in diesem Scan nicht mehr verfügbar und werden von den Summen ausgeschlossen."
+            }
+          },
+          "es": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Algunos elementos seleccionados ya no están disponibles en este análisis y se excluyen de los totales."
+            }
+          },
+          "fr": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Certains éléments sélectionnés ne sont plus disponibles dans cette analyse et sont exclus des totaux."
+            }
+          },
+          "it": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Alcuni elementi selezionati non sono più disponibili in questa scansione e sono esclusi dai totali."
+            }
+          },
+          "zh-Hans": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "部分所选项目在此扫描中已不再可用，因此不会计入总计。"
+            }
+          }
+        }
+      },
+      "This is expected on macOS.": {
+        "comment": "Inspector guidance that a protected system location is normal macOS behavior.",
+        "localizations": {
+          "de": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Dies ist unter macOS zu erwarten."
+            }
+          },
+          "es": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Esto es normal en macOS."
+            }
+          },
+          "fr": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "C’est normal sous macOS."
+            }
+          },
+          "it": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "È normale su macOS."
+            }
+          },
+          "zh-Hans": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "这是 macOS 的正常行为。"
+            }
+          }
+        }
+      },
+      "Full Disk Access may allow Radix to scan some of these locations.": {
+        "comment": "Inspector warning popover guidance when Full Disk Access may help.",
+        "localizations": {
+          "de": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Mit Festplattenvollzugriff kann Radix möglicherweise einige dieser Orte scannen."
+            }
+          },
+          "es": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "El acceso total al disco puede permitir que Radix analice algunas de estas ubicaciones."
+            }
+          },
+          "fr": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "L’accès complet au disque peut permettre à Radix d’analyser certains de ces emplacements."
+            }
+          },
+          "it": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Accesso completo al disco potrebbe consentire a Radix di scansionare alcune di queste posizioni."
+            }
+          },
+          "zh-Hans": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "完全磁盘访问权限可能允许 Radix 扫描其中部分位置。"
+            }
+          }
+        }
+      },
+      "No Full Disk Access change is required.": {
+        "comment": "Inspector warning popover confirmation when protected locations are expected.",
+        "localizations": {
+          "de": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Der Festplattenvollzugriff muss nicht geändert werden."
+            }
+          },
+          "es": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "No es necesario cambiar el acceso total al disco."
+            }
+          },
+          "fr": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Aucune modification de l’accès complet au disque n’est nécessaire."
+            }
+          },
+          "it": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Non è necessario modificare Accesso completo al disco."
+            }
+          },
+          "zh-Hans": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "无需更改完全磁盘访问权限。"
+            }
+          }
+        }
+      },
+    "%lld system locations are protected by macOS, so this selection’s total may be incomplete.": {
+      "comment": "Inspector warning summary for protected locations that Full Disk Access cannot unlock.",
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Systemort ist durch macOS geschützt, daher ist die Summe dieser Auswahl möglicherweise unvollständig."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Systemorte sind durch macOS geschützt, daher ist die Summe dieser Auswahl möglicherweise unvollständig."
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld system location is protected by macOS, so this selection’s total may be incomplete."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld system locations are protected by macOS, so this selection’s total may be incomplete."
+                }
+              }
+            }
+          }
+        },
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld ubicación del sistema está protegida por macOS, por lo que el total de esta selección puede estar incompleto."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld ubicaciones del sistema están protegidas por macOS, por lo que el total de esta selección puede estar incompleto."
+                }
+              }
+            }
+          }
+        },
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld emplacement système est protégé par macOS ; le total de cette sélection peut donc être incomplet."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld emplacements système sont protégés par macOS ; le total de cette sélection peut donc être incomplet."
+                }
+              }
+            }
+          }
+        },
+        "it": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld posizione di sistema è protetta da macOS, quindi il totale della selezione potrebbe essere incompleto."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld posizioni di sistema sono protette da macOS, quindi il totale della selezione potrebbe essere incompleto."
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld 个系统位置受 macOS 保护，因此此选择的总计可能不完整。"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "%lld locations in this selection couldn’t be read. Its allocated size and contents may be incomplete.": {
+      "comment": "Inspector warning summary for unreadable locations within the current selection.",
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Ort in dieser Auswahl konnte nicht gelesen werden. Die zugewiesene Größe und der Inhalt sind möglicherweise unvollständig."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Orte in dieser Auswahl konnten nicht gelesen werden. Die zugewiesene Größe und der Inhalt sind möglicherweise unvollständig."
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld location in this selection couldn’t be read. Its allocated size and contents may be incomplete."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld locations in this selection couldn’t be read. Its allocated size and contents may be incomplete."
+                }
+              }
+            }
+          }
+        },
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "No se pudo leer %lld ubicación de esta selección. Su tamaño asignado y contenido pueden estar incompletos."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "No se pudieron leer %lld ubicaciones de esta selección. Su tamaño asignado y contenido pueden estar incompletos."
+                }
+              }
+            }
+          }
+        },
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld emplacement de cette sélection n’a pas pu être lu. Sa taille allouée et son contenu peuvent être incomplets."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld emplacements de cette sélection n’ont pas pu être lus. Sa taille allouée et son contenu peuvent être incomplets."
+                }
+              }
+            }
+          }
+        },
+        "it": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Impossibile leggere %lld posizione in questa selezione. La dimensione allocata e i contenuti potrebbero essere incompleti."
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Impossibile leggere %lld posizioni in questa selezione. La dimensione allocata e i contenuti potrebbero essere incompleti."
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "无法读取此选择中的 %lld 个位置。其已分配大小和内容可能不完整。"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "%lld Protected Locations in %@": {
+      "comment": "Inspector warning popover title for protected locations.",
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld geschützter Ort in %@"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld geschützte Orte in %@"
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Protected Location in %@"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Protected Locations in %@"
+                }
+              }
+            }
+          }
+        },
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld ubicación protegida en %@"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld ubicaciones protegidas en %@"
+                }
+              }
+            }
+          }
+        },
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld emplacement protégé dans %@"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld emplacements protégés dans %@"
+                }
+              }
+            }
+          }
+        },
+        "it": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld posizione protetta in %@"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld posizioni protette in %@"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%2$@ 中有 %1$lld 个受保护位置"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "%lld Warnings in %@": {
+      "comment": "Inspector warning popover title.",
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Warnung in %@"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Warnungen in %@"
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Warning in %@"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Warnings in %@"
+                }
+              }
+            }
+          }
+        },
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld advertencia en %@"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld advertencias en %@"
+                }
+              }
+            }
+          }
+        },
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld avertissement dans %@"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld avertissements dans %@"
+                }
+              }
+            }
+          }
+        },
+        "it": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld avviso in %@"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld avvisi in %@"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%2$@ 中有 %1$lld 条警告"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+"%lld folders": {
+      "comment": "Inspector multiple-selection folder count.",
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Ordner"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Ordner"
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld folder"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld folders"
+                }
+              }
+            }
+          }
+        },
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld carpeta"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld carpetas"
+                }
+              }
+            }
+          }
+        },
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld dossier"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld dossiers"
+                }
+              }
+            }
+          }
+        },
+        "it": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld cartella"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld cartelle"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld 个文件夹"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "%lld packages": {
+      "comment": "Inspector multiple-selection package count.",
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Paket"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Pakete"
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld package"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld packages"
+                }
+              }
+            }
+          }
+        },
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld paquete"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld paquetes"
+                }
+              }
+            }
+          }
+        },
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld paquet"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld paquets"
+                }
+              }
+            }
+          }
+        },
+        "it": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld pacchetto"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld pacchetti"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld 个软件包"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+"Show Less": {
+        "comment": "Action that collapses the Inspector selected-items list.",
+        "localizations": {
+          "de": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Weniger anzeigen"
+            }
+          },
+          "es": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Mostrar menos"
+            }
+          },
+          "fr": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Afficher moins"
+            }
+          },
+          "it": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Mostra meno"
+            }
+          },
+          "zh-Hans": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "收起"
+            }
+          }
+        }
+      },
+      "Show %lld More": {
+        "comment": "Action that expands the Inspector selected-items list.",
+        "localizations": {
+          "de": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "%lld weitere anzeigen"
+            }
+          },
+          "es": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Mostrar %lld más"
+            }
+          },
+          "fr": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Afficher %lld de plus"
+            }
+          },
+          "it": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Mostra altri %lld"
+            }
+          },
+          "zh-Hans": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "再显示 %lld 项"
+            }
+          }
+        }
+      },
+      "Nothing Selected": {
+        "comment": "Inspector empty-state title.",
+        "localizations": {
+          "de": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Nichts ausgewählt"
+            }
+          },
+          "es": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Nada seleccionado"
+            }
+          },
+          "fr": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Aucune sélection"
+            }
+          },
+          "it": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Nessuna selezione"
+            }
+          },
+          "zh-Hans": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "未选择任何项目"
+            }
+          }
+        }
+      },
+      "Select an item in the disk map or file browser to inspect it.": {
+        "comment": "Inspector empty-state guidance.",
+        "localizations": {
+          "de": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Wähle ein Element in der Speicherkarte oder im Dateibrowser aus, um es zu prüfen."
+            }
+          },
+          "es": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Selecciona un elemento en el mapa de disco o en el explorador de archivos para inspeccionarlo."
+            }
+          },
+          "fr": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Sélectionnez un élément dans la carte du disque ou le navigateur de fichiers pour l’inspecter."
+            }
+          },
+          "it": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Seleziona un elemento nella mappa del disco o nel browser dei file per esaminarlo."
+            }
+          },
+          "zh-Hans": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "在磁盘图或文件浏览器中选择一个项目以查看其信息。"
+            }
+          }
+        }
+      },
+      "Protected by macOS": {
+        "comment": "Inspector warning title for locations macOS intentionally protects.",
+        "localizations": {
+          "de": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Von macOS geschützt"
+            }
+          },
+          "es": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Protegido por macOS"
+            }
+          },
+          "fr": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Protégé par macOS"
+            }
+          },
+          "it": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Protetto da macOS"
+            }
+          },
+          "zh-Hans": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "受 macOS 保护"
+            }
+          }
+        }
+      },
+      "Incomplete contents": {
+        "comment": "Inspector warning title for unreadable selected contents.",
+        "localizations": {
+          "de": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Unvollständige Inhalte"
+            }
+          },
+          "es": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Contenido incompleto"
+            }
+          },
+          "fr": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Contenu incomplet"
+            }
+          },
+          "it": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Contenuti incompleti"
+            }
+          },
+          "zh-Hans": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "内容不完整"
+            }
+          }
+        }
+      },
+    "Show %lld Warnings": {
+      "comment": "Action that opens the Inspector warning details popover.",
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Warnung anzeigen"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Warnungen anzeigen"
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Show %lld Warning"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Show %lld Warnings"
+                }
+              }
+            }
+          }
+        },
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Mostrar %lld advertencia"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Mostrar %lld advertencias"
+                }
+              }
+            }
+          }
+        },
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Afficher %lld avertissement"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Afficher %lld avertissements"
+                }
+              }
+            }
+          }
+        },
+        "it": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Mostra %lld avviso"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Mostra %lld avvisi"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "显示 %lld 条警告"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+"This selection comes from a saved scan. Removal actions are unavailable.": {
+        "comment": "Inspector notice explaining saved-scan action limits.",
+        "localizations": {
+          "de": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Diese Auswahl stammt aus einem gespeicherten Scan. Aktionen zum Entfernen sind nicht verfügbar."
+            }
+          },
+          "es": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Esta selección procede de un análisis guardado. Las acciones de eliminación no están disponibles."
+            }
+          },
+          "fr": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Cette sélection provient d’une analyse enregistrée. Les actions de suppression ne sont pas disponibles."
+            }
+          },
+          "it": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Questa selezione proviene da una scansione salvata. Le azioni di rimozione non sono disponibili."
+            }
+          },
+          "zh-Hans": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "此选择来自已保存的扫描。移除操作不可用。"
+            }
+          }
+        }
+      },
+      "The scanned volume itself cannot be added to the Discard Pile or moved to Trash.": {
+        "comment": "Inspector notice explaining scan-root action limits.",
+        "localizations": {
+          "de": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Das gescannte Volume selbst kann weder dem Ablagestapel hinzugefügt noch in den Papierkorb bewegt werden."
+            }
+          },
+          "es": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "El volumen analizado no se puede añadir a la pila de descarte ni mover a la papelera."
+            }
+          },
+          "fr": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Le volume analysé lui-même ne peut pas être ajouté à la pile de suppression ni placé dans la corbeille."
+            }
+          },
+          "it": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Il volume scansionato non può essere aggiunto alla pila degli scarti né spostato nel Cestino."
+            }
+          },
+          "zh-Hans": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "无法将扫描的宗卷本身添加到丢弃堆或移到废纸篓。"
+            }
+          }
+        }
+      },
+      "This location is protected from removal. You can still open it or reveal it in Finder.": {
+        "comment": "Inspector notice explaining protected-location action limits.",
+        "localizations": {
+          "de": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Dieser Ort ist vor dem Entfernen geschützt. Er kann weiterhin geöffnet oder im Finder angezeigt werden."
+            }
+          },
+          "es": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Esta ubicación está protegida contra la eliminación. Aún puedes abrirla o mostrarla en el Finder."
+            }
+          },
+          "fr": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Cet emplacement est protégé contre la suppression. Vous pouvez toujours l’ouvrir ou l’afficher dans le Finder."
+            }
+          },
+          "it": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Questa posizione è protetta dalla rimozione. Puoi comunque aprirla o mostrarla nel Finder."
+            }
+          },
+          "zh-Hans": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "此位置受保护，无法移除。你仍可打开它或在“访达”中显示它。"
+            }
+          }
+        }
+      },
+      "Some selected items are protected from removal. You can still reveal them in Finder.": {
+        "comment": "Inspector notice explaining protected multiple-selection action limits.",
+        "localizations": {
+          "de": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Einige ausgewählte Elemente sind vor dem Entfernen geschützt. Sie können weiterhin im Finder angezeigt werden."
+            }
+          },
+          "es": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Algunos elementos seleccionados están protegidos contra la eliminación. Aún puedes mostrarlos en el Finder."
+            }
+          },
+          "fr": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Certains éléments sélectionnés sont protégés contre la suppression. Vous pouvez toujours les afficher dans le Finder."
+            }
+          },
+          "it": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Alcuni elementi selezionati sono protetti dalla rimozione. Puoi comunque mostrarli nel Finder."
+            }
+          },
+          "zh-Hans": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "某些所选项目受保护，无法移除。你仍可在“访达”中显示它们。"
+            }
+          }
+        }
+      },
+      "Some selected items do not represent regular file paths, so file actions are unavailable.": {
+        "comment": "Inspector notice explaining why file actions are unavailable.",
+        "localizations": {
+          "de": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Einige ausgewählte Elemente stellen keine regulären Dateipfade dar, daher sind Dateiaktionen nicht verfügbar."
+            }
+          },
+          "es": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Algunos elementos seleccionados no representan rutas de archivo normales, por lo que las acciones de archivo no están disponibles."
+            }
+          },
+          "fr": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Certains éléments sélectionnés ne correspondent pas à des chemins de fichier ordinaires ; les actions de fichier ne sont donc pas disponibles."
+            }
+          },
+          "it": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Alcuni elementi selezionati non rappresentano normali percorsi di file, quindi le azioni sui file non sono disponibili."
+            }
+          },
+          "zh-Hans": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "某些所选项目并非常规文件路径，因此文件操作不可用。"
+            }
+          }
+        }
+      },
+      "Contents summarized": {
+        "comment": "Inspector notice title for a folder summarized during scanning.",
+        "localizations": {
+          "de": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Inhalte zusammengefasst"
+            }
+          },
+          "es": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Contenido resumido"
+            }
+          },
+          "fr": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Contenu résumé"
+            }
+          },
+          "it": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Contenuti riepilogati"
+            }
+          },
+          "zh-Hans": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "内容已汇总"
+            }
+          }
+        }
+      },
+      "Radix grouped this folder during the scan. Expand it to inspect individual items.": {
+        "comment": "Inspector explanation for a summarized folder.",
+        "localizations": {
+          "de": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Radix hat diesen Ordner beim Scan gruppiert. Erweitere ihn, um einzelne Elemente zu prüfen."
+            }
+          },
+          "es": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Radix agrupó esta carpeta durante el análisis. Expándela para inspeccionar los elementos individuales."
+            }
+          },
+          "fr": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Radix a regroupé ce dossier pendant l’analyse. Développez-le pour inspecter les éléments individuellement."
+            }
+          },
+          "it": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Radix ha raggruppato questa cartella durante la scansione. Espandila per esaminare i singoli elementi."
+            }
+          },
+          "zh-Hans": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Radix 在扫描期间汇总了此文件夹。展开它即可检查各个项目。"
+            }
+          }
+        }
+      },
+      "Details": {
+        "comment": "Inspector section title for file metadata.",
+        "localizations": {
+          "de": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Details"
+            }
+          },
+          "es": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Detalles"
+            }
+          },
+          "fr": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Détails"
+            }
+          },
+          "it": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Dettagli"
+            }
+          },
+          "zh-Hans": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "详细信息"
+            }
+          }
+        }
+      },
+      "More Actions": {
+        "comment": "Accessibility label and help text for the Inspector action menu.",
+        "localizations": {
+          "de": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Weitere Aktionen"
+            }
+          },
+          "es": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Más acciones"
+            }
+          },
+          "fr": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Plus d’actions"
+            }
+          },
+          "it": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Altre azioni"
+            }
+          },
+          "zh-Hans": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "更多操作"
+            }
+          }
+        }
+      },
+      "Selected Items": {
+        "comment": "Inspector section title listing a multiple selection.",
+        "localizations": {
+          "de": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Ausgewählte Elemente"
+            }
+          },
+          "es": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Elementos seleccionados"
+            }
+          },
+          "fr": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Éléments sélectionnés"
+            }
+          },
+          "it": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Elementi selezionati"
+            }
+          },
+          "zh-Hans": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "所选项目"
+            }
+          }
+        }
+      },
+      "Allocated size %@": {
+        "comment": "Accessibility label for the allocated storage value in the Inspector.",
+        "localizations": {
+          "de": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Zugewiesene Größe: %@"
+            }
+          },
+          "es": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Tamaño asignado: %@"
+            }
+          },
+          "fr": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Taille allouée : %@"
+            }
+          },
+          "it": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Dimensione allocata: %@"
+            }
+          },
+          "zh-Hans": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "已分配大小：%@"
+            }
+          }
+        }
+      },
+      "of parent": {
+        "comment": "Inspector statistic for a selected item's share of its parent folder.",
+        "localizations": {
+          "de": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "des übergeordneten Ordners"
+            }
+          },
+          "es": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "de la carpeta superior"
+            }
+          },
+          "fr": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "du dossier parent"
+            }
+          },
+          "it": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "della cartella superiore"
+            }
+          },
+          "zh-Hans": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "占父文件夹"
+            }
+          }
+        }
+      },
+      "of scan": {
+        "comment": "Inspector statistic for a selection's share of the entire scan.",
+        "localizations": {
+          "de": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "des Scans"
+            }
+          },
+          "es": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "del análisis"
+            }
+          },
+          "fr": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "de l’analyse"
+            }
+          },
+          "it": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "della scansione"
+            }
+          },
+          "zh-Hans": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "占扫描"
+            }
+          }
+        }
+      },
+      "Shared APFS storage": {
+        "comment": "Inspector title for a file known to share APFS storage.",
+        "localizations": {
+          "de": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Gemeinsam genutzter APFS-Speicher"
+            }
+          },
+          "es": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Almacenamiento APFS compartido"
+            }
+          },
+          "fr": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Stockage APFS partagé"
+            }
+          },
+          "it": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Spazio APFS condiviso"
+            }
+          },
+          "zh-Hans": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "共享的 APFS 存储空间"
+            }
+          }
+        }
+      },
+      "%@ logical size. Radix counts shared bytes once across clones, so deleting this file may free less than its apparent size.": {
+        "comment": "Inspector explanation for an APFS clone's logical size and attributed allocated storage.",
+        "localizations": {
+          "de": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "%@ logische Größe. Radix zählt gemeinsam genutzte Bytes klonübergreifend nur einmal, daher gibt das Löschen dieser Datei möglicherweise weniger als ihre scheinbare Größe frei."
+            }
+          },
+          "es": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "%@ de tamaño lógico. Radix cuenta los bytes compartidos una sola vez entre los clones, por lo que eliminar este archivo puede liberar menos que su tamaño aparente."
+            }
+          },
+          "fr": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "%@ de taille logique. Radix ne compte qu’une fois les octets partagés entre les clones ; supprimer ce fichier peut donc libérer moins que sa taille apparente."
+            }
+          },
+          "it": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "%@ di dimensione logica. Radix conta una sola volta i byte condivisi tra i cloni, quindi eliminare questo file potrebbe liberare meno della sua dimensione apparente."
+            }
+          },
+          "zh-Hans": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "逻辑大小为 %@。Radix 对克隆间共享的字节只计算一次，因此删除此文件释放的空间可能小于其显示大小。"
+            }
+          }
+        }
+      },
+      "%@ logical size. Parts of this file may share storage; exact shared and reclaimable bytes aren’t available from macOS.": {
+        "comment": "Inspector explanation for a file that may share APFS storage.",
+        "localizations": {
+          "de": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "%@ logische Größe. Teile dieser Datei nutzen möglicherweise gemeinsamen Speicher; macOS stellt die genaue Anzahl gemeinsam genutzter und freigebbarer Bytes nicht bereit."
+            }
+          },
+          "es": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "%@ de tamaño lógico. Algunas partes de este archivo pueden compartir almacenamiento; macOS no proporciona la cantidad exacta de bytes compartidos y recuperables."
+            }
+          },
+          "fr": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "%@ de taille logique. Certaines parties de ce fichier peuvent partager du stockage ; macOS ne fournit pas le nombre exact d’octets partagés et récupérables."
+            }
+          },
+          "it": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "%@ di dimensione logica. Alcune parti di questo file potrebbero condividere lo spazio; macOS non rende disponibili i byte condivisi e recuperabili esatti."
+            }
+          },
+          "zh-Hans": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "逻辑大小为 %@。此文件的部分内容可能共享存储空间；macOS 不提供共享和可回收字节的确切数量。"
+            }
+          }
+        }
+      },
+      "Saved scan": {
+        "comment": "Inspector notice title for a selection loaded from a saved scan.",
+        "localizations": {
+          "de": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Gespeicherter Scan"
+            }
+          },
+          "es": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Análisis guardado"
+            }
+          },
+          "fr": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Analyse enregistrée"
+            }
+          },
+          "it": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Scansione salvata"
+            }
+          },
+          "zh-Hans": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "已保存的扫描"
+            }
+          }
+        }
+      },
+      "Scan root": {
+        "comment": "Inspector notice title for the root of a scanned volume.",
+        "localizations": {
+          "de": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Scan-Wurzel"
+            }
+          },
+          "es": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Raíz del análisis"
+            }
+          },
+          "fr": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Racine de l’analyse"
+            }
+          },
+          "it": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Radice della scansione"
+            }
+          },
+          "zh-Hans": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "扫描根目录"
+            }
+          }
+        }
+      },
+      "Protected location": {
+        "comment": "Inspector notice title for a location protected from removal.",
+        "localizations": {
+          "de": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Geschützter Ort"
+            }
+          },
+          "es": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Ubicación protegida"
+            }
+          },
+          "fr": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Emplacement protégé"
+            }
+          },
+          "it": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Posizione protetta"
+            }
+          },
+          "zh-Hans": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "受保护的位置"
+            }
+          }
+        }
+      },
+      "Protected selection": {
+        "comment": "Inspector notice title for a multiple selection containing protected items.",
+        "localizations": {
+          "de": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Geschützte Auswahl"
+            }
+          },
+          "es": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Selección protegida"
+            }
+          },
+          "fr": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Sélection protégée"
+            }
+          },
+          "it": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Selezione protetta"
+            }
+          },
+          "zh-Hans": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "受保护的选择"
+            }
+          }
+        }
+      },
+      "Limited actions": {
+        "comment": "Inspector notice title when file actions are limited.",
+        "localizations": {
+          "de": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Eingeschränkte Aktionen"
+            }
+          },
+          "es": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Acciones limitadas"
+            }
+          },
+          "fr": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Actions limitées"
+            }
+          },
+          "it": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "Azioni limitate"
+            }
+          },
+          "zh-Hans": {
+            "stringUnit": {
+              "state": "translated",
+              "value": "操作受限"
+            }
+          }
+        }
+      },
+    "%lld Items Selected": {
+      "comment": "Inspector heading for a selection containing one or more items.",
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Element ausgewählt"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Elemente ausgewählt"
+                }
+              }
+            }
+          }
+        },
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Item Selected"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Items Selected"
+                }
+              }
+            }
+          }
+        },
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld elemento seleccionado"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld elementos seleccionados"
+                }
+              }
+            }
+          }
+        },
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld élément sélectionné"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld éléments sélectionnés"
+                }
+              }
+            }
+          }
+        },
+        "it": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld elemento selezionato"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld elementi selezionati"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "已选择 %lld 个项目"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+"Scans run" : {
       "comment" : "Stats pane label for the total number of scans run.",
       "localizations" : {
         "de" : {
@@ -1919,41 +4466,6 @@
         }
       }
     },
-    "1 file" : {
-      "comment" : "Tooltip metadata for a directory containing one file.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "1 Datei"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "1 archivo"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "1 fichier"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "1 file"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "1 个文件"
-          }
-        }
-      }
-    },
     "1 grouped item" : {
       "comment" : "Tooltip metadata for one item represented by an aggregate segment.",
       "localizations" : {
@@ -2263,42 +4775,114 @@
         }
       }
     },
-    "Add %lld Items to Discard Pile" : {
-      "comment" : "Action for marking multiple selected items for possible deletion.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld Elemente zur Löschliste hinzufügen"
+    "Add %lld Items to Discard Pile": {
+      "comment": "Action for marking one or more effective top-level selected items for possible deletion.",
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Element zur Löschliste hinzufügen"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Elemente zur Löschliste hinzufügen"
+                }
+              }
+            }
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Añadir %lld elementos a la pila de descarte"
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Add %lld Item to Discard Pile"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Add %lld Items to Discard Pile"
+                }
+              }
+            }
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajouter %lld éléments à la pile de suppression"
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Añadir %lld elemento a la pila de descarte"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Añadir %lld elementos a la pila de descarte"
+                }
+              }
+            }
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aggiungi %lld elementi all'elenco di eliminazione"
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Ajouter %lld élément à la pile de suppression"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Ajouter %lld éléments à la pile de suppression"
+                }
+              }
+            }
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "将 %lld 个项目加入待处理列表"
+        "it": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Aggiungi %lld elemento all'elenco di eliminazione"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Aggiungi %lld elementi all'elenco di eliminazione"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "将 %lld 个项目加入待处理列表"
+                }
+              }
+            }
           }
         }
       }
     },
-    "Add Cloud Item to Discard Pile?" : {
+"Add Cloud Item to Discard Pile?" : {
       "comment" : "Confirmation title before adding one cloud-stored item to the Discard Pile.",
       "localizations" : {
         "de" : {
@@ -8858,40 +11442,6 @@
         }
       }
     },
-    "Key Stats" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wichtige Statistiken"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Estadísticas clave"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Statistiques clés"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Statistiche chiave"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "关键统计信息"
-          }
-        }
-      }
-    },
     "Kind" : {
       "localizations" : {
         "de" : {
@@ -9445,40 +11995,6 @@
         }
       }
     },
-    "Logical Size" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Logische Größe"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tamaño lógico"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Taille logique"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dimensione logica"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "逻辑大小"
-          }
-        }
-      }
-    },
     "macOS could not copy the path for %@." : {
       "comment" : "Error shown when copying a selected file path fails.",
       "localizations" : {
@@ -9728,40 +12244,6 @@
         }
       }
     },
-    "Metadata" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metadaten"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metadatos"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Métadonnées"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Metadati"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "元数据"
-          }
-        }
-      }
-    },
     "Modification date unavailable" : {
       "comment" : "Tooltip metadata shown when a file's modification date is unavailable.",
       "localizations" : {
@@ -9937,41 +12419,114 @@
         }
       }
     },
-    "Move %lld Items to Trash" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld Elemente in den Papierkorb bewegen"
+    "Move %lld Items to Trash": {
+      "comment": "Destructive action for moving one or more effective top-level selected items to the Trash.",
+      "localizations": {
+        "de": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Element in den Papierkorb bewegen"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "%lld Elemente in den Papierkorb bewegen"
+                }
+              }
+            }
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mover %lld elementos a la papelera"
+        "en": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Move %lld Item to Trash"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Move %lld Items to Trash"
+                }
+              }
+            }
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Placer %lld éléments dans la corbeille"
+        "es": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Mover %lld elemento a la papelera"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Mover %lld elementos a la papelera"
+                }
+              }
+            }
           }
         },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sposta %lld elementi nel Cestino"
+        "fr": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Placer %lld élément dans la corbeille"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Placer %lld éléments dans la corbeille"
+                }
+              }
+            }
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "将 %lld 个项目移到废纸篓"
+        "it": {
+          "variations": {
+            "plural": {
+              "one": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Sposta %lld elemento nel Cestino"
+                }
+              },
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "Sposta %lld elementi nel Cestino"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans": {
+          "variations": {
+            "plural": {
+              "other": {
+                "stringUnit": {
+                  "state": "translated",
+                  "value": "将 %lld 个项目移到废纸篓"
+                }
+              }
+            }
           }
         }
       }
     },
-    "Move Cloud Item to Trash?" : {
+"Move Cloud Item to Trash?" : {
       "comment" : "Second confirmation title before moving one cloud-stored item to the Trash.",
       "localizations" : {
         "de" : {
@@ -10734,40 +13289,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "当前扫描没有活动的受保护文件夹警告。"
-          }
-        }
-      }
-    },
-    "No Selection" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Auswahl"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sin selección"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucune sélection"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nessuna selezione"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "未选择"
           }
         }
       }
@@ -15648,40 +18169,6 @@
         }
       }
     },
-    "Select a chart segment or table row to inspect metadata and file actions." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wählen Sie ein Diagrammsegment oder eine Tabellenzeile aus, um Metadaten und Dateiaktionen zu untersuchen."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selecciona un segmento del gráfico o una fila de la tabla para inspeccionar los metadatos y las acciones de archivo."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sélectionnez un segment du graphique ou une ligne du tableau pour inspecter les métadonnées et les actions sur les fichiers."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seleziona un segmento del grafico o una riga della tabella per esaminare i metadati e le azioni sui file."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择图表分区或表格行以查看元数据和文件操作。"
-          }
-        }
-      }
-    },
     "Select a row to inspect it. Double-click a folder to zoom in, or a summarized folder to expand it. Press Space for Quick Look." : {
       "localizations" : {
         "de" : {
@@ -15945,47 +18432,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此文件的部分内容可能共享 APFS 存储空间。macOS 未向 Radix 提供足够的信息，无法精确计算共享或可释放的字节数。"
-          }
-        }
-      }
-    },
-    "Storage" : {
-      "comment" : "Inspector section containing information about a file's storage behavior.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Speicher"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Storage"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Almacenamiento"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stockage"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Archiviazione"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "存储空间"
           }
         }
       }
@@ -19799,40 +22245,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "放大查看包含内容的目录以填充此表格。"
-          }
-        }
-      }
-    },
-    "Zoom Into Folder" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ordner vergrößern"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Acercar a la carpeta"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zoomer sur le dossier"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ingrandisci cartella"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "缩放到文件夹"
           }
         }
       }

--- a/Radix/Models/FileNodeRecord.swift
+++ b/Radix/Models/FileNodeRecord.swift
@@ -237,13 +237,4 @@ extension FileNodeRecord {
         return nil
     }
 
-    var accessDescription: String {
-        if isSynthetic {
-            return String(localized: "Estimated", comment: "Metadata value indicating that storage is estimated.")
-        }
-        return isAccessible
-            ? String(localized: "Readable", comment: "Metadata value indicating that a file or folder is readable.")
-            : String(localized: "Limited", comment: "Metadata value indicating that access to a file or folder is limited.")
-    }
-
 }

--- a/Radix/Services/SystemIntegration.swift
+++ b/Radix/Services/SystemIntegration.swift
@@ -16,6 +16,13 @@ nonisolated enum FullDiskAccessStatus: Equatable, Sendable {
     case unknown
 }
 
+nonisolated enum FullDiskAccessAdvice: Equatable, Sendable {
+    case none
+    case openSettings
+    case rescanMayBeNeeded
+    case savedScanIsHistorical
+}
+
 protocol SystemWorkspace {
     func activateFileViewerSelecting(_ fileURLs: [URL])
     func open(_ url: URL) -> Bool
@@ -815,30 +822,110 @@ private struct ProtectedPathProbe {
 }
 
 nonisolated enum PermissionAdvisor {
-    // Fragments whose contents Full Disk Access actually unlocks. Note that the
+    // Locations whose contents Full Disk Access actually unlocks. Note that the
     // TCC directory itself (/Library/Application Support/com.apple.TCC) is
     // root-owned/SIP-protected and stays unreadable even with FDA, so it must
-    // not be listed here — matching it would suggest FDA for a grant that can
-    // never resolve the warning.
-    private static let fullDiskAccessProtectedPathFragments = [
-        "/Library/Mail",
-        "/Library/Messages",
-        "/Library/Safari",
-        "/Library/HomeKit",
+    // not be listed here. These paths are resolved under the current user's
+    // home directory so similarly named folders and other users do not prompt.
+    private static let fullDiskAccessProtectedRelativePaths = [
+        "Library/Mail",
+        "Library/Messages",
+        "Library/Safari",
+        "Library/HomeKit",
+    ]
+
+    // Keep this deliberately conservative. These are locations Radix has
+    // verified remain protected by macOS rather than arbitrary EACCES/EPERM
+    // failures, which can also come from ownership or custom ACLs.
+    private static let expectedMacOSProtectedPaths = [
+        "/Library/Application Support/com.apple.TCC",
+        "/Library/Caches/com.apple.iconservices.store",
+        "/System/Volumes/Data/Library/Application Support/com.apple.TCC",
+        "/System/Volumes/Data/Library/Caches/com.apple.iconservices.store",
     ]
 
     static func shouldSuggestFullDiskAccess(
         for snapshot: ScanSnapshot?,
-        fullDiskAccessStatus: FullDiskAccessStatus
+        fullDiskAccessStatus: FullDiskAccessStatus,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
     ) -> Bool {
-        // Don't nag for access that is already granted. Many system paths
-        // (e.g. /Library/Caches/com.apple.iconservices.store) stay unreadable
-        // regardless of FDA, so warning presence alone must not drive the prompt.
-        guard fullDiskAccessStatus != .granted else { return false }
-        guard let snapshot else { return false }
-        return snapshot.scanWarnings.contains(where: { warning in
-            warning.category == .permissionDenied &&
-                fullDiskAccessProtectedPathFragments.contains(where: { warning.path.contains($0) })
-        })
+        shouldSuggestFullDiskAccess(
+            for: snapshot?.scanWarnings ?? [],
+            fullDiskAccessStatus: fullDiskAccessStatus,
+            homeDirectory: homeDirectory
+        )
+    }
+
+    static func shouldSuggestFullDiskAccess(
+        for warnings: [ScanWarning],
+        fullDiskAccessStatus: FullDiskAccessStatus,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) -> Bool {
+        // Only recommend a settings change after the probe has positively
+        // established that access is missing. An unknown status must not flash
+        // an FDA prompt for a user who has already granted it.
+        guard fullDiskAccessStatus == .notGranted else { return false }
+        return containsFullDiskAccessRelevantWarning(
+            warnings,
+            homeDirectory: homeDirectory
+        )
+    }
+
+    static func fullDiskAccessAdvice(
+        for warnings: [ScanWarning],
+        fullDiskAccessStatus: FullDiskAccessStatus,
+        snapshotSource: ScanSnapshotSource,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) -> FullDiskAccessAdvice {
+        guard containsFullDiskAccessRelevantWarning(
+            warnings,
+            homeDirectory: homeDirectory
+        ) else {
+            return .none
+        }
+        if snapshotSource.isImported {
+            return .savedScanIsHistorical
+        }
+        switch fullDiskAccessStatus {
+        case .notGranted:
+            return .openSettings
+        case .granted:
+            return .rescanMayBeNeeded
+        case .unknown:
+            return .none
+        }
+    }
+
+    static func isExpectedMacOSProtection(_ warning: ScanWarning) -> Bool {
+        guard warning.category == .permissionDenied else { return false }
+        let warningPath = URL(filePath: warning.path).standardizedFileURL.path
+        return expectedMacOSProtectedPaths.contains { protectedPath in
+            warningPath == protectedPath || warningPath.hasPrefix(protectedPath + "/")
+        }
+    }
+
+    private static func containsFullDiskAccessRelevantWarning(
+        _ warnings: [ScanWarning],
+        homeDirectory: URL
+    ) -> Bool {
+        let protectedPaths = fullDiskAccessProtectedPaths(homeDirectory: homeDirectory)
+        return warnings.contains { warning in
+            guard warning.category == .permissionDenied else { return false }
+            let warningPath = URL(filePath: warning.path).standardizedFileURL.path
+            return protectedPaths.contains { protectedPath in
+                warningPath == protectedPath || warningPath.hasPrefix(protectedPath + "/")
+            }
+        }
+    }
+
+    private static func fullDiskAccessProtectedPaths(homeDirectory: URL) -> [String] {
+        let homePath = homeDirectory.standardizedFileURL.path
+        let protectedPaths = fullDiskAccessProtectedRelativePaths.map { relativePath in
+            URL(filePath: homePath).appending(path: relativePath).standardizedFileURL.path
+        }
+        guard homePath != "/", !homePath.hasPrefix("/System/Volumes/Data/") else {
+            return protectedPaths
+        }
+        return protectedPaths + protectedPaths.map { "/System/Volumes/Data" + $0 }
     }
 }

--- a/Radix/ViewModels/InspectorSelectionSummary.swift
+++ b/Radix/ViewModels/InspectorSelectionSummary.swift
@@ -2,34 +2,87 @@ import Foundation
 
 nonisolated struct InspectorSelectionSummary: Equatable, Sendable {
     let selectedNodes: [FileNodeRecord]
-    let countedNodes: [FileNodeRecord]
+    let topLevelSelectedNodes: [FileNodeRecord]
     let allocatedSize: Int64
-    let logicalSize: Int64
+    let containsOverlappingSelections: Bool
+    let missingSelectedNodeCount: Int
 
     init(selectedNodes: [FileNodeRecord], fileTreeStore: FileTreeStore?) {
         self.selectedNodes = selectedNodes
 
         if let fileTreeStore {
+            let presentNodeIDs = selectedNodes.map(\.id).filter { fileTreeStore.node(id: $0) != nil }
             let selectedNodesByID = Dictionary(
                 uniqueKeysWithValues: selectedNodes.map { ($0.id, $0) }
             )
-            countedNodes = fileTreeStore
-                .topLevelNodeIDs(from: selectedNodes.map(\.id))
+            topLevelSelectedNodes = fileTreeStore
+                .topLevelNodeIDs(from: presentNodeIDs)
                 .compactMap { selectedNodesByID[$0] }
+            containsOverlappingSelections = topLevelSelectedNodes.count != presentNodeIDs.count
+            missingSelectedNodeCount = selectedNodes.count - presentNodeIDs.count
         } else {
-            countedNodes = selectedNodes
+            topLevelSelectedNodes = selectedNodes
+            containsOverlappingSelections = false
+            missingSelectedNodeCount = 0
         }
 
-        allocatedSize = Self.total(\.allocatedSize, in: countedNodes)
-        logicalSize = Self.total(\.logicalSize, in: countedNodes)
+        allocatedSize = Self.total(\.allocatedSize, in: topLevelSelectedNodes)
     }
 
     var selectedCount: Int {
         selectedNodes.count
     }
 
-    var containsOverlappingSelections: Bool {
-        countedNodes.count != selectedNodes.count
+    var topLevelSelectedCount: Int {
+        topLevelSelectedNodes.count
+    }
+
+    var selectedNodesByAllocatedSize: [FileNodeRecord] {
+        selectedNodes.sorted(by: Self.isOrderedBefore)
+    }
+
+    func largestSelectedNodes(limit: Int) -> [FileNodeRecord] {
+        guard limit > 0 else { return [] }
+        guard selectedNodes.count > limit else {
+            return selectedNodesByAllocatedSize
+        }
+
+        var largest: [FileNodeRecord] = []
+        largest.reserveCapacity(limit)
+        for node in selectedNodes {
+            let insertionIndex = largest.firstIndex { existing in
+                Self.isOrderedBefore(node, existing)
+            } ?? largest.endIndex
+            largest.insert(node, at: insertionIndex)
+            if largest.count > limit {
+                largest.removeLast()
+            }
+        }
+        return largest
+    }
+
+    var selectedFolderCount: Int {
+        selectedNodes.count { $0.isDirectory && !$0.isPackage && !$0.isSynthetic }
+    }
+
+    var selectedPackageCount: Int {
+        selectedNodes.count { $0.isPackage && !$0.isSynthetic }
+    }
+
+    var selectedFileCount: Int {
+        selectedNodes.count { !$0.isDirectory && !$0.isPackage && !$0.isSynthetic }
+    }
+
+    var selectedStorageCategoryCount: Int {
+        selectedNodes.count(where: \.isSynthetic)
+    }
+
+    var containsSharedStorageItems: Bool {
+        selectedNodes.contains { $0.cloneIdentity != nil || $0.mayShareDataBlocks }
+    }
+
+    var containsKnownClones: Bool {
+        selectedNodes.contains { $0.cloneIdentity != nil }
     }
 
     private static func total(
@@ -39,5 +92,12 @@ nonisolated struct InspectorSelectionSummary: Equatable, Sendable {
         nodes.reduce(0) { total, node in
             ScanIntegerMath.addingClamped(total, node[keyPath: keyPath])
         }
+    }
+
+    private static func isOrderedBefore(_ lhs: FileNodeRecord, _ rhs: FileNodeRecord) -> Bool {
+        if lhs.allocatedSize != rhs.allocatedSize {
+            return lhs.allocatedSize > rhs.allocatedSize
+        }
+        return lhs.name.localizedStandardCompare(rhs.name) == .orderedAscending
     }
 }

--- a/Radix/ViewModels/InspectorSelectionSummary.swift
+++ b/Radix/ViewModels/InspectorSelectionSummary.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+nonisolated struct InspectorSelectionSummary: Equatable, Sendable {
+    let selectedNodes: [FileNodeRecord]
+    let countedNodes: [FileNodeRecord]
+    let allocatedSize: Int64
+    let logicalSize: Int64
+
+    init(selectedNodes: [FileNodeRecord], fileTreeStore: FileTreeStore?) {
+        self.selectedNodes = selectedNodes
+
+        if let fileTreeStore {
+            let selectedNodesByID = Dictionary(
+                uniqueKeysWithValues: selectedNodes.map { ($0.id, $0) }
+            )
+            countedNodes = fileTreeStore
+                .topLevelNodeIDs(from: selectedNodes.map(\.id))
+                .compactMap { selectedNodesByID[$0] }
+        } else {
+            countedNodes = selectedNodes
+        }
+
+        allocatedSize = Self.total(\.allocatedSize, in: countedNodes)
+        logicalSize = Self.total(\.logicalSize, in: countedNodes)
+    }
+
+    var selectedCount: Int {
+        selectedNodes.count
+    }
+
+    var containsOverlappingSelections: Bool {
+        countedNodes.count != selectedNodes.count
+    }
+
+    private static func total(
+        _ keyPath: KeyPath<FileNodeRecord, Int64>,
+        in nodes: [FileNodeRecord]
+    ) -> Int64 {
+        nodes.reduce(0) { total, node in
+            ScanIntegerMath.addingClamped(total, node[keyPath: keyPath])
+        }
+    }
+}

--- a/RadixCoreTests/InspectorSelectionSummaryTests.swift
+++ b/RadixCoreTests/InspectorSelectionSummaryTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import RadixCore
+
+final class InspectorSelectionSummaryTests: XCTestCase {
+    func testSiblingSelectionsAreAggregated() {
+        let first = makeTestFileNode(id: "/root/first.txt", name: "first.txt", size: 12)
+        let second = makeTestFileNode(id: "/root/second.txt", name: "second.txt", size: 5)
+        let root = makeTestDirectoryNode(id: "/root", name: "root", children: [first, second])
+        let store = FileTreeStore(root: root, childrenByID: [root.id: [first, second]])
+
+        let summary = InspectorSelectionSummary(
+            selectedNodes: [first, second],
+            fileTreeStore: store
+        )
+
+        XCTAssertEqual(summary.selectedCount, 2)
+        XCTAssertEqual(summary.countedNodes.map(\.id), [first.id, second.id])
+        XCTAssertEqual(summary.allocatedSize, 17)
+        XCTAssertEqual(summary.logicalSize, 17)
+        XCTAssertFalse(summary.containsOverlappingSelections)
+    }
+
+    func testNestedSelectionIsCountedOnce() {
+        let nestedFile = makeTestFileNode(
+            id: "/root/folder/nested.txt",
+            name: "nested.txt",
+            size: 20
+        )
+        let folder = makeTestDirectoryNode(
+            id: "/root/folder",
+            name: "folder",
+            children: [nestedFile]
+        )
+        let sibling = makeTestFileNode(id: "/root/sibling.txt", name: "sibling.txt", size: 5)
+        let root = makeTestDirectoryNode(id: "/root", name: "root", children: [folder, sibling])
+        let store = FileTreeStore(root: root, childrenByID: [
+            root.id: [folder, sibling],
+            folder.id: [nestedFile]
+        ])
+
+        let summary = InspectorSelectionSummary(
+            selectedNodes: [nestedFile, folder, sibling],
+            fileTreeStore: store
+        )
+
+        XCTAssertEqual(summary.selectedCount, 3)
+        XCTAssertEqual(summary.countedNodes.map(\.id), [folder.id, sibling.id])
+        XCTAssertEqual(summary.allocatedSize, 25)
+        XCTAssertEqual(summary.logicalSize, 25)
+        XCTAssertTrue(summary.containsOverlappingSelections)
+    }
+}

--- a/RadixCoreTests/InspectorSelectionSummaryTests.swift
+++ b/RadixCoreTests/InspectorSelectionSummaryTests.swift
@@ -14,10 +14,11 @@ final class InspectorSelectionSummaryTests: XCTestCase {
         )
 
         XCTAssertEqual(summary.selectedCount, 2)
-        XCTAssertEqual(summary.countedNodes.map(\.id), [first.id, second.id])
+        XCTAssertEqual(summary.topLevelSelectedNodes.map(\.id), [first.id, second.id])
+        XCTAssertEqual(summary.topLevelSelectedCount, 2)
         XCTAssertEqual(summary.allocatedSize, 17)
-        XCTAssertEqual(summary.logicalSize, 17)
         XCTAssertFalse(summary.containsOverlappingSelections)
+        XCTAssertEqual(summary.missingSelectedNodeCount, 0)
     }
 
     func testNestedSelectionIsCountedOnce() {
@@ -44,9 +45,89 @@ final class InspectorSelectionSummaryTests: XCTestCase {
         )
 
         XCTAssertEqual(summary.selectedCount, 3)
-        XCTAssertEqual(summary.countedNodes.map(\.id), [folder.id, sibling.id])
+        XCTAssertEqual(summary.topLevelSelectedNodes.map(\.id), [folder.id, sibling.id])
+        XCTAssertEqual(summary.topLevelSelectedCount, 2)
         XCTAssertEqual(summary.allocatedSize, 25)
-        XCTAssertEqual(summary.logicalSize, 25)
         XCTAssertTrue(summary.containsOverlappingSelections)
+        XCTAssertEqual(summary.missingSelectedNodeCount, 0)
+    }
+
+    func testMissingSelectionIsNotReportedAsOverlap() {
+        let present = makeTestFileNode(id: "/root/present.txt", name: "present.txt", size: 12)
+        let stale = makeTestFileNode(id: "/root/stale.txt", name: "stale.txt", size: 30)
+        let root = makeTestDirectoryNode(id: "/root", name: "root", children: [present])
+        let store = FileTreeStore(root: root, childrenByID: [root.id: [present]])
+
+        let summary = InspectorSelectionSummary(
+            selectedNodes: [present, stale],
+            fileTreeStore: store
+        )
+
+        XCTAssertEqual(summary.selectedCount, 2)
+        XCTAssertEqual(summary.topLevelSelectedNodes.map(\.id), [present.id])
+        XCTAssertEqual(summary.topLevelSelectedCount, 1)
+        XCTAssertEqual(summary.allocatedSize, present.allocatedSize)
+        XCTAssertFalse(summary.containsOverlappingSelections)
+        XCTAssertEqual(summary.missingSelectedNodeCount, 1)
+    }
+
+    func testSelectionPresentationCountsKindsAndOrdersLargestItemsFirst() {
+        let file = makeTestFileNode(id: "/root/file.txt", name: "file.txt", size: 8)
+        let folderChild = makeTestFileNode(id: "/root/folder/child.txt", name: "child.txt", size: 20)
+        let folder = makeTestDirectoryNode(
+            id: "/root/folder",
+            name: "folder",
+            children: [folderChild]
+        )
+        let packageChild = makeTestFileNode(id: "/root/App.app/item", name: "item", size: 12)
+        let package = makeTestDirectoryNode(
+            id: "/root/App.app",
+            name: "App.app",
+            children: [packageChild],
+            isPackage: true
+        )
+
+        let summary = InspectorSelectionSummary(
+            selectedNodes: [file, package, folder],
+            fileTreeStore: nil
+        )
+
+        XCTAssertEqual(summary.selectedFolderCount, 1)
+        XCTAssertEqual(summary.selectedFileCount, 1)
+        XCTAssertEqual(summary.selectedPackageCount, 1)
+        XCTAssertEqual(summary.selectedStorageCategoryCount, 0)
+        XCTAssertEqual(
+            summary.selectedNodesByAllocatedSize.map(\.id),
+            [folder.id, package.id, file.id]
+        )
+        XCTAssertEqual(
+            summary.largestSelectedNodes(limit: 2).map(\.id),
+            [folder.id, package.id]
+        )
+    }
+
+    func testSyntheticStorageAndSharedFilesHaveDistinctPresentationState() {
+        let synthetic = makeTestFileNode(
+            id: "/root/unattributed",
+            name: "Unattributed",
+            size: 30,
+            isSynthetic: true
+        )
+        let clone = makeTestFileNode(
+            id: "/root/clone.dat",
+            name: "clone.dat",
+            size: 12,
+            cloneIdentity: CloneIdentity(device: 1, cloneID: 7)
+        )
+
+        let summary = InspectorSelectionSummary(
+            selectedNodes: [synthetic, clone],
+            fileTreeStore: nil
+        )
+
+        XCTAssertEqual(summary.selectedFileCount, 1)
+        XCTAssertEqual(summary.selectedStorageCategoryCount, 1)
+        XCTAssertTrue(summary.containsSharedStorageItems)
+        XCTAssertTrue(summary.containsKnownClones)
     }
 }

--- a/RadixCoreTests/ScanModelTests.swift
+++ b/RadixCoreTests/ScanModelTests.swift
@@ -259,18 +259,15 @@ final class ScanModelTests: XCTestCase {
         }
     }
 
-    func testAccessPresentationReflectsAccessibilityAndSyntheticState() {
+    func testSecondaryStatusTextReflectsAccessibilityAndSyntheticState() {
         let readableNode = makeNode(id: "/Users/example/file.txt", isDirectory: false, isSynthetic: false, isAccessible: true)
         let limitedNode = makeNode(id: "/Users/example/private", isDirectory: true, isSynthetic: false, isAccessible: false)
         let syntheticNode = makeNode(id: "/System & Unattributed", isDirectory: true, isSynthetic: true, isAccessible: true)
 
-        XCTAssertEqual(readableNode.accessDescription, "Readable")
         XCTAssertNil(readableNode.secondaryStatusText)
 
-        XCTAssertEqual(limitedNode.accessDescription, "Limited")
         XCTAssertEqual(limitedNode.secondaryStatusText, "Limited access")
 
-        XCTAssertEqual(syntheticNode.accessDescription, "Estimated")
         XCTAssertEqual(syntheticNode.secondaryStatusText, "Estimated from volume usage")
     }
 

--- a/RadixCoreTests/ScanModelTests.swift
+++ b/RadixCoreTests/ScanModelTests.swift
@@ -800,6 +800,7 @@ final class ScanModelTests: XCTestCase {
     }
 
     func testPermissionAdvisorSuppressesSuggestionWhenFullDiskAccessGranted() {
+        let exampleHome = URL(filePath: "/Users/example", directoryHint: .isDirectory)
         let root = makeNode(id: "/", isDirectory: true, isSynthetic: false, isAccessible: true)
         let snapshot = makeSnapshot(
             root: root,
@@ -815,10 +816,25 @@ final class ScanModelTests: XCTestCase {
 
         // FDA-unlockable warning present, but access is already granted: no nag.
         XCTAssertFalse(
-            PermissionAdvisor.shouldSuggestFullDiskAccess(for: snapshot, fullDiskAccessStatus: .granted)
+            PermissionAdvisor.shouldSuggestFullDiskAccess(
+                for: snapshot,
+                fullDiskAccessStatus: .granted,
+                homeDirectory: exampleHome
+            )
         )
         XCTAssertTrue(
-            PermissionAdvisor.shouldSuggestFullDiskAccess(for: snapshot, fullDiskAccessStatus: .notGranted)
+            PermissionAdvisor.shouldSuggestFullDiskAccess(
+                for: snapshot,
+                fullDiskAccessStatus: .notGranted,
+                homeDirectory: exampleHome
+            )
+        )
+        XCTAssertFalse(
+            PermissionAdvisor.shouldSuggestFullDiskAccess(
+                for: snapshot,
+                fullDiskAccessStatus: .unknown,
+                homeDirectory: exampleHome
+            )
         )
     }
 
@@ -849,6 +865,170 @@ final class ScanModelTests: XCTestCase {
         XCTAssertFalse(
             PermissionAdvisor.shouldSuggestFullDiskAccess(for: snapshot, fullDiskAccessStatus: .unknown)
         )
+    }
+
+    func testPermissionAdvisorCanEvaluateSelectionScopedWarnings() {
+        let exampleHome = URL(filePath: "/Users/example", directoryHint: .isDirectory)
+        let unlockableWarning = ScanWarning(
+            path: "/Users/example/Library/Mail",
+            message: "Permission denied",
+            category: .permissionDenied
+        )
+        let permanentlyProtectedWarning = ScanWarning(
+            path: "/Library/Application Support/com.apple.TCC",
+            message: "Permission denied",
+            category: .permissionDenied
+        )
+
+        XCTAssertTrue(
+            PermissionAdvisor.shouldSuggestFullDiskAccess(
+                for: [unlockableWarning],
+                fullDiskAccessStatus: .notGranted,
+                homeDirectory: exampleHome
+            )
+        )
+        XCTAssertFalse(
+            PermissionAdvisor.shouldSuggestFullDiskAccess(
+                for: [permanentlyProtectedWarning],
+                fullDiskAccessStatus: .notGranted,
+                homeDirectory: exampleHome
+            )
+        )
+        XCTAssertFalse(
+            PermissionAdvisor.shouldSuggestFullDiskAccess(
+                for: [unlockableWarning],
+                fullDiskAccessStatus: .granted,
+                homeDirectory: exampleHome
+            )
+        )
+        XCTAssertFalse(
+            PermissionAdvisor.shouldSuggestFullDiskAccess(
+                for: [
+                    ScanWarning(
+                        path: "/Users/example/Library/MailBackup",
+                        message: "Permission denied",
+                        category: .permissionDenied
+                    )
+                ],
+                fullDiskAccessStatus: .notGranted,
+                homeDirectory: exampleHome
+            )
+        )
+        for unrelatedPath in [
+            "/tmp/Library/Mail",
+            "/Users/other/Library/Mail",
+        ] {
+            XCTAssertFalse(
+                PermissionAdvisor.shouldSuggestFullDiskAccess(
+                    for: [
+                        ScanWarning(
+                            path: unrelatedPath,
+                            message: "Permission denied",
+                            category: .permissionDenied
+                        )
+                    ],
+                    fullDiskAccessStatus: .notGranted,
+                    homeDirectory: exampleHome
+                )
+            )
+        }
+        XCTAssertTrue(
+            PermissionAdvisor.shouldSuggestFullDiskAccess(
+                for: [
+                    ScanWarning(
+                        path: "/System/Volumes/Data/Users/example/Library/Mail/V10",
+                        message: "Permission denied",
+                        category: .permissionDenied
+                    )
+                ],
+                fullDiskAccessStatus: .notGranted,
+                homeDirectory: exampleHome
+            )
+        )
+    }
+
+    func testPermissionAdvisorPreservesAdviceForLiveAndSavedScans() {
+        let exampleHome = URL(filePath: "/Users/example", directoryHint: .isDirectory)
+        let warnings = [
+            ScanWarning(
+                path: "/Users/example/Library/Mail",
+                message: "Permission denied",
+                category: .permissionDenied
+            )
+        ]
+        let importedSource = ScanSnapshotSource.imported(
+            ImportedSnapshotContext(
+                sourceURL: URL(filePath: "/tmp/example.radixscan"),
+                pathMode: .absolute,
+                liveActionCapability: .pathValidation
+            )
+        )
+
+        XCTAssertEqual(
+            PermissionAdvisor.fullDiskAccessAdvice(
+                for: warnings,
+                fullDiskAccessStatus: .notGranted,
+                snapshotSource: .live,
+                homeDirectory: exampleHome
+            ),
+            .openSettings
+        )
+        XCTAssertEqual(
+            PermissionAdvisor.fullDiskAccessAdvice(
+                for: warnings,
+                fullDiskAccessStatus: .granted,
+                snapshotSource: .live,
+                homeDirectory: exampleHome
+            ),
+            .rescanMayBeNeeded
+        )
+        XCTAssertEqual(
+            PermissionAdvisor.fullDiskAccessAdvice(
+                for: warnings,
+                fullDiskAccessStatus: .unknown,
+                snapshotSource: .live,
+                homeDirectory: exampleHome
+            ),
+            .none
+        )
+        XCTAssertEqual(
+            PermissionAdvisor.fullDiskAccessAdvice(
+                for: warnings,
+                fullDiskAccessStatus: .notGranted,
+                snapshotSource: importedSource,
+                homeDirectory: exampleHome
+            ),
+            .savedScanIsHistorical
+        )
+    }
+
+    func testPermissionAdvisorClassifiesOnlyVerifiedExpectedMacOSProtection() {
+        let expectedWarnings = [
+            ScanWarning(
+                path: "/Library/Application Support/com.apple.TCC",
+                message: "Permission denied",
+                category: .permissionDenied
+            ),
+            ScanWarning(
+                path: "/Library/Caches/com.apple.iconservices.store",
+                message: "Permission denied",
+                category: .permissionDenied
+            ),
+        ]
+        let arbitraryPermissionFailure = ScanWarning(
+            path: "/Users/example/Private",
+            message: "Permission denied",
+            category: .permissionDenied
+        )
+        let historicalFullDiskAccessPath = ScanWarning(
+            path: "/Users/example/Library/Mail",
+            message: "Permission denied",
+            category: .permissionDenied
+        )
+
+        XCTAssertTrue(expectedWarnings.allSatisfy(PermissionAdvisor.isExpectedMacOSProtection))
+        XCTAssertFalse(PermissionAdvisor.isExpectedMacOSProtection(arbitraryPermissionFailure))
+        XCTAssertFalse(PermissionAdvisor.isExpectedMacOSProtection(historicalFullDiskAccessPath))
     }
 
     private func makeSnapshot(


### PR DESCRIPTION
### Inspector Overhaul

This PR brings an all-new Inspector. The new Inspector is less confusing, supports more information, and looks more visually appealing.

One potential issue that could be addressed with better onboarding is that features like Quick Look or Copy Path are no longer immediately visible in the Inspector. Quick Look is still available with the Space shortcut, and Copy Path is still available in a dropdown.

While removing a lot of the action buttons sounds like a downgrade at first, it's a fairly deliberate choice by me. First of all, it prevents the user from being overwhelmed by a bunch of functions they might not even use. Second of all, most of the action buttons are available in more convenient places (for example, the previous Quick Look button was also available with Space, which was a better way to use the feature) or are rarely used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a redesigned Inspector for single and multiple selections.
  * Added selection summaries with counts, storage details, largest items, shared-storage information, and availability notices.
  * Added contextual actions, including Finder reveal, discard, open, copy path, and move to Trash.
  * Added clearer warnings for protected locations, incomplete scans, historical scans, and Full Disk Access status.
  * Added adaptive disclosure for viewing selected items.

* **Bug Fixes**
  * Improved Full Disk Access detection and recommendations.
  * Simplified the no-selection state and improved item presentation and truncation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->