### PR TITLE
fix(scan): bound APFS clone accounting memory

### DIFF
--- a/Radix/Services/ScanEngine.swift
+++ b/Radix/Services/ScanEngine.swift
@@ -459,8 +459,6 @@ actor ScanEngine {
     }
 
     private struct PreparedOrdinaryLeafItem: Sendable {
-        let url: URL
-        let metadata: NodeMetadata
         let weight: Double
         let node: FileNodeRecord
         let sharedAllocationClaim: SharedAllocationClaim?
@@ -472,9 +470,8 @@ actor ScanEngine {
     }
 
     private struct PackageSummaryResult: Sendable {
-        let item: ScanWorkItem
         let itemKey: Int
-        let metadata: NodeMetadata
+        let weight: Double
         let leaf: LeafNodeResult
     }
 
@@ -1670,9 +1667,8 @@ actor ScanEngine {
                             emissionState: &localEmissionState
                         )
                         return .package(PackageSummaryResult(
-                            item: taskItem,
                             itemKey: taskItemKey,
-                            metadata: taskMetadata,
+                            weight: taskItem.weight,
                             leaf: leaf
                         ))
                     }
@@ -1841,7 +1837,6 @@ actor ScanEngine {
                     completedByKey[itemKey] = .leaf(inaccessibleNode)
                 case .package(let packageResult):
                     activePackageTasks -= 1
-                    let item = packageResult.item
                     let leafResult = packageResult.leaf
                     metrics.pendingPackageSummaryCount = max(
                         metrics.pendingPackageSummaryCount - 1,
@@ -1853,7 +1848,7 @@ actor ScanEngine {
                     }
                     applyLeafMetrics(
                         leafResult.node,
-                        weight: item.weight,
+                        weight: packageResult.weight,
                         summaryVisitedItemCount: leafResult.summaryVisitedItemCount,
                         metrics: &metrics
                     )
@@ -2032,8 +2027,6 @@ actor ScanEngine {
                             metadata: childMetadata
                         )
                         let preparedItem = PreparedOrdinaryLeafItem(
-                            url: childEntry.url,
-                            metadata: childMetadata,
                             weight: item.weight / totalWeightUnits,
                             node: childNode,
                             sharedAllocationClaim: SharedAllocationDeduplicator.claim(
@@ -2332,8 +2325,6 @@ actor ScanEngine {
             }
             let node = makeFileNode(url: entry.url, metadata: metadata)
             items.append(PreparedOrdinaryLeafItem(
-                url: entry.url,
-                metadata: metadata,
                 weight: request.parentWeight / request.totalWeightUnits,
                 node: node,
                 sharedAllocationClaim: SharedAllocationDeduplicator.claim(
@@ -2366,7 +2357,7 @@ actor ScanEngine {
         if let previousKey = scanKeyByNodeID.updateValue(nextKey, forKey: childPath) {
             scanKeyByNodeID[childPath] = previousKey
             recordDuplicateNode(
-                at: item.url,
+                at: childNode.url,
                 weight: item.weight,
                 metrics: &metrics,
                 warnings: &warnings,

--- a/Radix/Services/ScanEngine.swift
+++ b/Radix/Services/ScanEngine.swift
@@ -503,11 +503,9 @@ actor ScanEngine {
     }
 
     /// A completed directory scan awaiting parent assembly.
-    private struct CompletedDirScan {
-        let node: FileNodeRecord?     // Leaves carry a node; traversable dirs are resolved in phase 2.
-        let metadata: NodeMetadata
-        let url: URL
-        let isTraversable: Bool     // True if this was a directory we intended to traverse.
+    private enum CompletedDirScan {
+        case leaf(FileNodeRecord)
+        case traversableDirectory(metadata: NodeMetadata, url: URL)
     }
 
     typealias DirectoryContentsProvider = @Sendable (
@@ -1643,12 +1641,7 @@ actor ScanEngine {
                         }
                         maybeEmitProgress(metrics: &metrics, continuation: continuation, emissionState: &emissionState, summaryPool: atomicSummaryPool)
 
-                        completedByKey[itemKey] = CompletedDirScan(
-                            node: leafResult.node,
-                            metadata: meta,
-                            url: item.url,
-                            isTraversable: false
-                        )
+                        completedByKey[itemKey] = .leaf(leafResult.node)
                     }
                 }
 
@@ -1845,12 +1838,7 @@ actor ScanEngine {
                         isSynthetic: false,
                         isAutoSummarized: false
                     )
-                    completedByKey[itemKey] = CompletedDirScan(
-                        node: inaccessibleNode,
-                        metadata: meta,
-                        url: item.url,
-                        isTraversable: false
-                    )
+                    completedByKey[itemKey] = .leaf(inaccessibleNode)
                 case .package(let packageResult):
                     activePackageTasks -= 1
                     let item = packageResult.item
@@ -1879,12 +1867,7 @@ actor ScanEngine {
                     // when `maybeEmitProgress`'s item-count gate would skip the update.
                     metrics.recalculateProgress()
                     atomicSummaryPool.updateProgress(metrics, continuation: continuation)
-                    completedByKey[packageResult.itemKey] = CompletedDirScan(
-                        node: leafResult.node,
-                        metadata: packageResult.metadata,
-                        url: item.url,
-                        isTraversable: false
-                    )
+                    completedByKey[packageResult.itemKey] = .leaf(leafResult.node)
 
                 case .atomicDirectory(let atomicResult):
                     activePackageTasks -= 1
@@ -1980,12 +1963,7 @@ actor ScanEngine {
                     metrics.recalculateProgress()
                     atomicSummaryPool.updateProgress(metrics, continuation: continuation)
 
-                    completedByKey[candidate.itemKey] = CompletedDirScan(
-                        node: atomicNode,
-                        metadata: meta,
-                        url: item.url,
-                        isTraversable: false
-                    )
+                    completedByKey[candidate.itemKey] = .leaf(atomicNode)
                 case .ordinaryLeaves(let batch):
                     activeOrdinaryLeafTasks -= 1
                     for item in batch.items {
@@ -2101,11 +2079,9 @@ actor ScanEngine {
                     )
                 }
                 // Register this directory so phase 2 can assemble it.
-                completedByKey[itemKey] = CompletedDirScan(
-                    node: nil,
+                completedByKey[itemKey] = .traversableDirectory(
                     metadata: candidate.metadata,
-                    url: item.url,
-                    isTraversable: true
+                    url: item.url
                 )
             }
         }
@@ -2174,7 +2150,8 @@ actor ScanEngine {
             let nodeOffset = nodes.count
             assert(nodeOffset == nextKey - key - 1)
 
-            if completed.isTraversable {
+            switch completed {
+            case .traversableDirectory(let metadata, let url):
                 // Traversable directories must still be materialized when empty.
                 var sortedChildKeys = childrenKeysByKey[key] ?? []
                 childrenKeysByKey[key] = nil
@@ -2189,7 +2166,7 @@ actor ScanEngine {
                     return lhs.allocatedSize > rhs.allocatedSize
                 }
                 try Task.checkCancellation()
-                let directoryID = completed.url.path
+                let directoryID = url.path
                 var allocatedSize: Int64 = 0
                 var logicalSize: Int64 = 0
                 var descendantFileCount = 0
@@ -2219,19 +2196,19 @@ actor ScanEngine {
 
                 let assembled = FileNodeRecord(
                     id: directoryID,
-                    url: completed.url,
-                    name: ScanTarget.displayName(for: completed.url),
+                    url: url,
+                    name: ScanTarget.displayName(for: url),
                     isDirectory: true,
                     isSymbolicLink: false,
                     allocatedSize: allocatedSize,
                     logicalSize: logicalSize,
                     descendantFileCount: descendantFileCount,
-                    lastModified: completed.metadata.lastModified,
-                    fileIdentity: completed.metadata.fileIdentity,
-                    linkCount: completed.metadata.linkCount,
-                    isPackage: completed.metadata.isPackage,
-                    isAccessible: completed.metadata.isReadable && childrenAreAccessible,
-                    isSelfAccessible: completed.metadata.isReadable,
+                    lastModified: metadata.lastModified,
+                    fileIdentity: metadata.fileIdentity,
+                    linkCount: metadata.linkCount,
+                    isPackage: metadata.isPackage,
+                    isAccessible: metadata.isReadable && childrenAreAccessible,
+                    isSelfAccessible: metadata.isReadable,
                     isSynthetic: false,
                     isAutoSummarized: false
                 )
@@ -2244,7 +2221,7 @@ actor ScanEngine {
                 aggregateStats.include(assembled, hasChildren: childIndices.count > childSpanStart)
 
                 metrics.completedItems = min(metrics.discoveredItems, metrics.completedItems + 1)
-            } else if let onlyChild = completed.node {
+            case .leaf(let onlyChild):
                 // Leaf node or inaccessible directory: use the child directly.
                 let correctedChild = SharedAllocationDeduplicator.deduplicatedNode(
                     onlyChild,
@@ -2255,9 +2232,6 @@ actor ScanEngine {
                 parentRawIndices.append(UInt32.max)
                 childSpans.append(FileTreeChildSpan())
                 aggregateStats.include(correctedChild, hasChildren: false)
-            } else {
-                assertionFailure("Missing finalized node for scan key \(key).")
-                throw ScanEngineError.missingRootNode
             }
 
             if finalizedItems.isMultiple(of: finalizationProgressInterval) || finalizedItems == finalizationTotal {
@@ -2423,12 +2397,7 @@ actor ScanEngine {
             emissionState: &emissionState,
             summaryPool: summaryPool
         )
-        completedByKey[childKey] = CompletedDirScan(
-            node: childNode,
-            metadata: item.metadata,
-            url: item.url,
-            isTraversable: false
-        )
+        completedByKey[childKey] = .leaf(childNode)
     }
 
     private nonisolated func applyLeafMetrics(
@@ -2561,22 +2530,8 @@ actor ScanEngine {
             summaryPool: summaryPool
         )
 
-        completedByKey[itemKey] = CompletedDirScan(
-            node: makeUnavailableNode(for: item.url, isDirectory: isDirectory),
-            metadata: NodeMetadata(
-                isDirectory: isDirectory,
-                isPackage: false,
-                isSymbolicLink: false,
-                logicalSize: 0,
-                allocatedSize: 0,
-                lastModified: nil,
-                isReadable: false,
-                volumeCapacity: nil,
-                fileIdentity: nil,
-                linkCount: 0
-            ),
-            url: item.url,
-            isTraversable: false
+        completedByKey[itemKey] = .leaf(
+            makeUnavailableNode(for: item.url, isDirectory: isDirectory)
         )
     }
 

--- a/Radix/Services/SharedAllocationOwnerAccumulator.swift
+++ b/Radix/Services/SharedAllocationOwnerAccumulator.swift
@@ -15,14 +15,16 @@ import Foundation
 /// clone's resource fork and prevents hard-linked paths from entering clone
 /// accounting more than once.
 nonisolated struct SharedAllocationOwnerAccumulator: Sendable {
-    private enum CloneFileKey: Hashable, Sendable {
-        case identity(FileIdentity)
-        case path(String)
+    private struct CloneWinner: Sendable {
+        let ownerNodeID: String
+        let path: String
+        let cloneAllocatedSize: Int64
     }
 
     private var hardLinkWinnerByIdentity: [FileIdentity: SharedAllocationClaim] = [:]
-    private var standaloneCloneWinnerByFile: [CloneFileKey: SharedAllocationClaim] = [:]
+    private var standaloneCloneWinnerByIdentity: [CloneIdentity: CloneWinner] = [:]
     private var hardLinkDuplicateAllocatedSizeByOwner: [String: Int64] = [:]
+    private var standaloneCloneDuplicateAllocatedSizeByOwner: [String: Int64] = [:]
 
     nonisolated init() {}
 
@@ -38,24 +40,26 @@ nonisolated struct SharedAllocationOwnerAccumulator: Sendable {
         cancellationCheck: () throws -> Void
     ) rethrows -> [String: Int64] {
         var corrections = hardLinkDuplicateAllocatedSizeByOwner
-        var cloneWinnerByIdentity: [CloneIdentity: SharedAllocationClaim] = [:]
+        for (ownerNodeID, allocatedSize) in standaloneCloneDuplicateAllocatedSizeByOwner {
+            corrections[ownerNodeID, default: 0] += allocatedSize
+        }
+        var cloneWinnerByIdentity = standaloneCloneWinnerByIdentity
 
         for (offset, claim) in hardLinkWinnerByIdentity.values.enumerated() {
             if offset.isMultiple(of: 256) {
                 try cancellationCheck()
             }
-            Self.recordCloneCorrection(
-                for: claim,
-                winnerByIdentity: &cloneWinnerByIdentity,
-                corrections: &corrections
-            )
-        }
-        for (offset, claim) in standaloneCloneWinnerByFile.values.enumerated() {
-            if offset.isMultiple(of: 256) {
-                try cancellationCheck()
+            guard let cloneIdentity = claim.cloneIdentity,
+                  claim.cloneAllocatedSize > 0 else {
+                continue
             }
             Self.recordCloneCorrection(
-                for: claim,
+                identity: cloneIdentity,
+                winner: CloneWinner(
+                    ownerNodeID: claim.ownerNodeID,
+                    path: claim.path,
+                    cloneAllocatedSize: claim.cloneAllocatedSize
+                ),
                 winnerByIdentity: &cloneWinnerByIdentity,
                 corrections: &corrections
             )
@@ -70,16 +74,12 @@ nonisolated struct SharedAllocationOwnerAccumulator: Sendable {
                 cloneIdentities.insert(cloneIdentity)
             }
         }
-        for claim in standaloneCloneWinnerByFile.values {
-            if let cloneIdentity = claim.cloneIdentity {
-                cloneIdentities.insert(cloneIdentity)
-            }
-        }
+        cloneIdentities.formUnion(standaloneCloneWinnerByIdentity.keys)
         return hardLinkWinnerByIdentity.count + cloneIdentities.count
     }
 
     nonisolated var isEmpty: Bool {
-        hardLinkWinnerByIdentity.isEmpty && standaloneCloneWinnerByFile.isEmpty
+        hardLinkWinnerByIdentity.isEmpty && standaloneCloneWinnerByIdentity.isEmpty
     }
 
     nonisolated func winner(for identity: FileIdentity) -> SharedAllocationClaim? {
@@ -91,15 +91,18 @@ nonisolated struct SharedAllocationOwnerAccumulator: Sendable {
 
         if let hardLinkIdentity = claim.hardLinkIdentity {
             recordHardLink(claim, identity: hardLinkIdentity)
-        } else if claim.cloneIdentity != nil {
-            let key = claim.fileIdentity.map(CloneFileKey.identity) ?? .path(claim.path)
-            if let currentWinner = standaloneCloneWinnerByFile[key] {
-                if Self.precedes(claim, currentWinner) {
-                    standaloneCloneWinnerByFile[key] = claim
-                }
-            } else {
-                standaloneCloneWinnerByFile[key] = claim
-            }
+        } else if let cloneIdentity = claim.cloneIdentity,
+                  claim.cloneAllocatedSize > 0 {
+            Self.recordCloneCorrection(
+                identity: cloneIdentity,
+                winner: CloneWinner(
+                    ownerNodeID: claim.ownerNodeID,
+                    path: claim.path,
+                    cloneAllocatedSize: claim.cloneAllocatedSize
+                ),
+                winnerByIdentity: &standaloneCloneWinnerByIdentity,
+                corrections: &standaloneCloneDuplicateAllocatedSizeByOwner
+            )
         }
     }
 
@@ -114,11 +117,19 @@ nonisolated struct SharedAllocationOwnerAccumulator: Sendable {
         for (ownerNodeID, allocatedSize) in other.hardLinkDuplicateAllocatedSizeByOwner {
             hardLinkDuplicateAllocatedSizeByOwner[ownerNodeID, default: 0] += allocatedSize
         }
+        for (ownerNodeID, allocatedSize) in other.standaloneCloneDuplicateAllocatedSizeByOwner {
+            standaloneCloneDuplicateAllocatedSizeByOwner[ownerNodeID, default: 0] += allocatedSize
+        }
         for winner in other.hardLinkWinnerByIdentity.values {
             record(winner)
         }
-        for winner in other.standaloneCloneWinnerByFile.values {
-            record(winner)
+        for (identity, winner) in other.standaloneCloneWinnerByIdentity {
+            Self.recordCloneCorrection(
+                identity: identity,
+                winner: winner,
+                winnerByIdentity: &standaloneCloneWinnerByIdentity,
+                corrections: &standaloneCloneDuplicateAllocatedSizeByOwner
+            )
         }
     }
 
@@ -137,25 +148,29 @@ nonisolated struct SharedAllocationOwnerAccumulator: Sendable {
     }
 
     private nonisolated static func recordCloneCorrection(
-        for claim: SharedAllocationClaim,
-        winnerByIdentity: inout [CloneIdentity: SharedAllocationClaim],
+        identity: CloneIdentity,
+        winner: CloneWinner,
+        winnerByIdentity: inout [CloneIdentity: CloneWinner],
         corrections: inout [String: Int64]
     ) {
-        guard let cloneIdentity = claim.cloneIdentity,
-              claim.cloneAllocatedSize > 0 else {
-            return
-        }
-        guard let currentWinner = winnerByIdentity[cloneIdentity] else {
-            winnerByIdentity[cloneIdentity] = claim
+        guard let currentWinner = winnerByIdentity[identity] else {
+            winnerByIdentity[identity] = winner
             return
         }
 
-        if precedes(claim, currentWinner) {
+        if precedes(winner, currentWinner) {
             corrections[currentWinner.ownerNodeID, default: 0] += currentWinner.cloneAllocatedSize
-            winnerByIdentity[cloneIdentity] = claim
+            winnerByIdentity[identity] = winner
         } else {
-            corrections[claim.ownerNodeID, default: 0] += claim.cloneAllocatedSize
+            corrections[winner.ownerNodeID, default: 0] += winner.cloneAllocatedSize
         }
+    }
+
+    private nonisolated static func precedes(_ lhs: CloneWinner, _ rhs: CloneWinner) -> Bool {
+        if lhs.path == rhs.path {
+            return lhs.ownerNodeID < rhs.ownerNodeID
+        }
+        return lhs.path < rhs.path
     }
 
     private nonisolated static func precedes(_ lhs: SharedAllocationClaim, _ rhs: SharedAllocationClaim) -> Bool {

--- a/Radix/Services/SharedAllocationOwnerAccumulator.swift
+++ b/Radix/Services/SharedAllocationOwnerAccumulator.swift
@@ -61,6 +61,10 @@ nonisolated struct SharedAllocationOwnerAccumulator: Sendable {
                   claim.cloneAllocatedSize > 0 else {
                 continue
             }
+            if hardLinkCloneWinnerByIdentity[cloneIdentity] == nil,
+               let standaloneWinner = standaloneCloneWinnerByIdentity[cloneIdentity] {
+                hardLinkCloneWinnerByIdentity[cloneIdentity] = standaloneWinner
+            }
             Self.recordCloneCorrection(
                 identity: cloneIdentity,
                 winner: CloneWinner(
@@ -71,19 +75,6 @@ nonisolated struct SharedAllocationOwnerAccumulator: Sendable {
                 winnerByIdentity: &hardLinkCloneWinnerByIdentity,
                 corrections: &corrections
             )
-        }
-        for (offset, entry) in hardLinkCloneWinnerByIdentity.enumerated() {
-            if offset.isMultiple(of: 256) {
-                try cancellationCheck()
-            }
-            let (identity, hardLinkWinner) = entry
-            guard let standaloneWinner = standaloneCloneWinnerByIdentity[identity] else {
-                continue
-            }
-            let loser = Self.precedes(hardLinkWinner, standaloneWinner)
-                ? standaloneWinner
-                : hardLinkWinner
-            corrections[loser.ownerNodeID, default: 0] += loser.cloneAllocatedSize
         }
         return corrections
     }

--- a/Radix/Services/SharedAllocationOwnerAccumulator.swift
+++ b/Radix/Services/SharedAllocationOwnerAccumulator.swift
@@ -14,6 +14,10 @@ import Foundation
 /// Keeping those stages separate preserves allocation that belongs only to a
 /// clone's resource fork and prevents hard-linked paths from entering clone
 /// accounting more than once.
+///
+/// Standalone clone claims are reduced without retaining per-file identities.
+/// Callers must therefore record each standalone filesystem entry once and
+/// merge only accumulators whose standalone entries are disjoint.
 nonisolated struct SharedAllocationOwnerAccumulator: Sendable {
     private struct CloneWinner: Sendable {
         let ownerNodeID: String
@@ -47,7 +51,7 @@ nonisolated struct SharedAllocationOwnerAccumulator: Sendable {
             let (ownerNodeID, allocatedSize) = correction
             corrections[ownerNodeID, default: 0] += allocatedSize
         }
-        var cloneWinnerByIdentity = standaloneCloneWinnerByIdentity
+        var hardLinkCloneWinnerByIdentity: [CloneIdentity: CloneWinner] = [:]
 
         for (offset, claim) in hardLinkWinnerByIdentity.values.enumerated() {
             if offset.isMultiple(of: 256) {
@@ -64,9 +68,22 @@ nonisolated struct SharedAllocationOwnerAccumulator: Sendable {
                     path: claim.path,
                     cloneAllocatedSize: claim.cloneAllocatedSize
                 ),
-                winnerByIdentity: &cloneWinnerByIdentity,
+                winnerByIdentity: &hardLinkCloneWinnerByIdentity,
                 corrections: &corrections
             )
+        }
+        for (offset, entry) in hardLinkCloneWinnerByIdentity.enumerated() {
+            if offset.isMultiple(of: 256) {
+                try cancellationCheck()
+            }
+            let (identity, hardLinkWinner) = entry
+            guard let standaloneWinner = standaloneCloneWinnerByIdentity[identity] else {
+                continue
+            }
+            let loser = Self.precedes(hardLinkWinner, standaloneWinner)
+                ? standaloneWinner
+                : hardLinkWinner
+            corrections[loser.ownerNodeID, default: 0] += loser.cloneAllocatedSize
         }
         return corrections
     }
@@ -74,7 +91,8 @@ nonisolated struct SharedAllocationOwnerAccumulator: Sendable {
     nonisolated var identityCount: Int {
         var cloneIdentities = Set<CloneIdentity>()
         for claim in hardLinkWinnerByIdentity.values {
-            if let cloneIdentity = claim.cloneIdentity {
+            if let cloneIdentity = claim.cloneIdentity,
+               claim.cloneAllocatedSize > 0 {
                 cloneIdentities.insert(cloneIdentity)
             }
         }
@@ -116,7 +134,7 @@ nonisolated struct SharedAllocationOwnerAccumulator: Sendable {
         }
     }
 
-    /// Merges package-local state without reconstructing discarded duplicate claims.
+    /// Merges disjoint package-local state without reconstructing discarded claims.
     nonisolated mutating func merge(_ other: Self) {
         for (ownerNodeID, allocatedSize) in other.hardLinkDuplicateAllocatedSizeByOwner {
             hardLinkDuplicateAllocatedSizeByOwner[ownerNodeID, default: 0] += allocatedSize

--- a/Radix/Services/SharedAllocationOwnerAccumulator.swift
+++ b/Radix/Services/SharedAllocationOwnerAccumulator.swift
@@ -40,7 +40,11 @@ nonisolated struct SharedAllocationOwnerAccumulator: Sendable {
         cancellationCheck: () throws -> Void
     ) rethrows -> [String: Int64] {
         var corrections = hardLinkDuplicateAllocatedSizeByOwner
-        for (ownerNodeID, allocatedSize) in standaloneCloneDuplicateAllocatedSizeByOwner {
+        for (offset, correction) in standaloneCloneDuplicateAllocatedSizeByOwner.enumerated() {
+            if offset.isMultiple(of: 256) {
+                try cancellationCheck()
+            }
+            let (ownerNodeID, allocatedSize) = correction
             corrections[ownerNodeID, default: 0] += allocatedSize
         }
         var cloneWinnerByIdentity = standaloneCloneWinnerByIdentity

--- a/RadixCoreTests/SharedAllocationOwnerAccumulatorTests.swift
+++ b/RadixCoreTests/SharedAllocationOwnerAccumulatorTests.swift
@@ -158,8 +158,8 @@ final class SharedAllocationOwnerAccumulatorTests: XCTestCase {
         XCTAssertEqual(checkCount, 2)
     }
 
-    func testMixedCloneCorrectionChecksCancellationAfterHardLinkReduction() {
-        let claims = (0..<512).flatMap { index in
+    func testMixedCloneCorrectionChecksCancellationDuringHardLinkReduction() {
+        let claims = (0..<768).flatMap { index in
             let device = UInt64(8)
             let cloneIdentity = CloneIdentity(device: device, cloneID: UInt64(index))
             let hardLinkIdentity = FileIdentity(device: device, inode: UInt64(index * 2))

--- a/RadixCoreTests/SharedAllocationOwnerAccumulatorTests.swift
+++ b/RadixCoreTests/SharedAllocationOwnerAccumulatorTests.swift
@@ -122,6 +122,42 @@ final class SharedAllocationOwnerAccumulatorTests: XCTestCase {
         XCTAssertEqual(checkCount, 2)
     }
 
+    func testStandaloneCloneCorrectionMaterializationChecksCancellationDuringTraversal() {
+        let claims = (0..<512).flatMap { index in
+            let cloneIdentity = CloneIdentity(device: 7, cloneID: UInt64(index))
+            return [
+                cloneClaim(
+                    fileIdentity: FileIdentity(device: 7, inode: UInt64(index * 2)),
+                    cloneIdentity: cloneIdentity,
+                    owner: "/winner-\(index)",
+                    path: "/a-\(index)",
+                    totalSize: 1,
+                    dataSize: 1
+                ),
+                cloneClaim(
+                    fileIdentity: FileIdentity(device: 7, inode: UInt64(index * 2 + 1)),
+                    cloneIdentity: cloneIdentity,
+                    owner: "/loser-\(index)",
+                    path: "/z-\(index)",
+                    totalSize: 1,
+                    dataSize: 1
+                ),
+            ]
+        }
+        let accumulator = SharedAllocationOwnerAccumulator(claims)
+        var checkCount = 0
+
+        XCTAssertThrowsError(try accumulator.duplicateAllocatedSizeByOwner {
+            checkCount += 1
+            if checkCount == 2 {
+                throw CancellationError()
+            }
+        }) { error in
+            XCTAssertTrue(error is CancellationError)
+        }
+        XCTAssertEqual(checkCount, 2)
+    }
+
     func testHardLinkedCloneEntersCloneAccountingOnlyOnce() {
         let fileIdentity = FileIdentity(device: 1, inode: 10)
         let cloneIdentity = CloneIdentity(device: 1, cloneID: 99)

--- a/RadixCoreTests/SharedAllocationOwnerAccumulatorTests.swift
+++ b/RadixCoreTests/SharedAllocationOwnerAccumulatorTests.swift
@@ -157,6 +157,75 @@ final class SharedAllocationOwnerAccumulatorTests: XCTestCase {
         ])
     }
 
+    func testStandaloneCloneGroupRetainsOneIdentityAndAccumulatesLosers() {
+        let cloneIdentity = CloneIdentity(device: 1, cloneID: 99)
+        let claims = (0..<10_000).map { index in
+            cloneClaim(
+                fileIdentity: FileIdentity(device: 1, inode: UInt64(index)),
+                cloneIdentity: cloneIdentity,
+                owner: "/summary",
+                path: String(format: "/file-%05d", index),
+                totalSize: 130,
+                dataSize: 80
+            )
+        }
+
+        let accumulator = SharedAllocationOwnerAccumulator(claims.reversed())
+
+        XCTAssertEqual(accumulator.identityCount, 1)
+        XCTAssertEqual(accumulator.duplicateAllocatedSizeByOwner, [
+            "/summary": 9_999 * 80,
+        ])
+    }
+
+    func testStandaloneCloneMergeMatchesDirectAccumulationInEitherOrder() {
+        let cloneIdentity = CloneIdentity(device: 2, cloneID: 7)
+        let firstClaims = [
+            cloneClaim(
+                fileIdentity: FileIdentity(device: 2, inode: 1),
+                cloneIdentity: cloneIdentity,
+                owner: "/summary-a",
+                path: "/z",
+                totalSize: 100,
+                dataSize: 80
+            ),
+            cloneClaim(
+                fileIdentity: FileIdentity(device: 2, inode: 2),
+                cloneIdentity: cloneIdentity,
+                owner: "/summary-a",
+                path: "/y",
+                totalSize: 100,
+                dataSize: 80
+            ),
+        ]
+        let secondClaims = [
+            cloneClaim(
+                fileIdentity: FileIdentity(device: 2, inode: 3),
+                cloneIdentity: cloneIdentity,
+                owner: "/summary-b",
+                path: "/a",
+                totalSize: 100,
+                dataSize: 80
+            ),
+        ]
+        let first = SharedAllocationOwnerAccumulator(firstClaims)
+        let second = SharedAllocationOwnerAccumulator(secondClaims)
+
+        var forward = first
+        forward.merge(second)
+        var reverse = second
+        reverse.merge(first)
+        let direct = SharedAllocationOwnerAccumulator(firstClaims + secondClaims)
+
+        XCTAssertEqual(forward.duplicateAllocatedSizeByOwner, direct.duplicateAllocatedSizeByOwner)
+        XCTAssertEqual(reverse.duplicateAllocatedSizeByOwner, direct.duplicateAllocatedSizeByOwner)
+        XCTAssertEqual(forward.duplicateAllocatedSizeByOwner, [
+            "/summary-a": 160,
+        ])
+        XCTAssertEqual(forward.identityCount, 1)
+        XCTAssertEqual(reverse.identityCount, 1)
+    }
+
     private func claim(
         _ identity: FileIdentity,
         owner: String,
@@ -176,6 +245,7 @@ final class SharedAllocationOwnerAccumulatorTests: XCTestCase {
         hardLinkIdentity: FileIdentity? = nil,
         cloneIdentity: CloneIdentity,
         owner: String,
+        path: String? = nil,
         totalSize: Int64,
         dataSize: Int64
     ) -> SharedAllocationClaim {
@@ -184,7 +254,7 @@ final class SharedAllocationOwnerAccumulatorTests: XCTestCase {
             hardLinkIdentity: hardLinkIdentity,
             cloneIdentity: cloneIdentity,
             ownerNodeID: owner,
-            path: owner,
+            path: path ?? owner,
             allocatedSize: totalSize,
             cloneAllocatedSize: dataSize
         )

--- a/RadixCoreTests/SharedAllocationOwnerAccumulatorTests.swift
+++ b/RadixCoreTests/SharedAllocationOwnerAccumulatorTests.swift
@@ -158,6 +158,77 @@ final class SharedAllocationOwnerAccumulatorTests: XCTestCase {
         XCTAssertEqual(checkCount, 2)
     }
 
+    func testMixedCloneCorrectionChecksCancellationAfterHardLinkReduction() {
+        let claims = (0..<512).flatMap { index in
+            let device = UInt64(8)
+            let cloneIdentity = CloneIdentity(device: device, cloneID: UInt64(index))
+            let hardLinkIdentity = FileIdentity(device: device, inode: UInt64(index * 2))
+            return [
+                cloneClaim(
+                    fileIdentity: FileIdentity(device: device, inode: UInt64(index * 2 + 1)),
+                    cloneIdentity: cloneIdentity,
+                    owner: "/standalone-\(index)",
+                    path: "/a-\(index)",
+                    totalSize: 1,
+                    dataSize: 1
+                ),
+                cloneClaim(
+                    fileIdentity: hardLinkIdentity,
+                    hardLinkIdentity: hardLinkIdentity,
+                    cloneIdentity: cloneIdentity,
+                    owner: "/hard-link-\(index)",
+                    path: "/z-\(index)",
+                    totalSize: 1,
+                    dataSize: 1
+                ),
+            ]
+        }
+        let accumulator = SharedAllocationOwnerAccumulator(claims)
+        var checkCount = 0
+
+        XCTAssertThrowsError(try accumulator.duplicateAllocatedSizeByOwner {
+            checkCount += 1
+            if checkCount == 3 {
+                throw CancellationError()
+            }
+        }) { error in
+            XCTAssertTrue(error is CancellationError)
+        }
+        XCTAssertEqual(checkCount, 3)
+    }
+
+    func testZeroDataCloneDoesNotCreateCloneAccountingState() {
+        let device = UInt64(9)
+        let cloneIdentity = CloneIdentity(device: device, cloneID: 1)
+        let standalone = SharedAllocationOwnerAccumulator([
+            cloneClaim(
+                fileIdentity: FileIdentity(device: device, inode: 1),
+                cloneIdentity: cloneIdentity,
+                owner: "/standalone",
+                totalSize: 32,
+                dataSize: 0
+            ),
+        ])
+        let hardLinkIdentity = FileIdentity(device: device, inode: 2)
+        let hardLinked = SharedAllocationOwnerAccumulator([
+            cloneClaim(
+                fileIdentity: hardLinkIdentity,
+                hardLinkIdentity: hardLinkIdentity,
+                cloneIdentity: cloneIdentity,
+                owner: "/hard-link",
+                totalSize: 32,
+                dataSize: 0
+            ),
+        ])
+
+        XCTAssertTrue(standalone.isEmpty)
+        XCTAssertEqual(standalone.identityCount, 0)
+        XCTAssertTrue(standalone.duplicateAllocatedSizeByOwner.isEmpty)
+        XCTAssertFalse(hardLinked.isEmpty)
+        XCTAssertEqual(hardLinked.identityCount, 1)
+        XCTAssertTrue(hardLinked.duplicateAllocatedSizeByOwner.isEmpty)
+    }
+
     func testHardLinkedCloneEntersCloneAccountingOnlyOnce() {
         let fileIdentity = FileIdentity(device: 1, inode: 10)
         let cloneIdentity = CloneIdentity(device: 1, cloneID: 99)
@@ -190,6 +261,57 @@ final class SharedAllocationOwnerAccumulatorTests: XCTestCase {
         XCTAssertEqual(accumulator.duplicateAllocatedSizeByOwner, [
             "/b-hard-link": 100,
             "/z-clone": 80,
+        ])
+    }
+
+    func testStandaloneCloneWinsAcrossMultipleHardLinkedInodes() {
+        let cloneIdentity = CloneIdentity(device: 1, cloneID: 100)
+        let firstHardLinkIdentity = FileIdentity(device: 1, inode: 20)
+        let secondHardLinkIdentity = FileIdentity(device: 1, inode: 21)
+        let claims = [
+            cloneClaim(
+                fileIdentity: firstHardLinkIdentity,
+                hardLinkIdentity: firstHardLinkIdentity,
+                cloneIdentity: cloneIdentity,
+                owner: "/hard-link-b",
+                path: "/b",
+                totalSize: 100,
+                dataSize: 80
+            ),
+            cloneClaim(
+                fileIdentity: secondHardLinkIdentity,
+                hardLinkIdentity: secondHardLinkIdentity,
+                cloneIdentity: cloneIdentity,
+                owner: "/hard-link-c",
+                path: "/c",
+                totalSize: 130,
+                dataSize: 80
+            ),
+            cloneClaim(
+                fileIdentity: secondHardLinkIdentity,
+                hardLinkIdentity: secondHardLinkIdentity,
+                cloneIdentity: cloneIdentity,
+                owner: "/hard-link-d",
+                path: "/d",
+                totalSize: 130,
+                dataSize: 80
+            ),
+            cloneClaim(
+                fileIdentity: FileIdentity(device: 1, inode: 22),
+                cloneIdentity: cloneIdentity,
+                owner: "/standalone-a",
+                path: "/a",
+                totalSize: 110,
+                dataSize: 80
+            ),
+        ]
+
+        let accumulator = SharedAllocationOwnerAccumulator(claims)
+
+        XCTAssertEqual(accumulator.duplicateAllocatedSizeByOwner, [
+            "/hard-link-b": 80,
+            "/hard-link-c": 80,
+            "/hard-link-d": 130,
         ])
     }
 


### PR DESCRIPTION
## Summary

- reduce standalone APFS clone claims incrementally by `CloneIdentity` instead of retaining one path-heavy claim per file until scan finalization
- accumulate displaced allocation by owner while preserving deterministic winner selection, hard-link/clone staging, resource-fork accounting, and cancellation responsiveness
- compact completed leaf state so finished leaves do not retain scan-only metadata
- bound retained clone state to clone identities and corrected owners, including inside auto-summarized directories

## Validation

- `swift test --filter SharedAllocationOwnerAccumulatorTests` (10 passed)
- `swift test --filter ScanEngineTests` (121 passed)
- 50,000-clone forced-summary repro: peak physical memory fell from 73.8 MiB to 10.8 MiB with the same 3-node result
- repeated-scan repro plateaued after allocator warm-up; debug timings were neutral to slightly faster

Closes #53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved disk usage reporting for APFS clones, including more accurate duplicate allocation totals by owner.
  - Ensured clone-related results remain consistent regardless of processing or merge order.
  - Improved scan reliability for files, directories, packages, and unavailable content.
  - Corrected accounting for zero-data clones, standalone clone groups, and files sharing hard links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->